### PR TITLE
docs(process): reviewer notes convention (Known gaps in slice work log)

### DIFF
--- a/docs/architecture/00-index/agent-handoff.md
+++ b/docs/architecture/00-index/agent-handoff.md
@@ -64,6 +64,17 @@ How coding agents coordinate without stepping on each other. This is a *protocol
 - Check [[00-index/definition-of-done]] line-by-line before requesting review.
 - Any CI failure reverts you to step 5.
 
+#### Reviewer notes — where they land
+
+PR review comments are transient: once the PR merges, they fade into the PR timeline and are no longer discoverable to the next agent picking up the slice. To keep reviewer findings durable, reviewers use the following homes:
+
+- **Merge-blockers (Must-fix).** Do not approve. Comment on the PR; the author pushes a fix; re-review.
+- **Non-blocking gaps inside the slice's scope (Should-fix).** Append a `### Known gaps at in-review — <YYYY-MM-DD> — <reviewer-id>` subsection to the slice's **Work log** in the same PR (push an extra commit to the PR branch, scoped to the slice file only). List each gap with its `src/…` path + line range + remedy. These items must be closed before the slice flips `status: done`.
+- **Non-blocking gaps outside the slice's scope (e.g. tool bugs, infrastructure).** Open a GitHub Issue with `type:followup` + the relevant `area:*` label + `priority:low`. Link the originating PR review comment.
+- **Stylistic / future-wondering / nice-to-haves (Nits).** PR comment only. Do not promote to the work log unless the author or reviewer judges they cross the Should-fix threshold.
+
+The rule: **if a reviewer note has to survive a PR merge to be useful, it goes in the slice work log or an Issue. Never leave actionable findings only on the PR timeline.**
+
 ### 7. Cross-slice coordination
 
 If your slice needs a change outside `owns_paths`:


### PR DESCRIPTION
## Summary

Codifies where reviewer findings land after a PR merges, so Should-fix items don't vanish into the PR timeline.

- Adds a '### Reviewer notes — where they land' subsection under §6 Review in `docs/architecture/00-index/agent-handoff.md`.
- Establishes four homes:
  - **Must-fix** → PR comment only; block merge.
  - **Should-fix, in-scope** → `### Known gaps at in-review — YYYY-MM-DD — reviewer-id` subsection in the slice's Work log. Must be closed before the slice flips `status: done`.
  - **Should-fix, out-of-scope** (tool bugs, infra) → GitHub Issue with `type:followup` + `area:*` + `priority:low`.
  - **Nits** → PR comment only.

## Worked example (lands in companion changes, not this PR)

- **Should-fix, in-scope example:** three coverage gaps on `CachedEmbedder` + reranker missing-scores raised during the PR #41 review are captured as a '### Known gaps at in-review' block in `_slices/slice-embedding.md` on that PR's branch.
- **Should-fix, out-of-scope example:** the `tc-coverage` 5-line skip-reason lookback bug surfaced during the PR #42 review was opened as Issue #43 with `area:tools` + `type:followup` + `priority:low`.

## Why

PR review comments are transient — once a PR merges, the next agent picking up the slice has no signal that Should-fix items exist. This routes findings to durable homes (slice work log, Issues) that future agents naturally consult.

## Authorisation

`CLAUDE.md §Paths you may NOT touch without authorization` lists `00-index/agent-handoff.md` as meta-rules requiring a human. Authorised by Eric in the Claude Code session on 2026-04-19.

## New labels introduced

- `area:tools` — changes to `_tools/` or Makefile targets.
- `priority:low` — not blocking; nice-to-fix.
- `type:followup` — reviewer-identified follow-up work separable from its originating PR.

## Test plan

- [ ] No code changes; docs-only. CI trivially green.
- [ ] `make agent-check` exits clean (no new validation for this convention yet).
- [ ] Eyeball render in Obsidian — subsection sits under §6 Review as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)