### PR TITLE
docs(process): codify before-handoff checks + linked-Issue rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,24 @@ Paste this into your PR description (the template has it):
 
 One row per spec Test Contract bullet. Silent omissions get request-changes.
 
+### Before handoff — the five checks
+
+Before flipping slice `in-progress → in-review` and marking a PR ready-for-review, run and carefully read the output of each:
+
+1. **`make check`** — ruff format + lint (whole repo, matches CI) + mypy strict + pytest + coverage. Must exit 0.
+2. **`make tc-coverage SLICE=<slice-id>`** — Closure Rule audit. Must exit 0.
+3. **`make agent-check`** — vault-hygiene audit. **Distinguish `✗` errors from `⚠` warnings.** Exit non-zero? Grep for `✗` first — don't wave off a pre-existing warning.
+4. **`gh pr checks <pr-number>`** — remote CI state. Local-green + remote-red means tooling drift; stop and diagnose, do not `--admin` past it.
+5. **PR body linkage:**
+   - Slice PRs: first line of the body is `Closes #<issue-number>.` (exact keyword, case-insensitive: `Closes` / `Fixes` / `Resolves` — prefer `Closes`). Without it GitHub doesn't auto-link and the Issue stays open after merge.
+   - Chore / infra / docs PRs with no tracking Issue: include a line `No tracking Issue: <one-sentence reason>` so the absence is deliberate.
+
+### Additional handoff-readiness rules
+
+- **Symmetric coverage.** A class / function / module that promises X and Y in its docstring needs tests for both. Defensive-branch exceptions apply only to validation + error paths, never to advertised features.
+- **ADR-punted dependencies must fail loud.** If you defer a dependency behind an ADR, the production path must `raise NotImplementedError` or log at `ERROR`/`CRITICAL` with an explicit stub message. `info` logs are not safety gates.
+- **PR body reflects shipped code.** If the design evolved during implementation, update the PR description before marking ready-for-review. Don't make the reviewer reconcile stale intent against actual behaviour.
+
 ## Hard prohibitions (automatic revert)
 
 - Silent `time.sleep()` in production code (async waits + timeouts only).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,24 @@ Not all agents are equivalent. Rough guide (details in [docs/AGENT-PROCESS.md §
 3. Flip your slice to `blocked` (frontmatter + Issue label).
 4. Pick up another slice.
 
+## Before handoff (the five checks)
+
+Before you flip a slice `in-progress → in-review` and mark a PR ready-for-review, run and carefully read the output of each:
+
+1. **`make check`** — ruff format + ruff lint (both scan the whole repo, matching CI) + mypy strict + pytest + coverage. Must exit 0.
+2. **`make tc-coverage SLICE=<slice-id>`** — Closure Rule audit. Every Test Contract bullet must be in one of the three Closure states (passing / `@pytest.mark.skip(reason="deferred to slice-X: ...")` / declared out-of-scope in the slice's `## Work log`). Must exit 0.
+3. **`make agent-check`** — vault-hygiene audit. **Distinguish `✗` errors from `⚠` warnings**: errors block, warnings don't. If exit code is non-zero, grep the output for `✗` first — don't assume a pre-existing warning is the cause.
+4. **`gh pr checks <your-pr-number>`** — remote GitHub Actions state. Remote CI can fail on drift that local gates don't surface. If local green + remote red, stop and diagnose — don't `--admin` past it.
+5. **PR body linkage:**
+   - **Slice PRs:** first line of the body must be `Closes #<issue-number>.` on its own. GitHub only auto-links on those exact keywords (`Closes`, `Fixes`, `Resolves`, case-insensitive — prefer `Closes` for consistency). Missing the keyword breaks auto-close on merge, the "Linked issues" sidebar, and the Dual-update drift check's PR↔Issue path.
+   - **Chore / infra / docs PRs with no tracking Issue:** include a line `No tracking Issue: <one-sentence reason>` so the absence is a deliberate choice, not an oversight.
+
+Additional handoff-readiness rules:
+
+- **Symmetric coverage.** If a class, module, or function docstring promises features X *and* Y, both need tests. "Defensive branch" is only a valid coverage-gap justification for validation / exception paths — never for a feature promised in the docstring.
+- **ADR-punted dependencies must fail loud, not silently no-op.** If you defer wiring a real dependency (e.g. production scheduler, LLM client) behind an ADR, the production path must `raise NotImplementedError` or emit at `ERROR`/`CRITICAL` with an explicit "THIS DOES NOT TICK / IS STUBBED" message. An `info` log is not a safety gate.
+- **Keep PR body and code in sync.** If the design evolved during implementation, rewrite the design note in the PR description before marking ready-for-review. Reviewers shouldn't have to reconcile stale intent against actual behaviour.
+
 ## When you ship
 
 1. PR merged, CI green.
@@ -169,10 +187,10 @@ Not all agents are equivalent. Rough guide (details in [docs/AGENT-PROCESS.md §
 - [ ] GitHub Issue claimed (you are the assignee; label is `status:in-progress`).
 - [ ] `_inbox/locks/<slice-id>.lock` dropped in the vault as a secondary signal.
 - [ ] Slice frontmatter: `status: in-progress`, `owner:` set.
-- [ ] Draft PR opened.
+- [ ] Draft PR opened; **body first line is `Closes #<issue>.`** (or `No tracking Issue: <reason>` for chore/infra).
 - [ ] First commit on the branch is the test file.
-- [ ] `make check` passes.
-- [ ] PR description references the slice id and the specs implemented.
+- [ ] `make check` + `make tc-coverage SLICE=<id>` + `make agent-check` all exit 0.
+- [ ] `gh pr checks <pr>` reports green *before* flipping to ready-for-review.
 - [ ] Definition of Done items checked.
 
 Now go read [docs/AGENT-PROCESS.md](docs/AGENT-PROCESS.md) and either open the Issue you were assigned or `gh issue list --label "slice,status:ready"`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -57,10 +57,21 @@ State changes update **both** the slice file's frontmatter **and** the GitHub Is
 1. `gh issue list --label "slice,status:ready"` → pick one.
 2. Claim via Dual-update rule §Claim (both Issue label AND frontmatter).
 3. `git switch -c slice/<slice-id>`, push with `-u`.
-4. `gh pr create --draft --base v2` with `Closes #<n>` in the body.
+4. `gh pr create --draft --base v2` with **first line of body = `Closes #<n>.`** (exact keyword; GitHub doesn't auto-link otherwise).
 5. First commit: the test file (every Test Contract bullet = function with verbatim name).
 6. Implement. Respect `forbidden_paths`.
-7. `make check` + `make agent-check` green → Dual-update rule §Handoff → `gh pr ready <m>`.
+7. Before `gh pr ready`, run the **five handoff checks**:
+   - `make check` (whole repo; matches CI)
+   - `make tc-coverage SLICE=<id>` — exit 0
+   - `make agent-check` — distinguish `✗` errors from `⚠` warnings; only `✗` blocks
+   - `gh pr checks <pr>` — remote CI green too (not just local)
+   - PR body first line is `Closes #<n>.` for slice PRs, or `No tracking Issue: <reason>` for chore/infra PRs
+
+### Additional handoff rules Gemini is most likely to trip
+
+- **Symmetric coverage.** A docstring promising X and Y needs tests for both. Defensive-branch coverage gaps are only OK for validation + error paths, not for advertised features.
+- **ADR-punted deps fail loud, not silently no-op.** If you stub a dependency, `raise NotImplementedError` or log at `ERROR`/`CRITICAL` — never just `info`.
+- **PR body and code stay in sync.** If the design evolved during implementation, rewrite the description before handoff.
 
 ## Style
 


### PR DESCRIPTION
No tracking Issue: process-doc convergence PR derived from reviewer observations across PRs #40, #41, #42, #44, #45.

## Summary

Adds a shared "Before handoff (the five checks)" section to `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md`. Three drift patterns surfaced in the 2026-04-19 three-agent round; this PR makes the preventative rules explicit so the next round doesn't repeat them.

## The five checks

1. `make check` — whole-repo scope (matches CI after PR #45)
2. `make tc-coverage SLICE=<id>` — Closure Rule audit
3. `make agent-check` — **distinguish `✗` errors from `⚠` warnings**
4. `gh pr checks <n>` — remote CI green, not just local
5. PR body first line: `Closes #<issue>.` (slice) or `No tracking Issue: <reason>` (chore/infra)

## Three handoff-readiness rules

- **Symmetric coverage** — docstring promises X AND Y → tests for both.
- **ADR-punted deps fail loud, not silently no-op** — `raise NotImplementedError` or log at `ERROR`/`CRITICAL`.
- **PR body reflects shipped code** — if design evolved, rewrite the description before flipping to ready.

## Gaps this closes

| Gap | Pattern | Where the rule lands |
|---|---|---|
| PR #40 merged without `Closes #11` | missing linked-Issue syntax → GitHub sidebar empty, Issue doesn't auto-close | Rule 5 |
| PR #42 cross-slice ticket missing frontmatter | `make agent-check` exit-nonzero waved off as pre-existing drift warning | Rule 3 (distinguish ✗ vs ⚠) |
| PR #45 ruff drift on `_tools/` | Makefile scoped to `src tests` while CI scanned `.` | Rule 4 (check remote CI) — plus the Makefile alignment in PR #45 itself |
| Codex's `CachedEmbedder.embed_sparse` uncovered | docstring promised sparse + dense, only dense tested | "Symmetric coverage" rule |
| Cowork's `build_scheduler(testing=False)` silent no-op | production path stubbed with `info` log | "ADR-punted deps fail loud" rule |
| Cowork's PR body claimed `VersionConflictError` the code didn't raise | design description drifted from shipped code | "PR body reflects shipped code" rule |

## Authorisation

`CLAUDE.md § Paths you may NOT touch without authorization` lists `CLAUDE.md` / `AGENTS.md` / `00-index/agent-handoff.md` as meta-rules requiring a human. Authorized by Eric in the Claude Code session on 2026-04-19.

## Test plan

- [ ] `make check` passes (docs-only change, no tests affected).
- [ ] `make agent-check` exits 0 with warnings only.
- [ ] Eyeball the three agent-entry files render cleanly in Markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)