### PR TITLE
fix(lifecycle): concept_maturation_sweep respects contradicts list

### DIFF
--- a/docs/architecture/_inbox/cross-slice/slice-lifecycle-synthesis-slice-lifecycle-maturation-missing-contradicts-check.md
+++ b/docs/architecture/_inbox/cross-slice/slice-lifecycle-synthesis-slice-lifecycle-maturation-missing-contradicts-check.md
@@ -2,9 +2,17 @@
 title: "Cross-slice: concept_maturation_sweep should respect contradicts list"
 section: _inbox/cross-slice
 type: cross-slice
-status: open
-tags: [section/inbox-cross-slice, type/cross-slice, status/open]
+status: resolved
+tags: [section/inbox-cross-slice, type/cross-slice, status/resolved]
 updated: 2026-04-19
+---
+
+## Resolution
+
+Fixed by operator chore PR on 2026-04-19 — see v2 commit for `src/musubi/lifecycle/maturation.py` adding the contradicts-list check in `concept_maturation_sweep`. Test `test_synthesized_blocked_from_maturing_with_contradiction` in `tests/lifecycle/test_synthesis.py` un-skipped as part of the same fix.
+
+Original ticket preserved below for audit.
+
 ---
 
 ## Bug

--- a/src/musubi/lifecycle/maturation.py
+++ b/src/musubi/lifecycle/maturation.py
@@ -630,6 +630,18 @@ async def concept_maturation_sweep(
     for row in candidates:
         if int(row.get("reinforcement_count", 0)) < cfg.concept_reinforcement_threshold:
             continue
+        # Skip concepts with active contradictions — spec says maturation is
+        # blocked until the contradiction is resolved (surfaced by
+        # slice-lifecycle-synthesis; see cross-slice ticket
+        # _inbox/cross-slice/slice-lifecycle-synthesis-slice-lifecycle-maturation-missing-contradicts-check.md).
+        contradicts = row.get("contradicts", [])
+        if isinstance(contradicts, list) and len(contradicts) > 0:
+            log.info(
+                "skipping concept-maturation for %s: %d active contradiction(s)",
+                row["object_id"],
+                len(contradicts),
+            )
+            continue
         result = transition(
             client,
             object_id=row["object_id"],

--- a/tests/lifecycle/test_synthesis.py
+++ b/tests/lifecycle/test_synthesis.py
@@ -616,9 +616,6 @@ async def test_synthesized_matures_after_24h_without_contradiction(
     assert report.transitioned == 1
 
 
-@pytest.mark.skip(
-    reason="blocked by cross-slice issue slice-lifecycle-synthesis-slice-lifecycle-maturation-missing-contradicts-check"
-)
 async def test_synthesized_blocked_from_maturing_with_contradiction(
     qdrant: QdrantClient,
     ns: str,


### PR DESCRIPTION
No tracking Issue: operator-side cross-slice-ticket resolution. Closes the ticket Hana filed on PR #62 (slice-lifecycle-synthesis) at `docs/architecture/_inbox/cross-slice/slice-lifecycle-synthesis-slice-lifecycle-maturation-missing-contradicts-check.md`.

## Summary

7-line fix to `src/musubi/lifecycle/maturation.py::concept_maturation_sweep` — skip concepts with a non-empty `contradicts` list (matches the lifecycle spec; was overlooked when slice-lifecycle-maturation landed).

Also un-skips `test_synthesized_blocked_from_maturing_with_contradiction` (bullet 19) in `tests/lifecycle/test_synthesis.py`. Hana added it as a skipped test on PR #62 specifically to keep the Closure Rule satisfied across the cross-slice boundary — now that the fix is in, it runs.

Ticket frontmatter flipped `status: open → resolved` with audit note.

## Process note

This is the canonical example of the "cross-slice fix landed via tiny chore PR" pattern — when an agent discovers a bug in a sibling slice's code, file a cross-slice ticket (don't patch in place), and the fix lands via a separate small PR authorized by the operator (or whichever slice-owner picks it up). See AGENTS.md §The non-negotiables #1 + §Cross-slice coordination.

## Test plan

- [x] `make check` passes (499 tests, up from 462 — includes the un-skipped bullet 19).
- [x] `make tc-coverage SLICE=slice-lifecycle-synthesis` satisfies Closure Rule with no pending skips on the contradicts bullet.
- [x] `make agent-check` clean (warnings only).
- [ ] CI passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)