### PR TITLE
chore(types): add in_reply_to + supersedes to Thought (unblocks #24)

### DIFF
--- a/src/musubi/types/thought.py
+++ b/src/musubi/types/thought.py
@@ -1,6 +1,11 @@
 """``Thought`` — ambient messages between presences.
 
-Preserved from the POC. Thoughts are messages, not knowledge — no lineage.
+Preserved from the POC: a Thought is a message, not a memory. It carries
+minimal lineage (``in_reply_to`` / ``supersedes``) per the
+[[04-data-model/thoughts]] spec so a reply-chain or a correction-chain can
+be walked, but it is not a first-class MemoryObject (no embeddings tracked
+here, no reinforcement, no maturation beyond ``provisional → matured →
+archived``).
 """
 
 from __future__ import annotations
@@ -10,6 +15,7 @@ from typing import Literal
 from pydantic import Field
 
 from musubi.types.base import MusubiObject
+from musubi.types.common import KSUID
 
 
 class Thought(MusubiObject):
@@ -26,6 +32,13 @@ class Thought(MusubiObject):
     read_by: list[str] = Field(default_factory=list)
     channel: str = "default"
     importance: int = Field(ge=1, le=10, default=5)
+
+    # Lineage (rare, but supported — see 04-data-model/thoughts.md §Pydantic model).
+    # ``in_reply_to`` links a reply to its parent thought; ``supersedes`` lists
+    # prior thought object_ids this one replaces (e.g. a correction to an
+    # earlier broadcast). Both default to empty so the common case is unaffected.
+    in_reply_to: KSUID | None = None
+    supersedes: list[KSUID] = Field(default_factory=list)
 
 
 __all__ = ["Thought"]


### PR DESCRIPTION
No tracking Issue: cross-slice unblock for Issue #24 (slice-plane-thoughts). The cross-slice ticket itself lives on Nyla's branch at `docs/architecture/_inbox/cross-slice/slice-plane-thoughts-slice-types-missing-lineage-fields.md` and will land when that PR merges.

## Summary

Adds two missing lineage fields to `Thought`:

- `in_reply_to: KSUID | None = None`
- `supersedes: list[KSUID] = Field(default_factory=list)`

Both were declared in `docs/architecture/04-data-model/thoughts.md` §Pydantic model (lines 49–51) but silently omitted when slice-types shipped. The type file even carried a misleading docstring ("Thoughts are messages, not knowledge — no lineage") that contradicted the spec. Docstring replaced with an accurate one.

## Why

Nyla/Gemini hit this while implementing `ThoughtsPlane` for Issue #24 (slice-plane-thoughts). Test Contract bullet 13 of `thoughts.md` — `test_thought_in_reply_to_chain_queries_correctly` — needs the field. Nyla correctly did NOT silently patch around it:

- Opened cross-slice ticket
- Filed question file
- Flipped slice + Issue #24 to `status:blocked`
- Pushed WIP to branch `slice/slice-plane-thoughts`
- Stopped work

This PR is the cross-slice resolution. Once merged, Nyla pulls v2, rebases `slice/slice-plane-thoughts` onto the new v2 HEAD, flips slice + Issue back to `in-progress`, and continues.

## Scope

- 1 file (`src/musubi/types/thought.py`), 14 insertions + 1 deletion.
- Both fields default to safe values (Optional / empty list) — existing Thought construction sites are unaffected.
- No behavior change, no test additions (Nyla's slice PR will exercise the new fields).
- No spec changes — this PR conforms to the already-authoritative spec.

## Authorization

`CLAUDE.md § Paths you may NOT touch without authorization` lists `src/musubi/types/` as slice-types-only. Authorised by Eric in the Claude Code session on 2026-04-19 as a cross-slice unblock operator action.

## Test plan

- [x] `make check` passes (313 passed, 61 skipped, coverage green).
- [x] `make agent-check` exits clean (warnings only; the slice-plane-thoughts drift warning clears when Nyla re-pushes after unblock).
- [ ] CI passes on this PR.
- [ ] After merge + Nyla rebases: `pytest tests/planes/test_thoughts.py::test_thought_in_reply_to_chain_queries_correctly` passes on her branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)