### PR TITLE
ci(vault): wire GH_TOKEN into vault-check so Issue-drift runs in CI

### DIFF
--- a/.github/workflows/vault-check.yml
+++ b/.github/workflows/vault-check.yml
@@ -37,6 +37,11 @@ jobs:
         #   - slice DAG (no cycles, owns_paths non-conflict, status valid)
         #   - spec Test Contract hygiene (presence, implements: field)
         #   - wikilink resolution (.md + .canvas + .base; skips code spans + _templates/)
-        #   - vault ↔ GitHub Issue drift (skipped here since gh CLI isn't authed
-        #     in PR builds; runs locally via `make issue-check`)
+        #   - vault ↔ GitHub Issue drift (Dual-update rule, via GH_TOKEN below).
+        env:
+          # gh is pre-installed on ubuntu-latest; surface the Actions token as
+          # GH_TOKEN so check.py's `_fetch_slice_issues` shell-out can read
+          # Issue labels and enforce the Dual-update rule in CI (not just
+          # locally via `make issue-check`).
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 docs/architecture/_tools/check.py all


### PR DESCRIPTION
## Summary

One-line env addition in `.github/workflows/vault-check.yml` so `check.py`'s Issue-drift check actually runs in CI instead of silently skipping.

Closes #46.

## Why

\`check.py::_fetch_slice_issues\` shells out to \`gh issue list\` to enforce the Dual-update rule (vault frontmatter status vs. GitHub Issue status: label). Without \`GH_TOKEN\`, \`gh\` returns non-zero, \`_fetch_slice_issues\` returns None, and the check falls through to a warning. That warning has been firing on every PR's Vault hygiene job for weeks — effectively making the drift check local-only.

## How

\`gh\` is pre-installed on \`ubuntu-latest\`. GitHub Actions provides \`GITHUB_TOKEN\` automatically via \`secrets.GITHUB_TOKEN\`. \`gh\` reads \`GH_TOKEN\` by convention. Surfacing one into the other on the check.py step is the whole fix.

## Validation

- [ ] CI's Vault hygiene job log no longer contains \`gh CLI unavailable; skipping issue drift check\`.
- [ ] Any actual frontmatter-vs-label drift now surfaces as a \`⚠\` in CI — which will remain visible until PR #40 (slice-lifecycle-engine) and PR #42 (slice-plane-concept) merge.

## Scope

- One workflow file, 7 lines added (6 comment + 1 env key).
- No new secrets, no workflow permissions changes required.
- No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)