### PR TITLE
docs(deploy): ADR-0019 phase-gated Qwen placement + spec update

### DIFF
--- a/docs/architecture/08-deployment/gpu-inference-topology.md
+++ b/docs/architecture/08-deployment/gpu-inference-topology.md
@@ -4,13 +4,15 @@ section: 08-deployment
 tags: [deployment, gpu, inference, ollama, section/deployment, status/complete, tei, type/spec]
 type: spec
 status: complete
-updated: 2026-04-17
+updated: 2026-04-19
 up: "[[08-deployment/index]]"
 reviewed: false
 ---
 # GPU Inference Topology
 
-How 10 GB of VRAM hosts BGE-M3, SPLADE++ V3, BGE-reranker-v2-m3, and Qwen2.5-7B-Instruct Q4 simultaneously — without OOMs.
+How 10 GB of VRAM hosts BGE-M3, SPLADE++ V3, BGE-reranker-v2-m3, and a Qwen 3 4B LLM simultaneously — without OOMs.
+
+**Host:** `musubi.mey.house` — bare-metal Ubuntu 24.04, RTX 3080 10 GB, dedicated to Musubi. See [[13-decisions/0019-qwen-on-musubi-gpu-phase-1]] for the phase-gated LLM placement decision behind the model choice below.
 
 ## The constraint
 
@@ -18,14 +20,33 @@ RTX 3080 has **10 GB VRAM**. We need:
 
 | Model | Role | VRAM (loaded, FP16 or Q4) |
 |---|---|---|
-| BGE-M3 (dense encoder, 560M) | Embedding | ~1.4 GB |
+| BGE-M3 (dense encoder, 560M) | Embedding | ~2.3 GB |
 | SPLADE++ V3 (~110M) | Sparse encoder | ~0.5 GB |
-| BGE-reranker-v2-m3 (~560M) | Cross-encoder rerank | ~1.4 GB |
-| Qwen2.5-7B-Instruct Q4_K_M | LLM for synthesis / rendering | ~4.8 GB |
-| CUDA context + KV cache headroom | — | ~1.5 GB |
-| **Total** | | **~9.6 GB** |
+| BGE-reranker-v2-m3 (~560M) | Cross-encoder rerank | ~2.0 GB |
+| **Qwen 3 4B Q4_K_M** | LLM for synthesis / rendering / rationale | **~2.5 GB** |
+| CUDA context + KV cache (shared across services) | — | ~1.5-2.0 GB |
+| **Total** | | **~8.8-9.3 GB** |
 
-Tight. Leaves ~0.4 GB overhead. Acceptable, but we need discipline — model reloads, large batch queries, or multi-request LLM usage can push it over.
+Workable. Leaves ~0.7-1.2 GB headroom. Tight enough that growth (larger TEI batch sizes, hot-path retrieval-deep LLM calls, multi-model experiments) will trigger the Phase 2 plan below.
+
+## Phase 2 triggers (summary)
+
+Move Qwen off musubi — either to `photo-club.mey.house` (5070 Ti 16 GB) over the VLAN, or upgrade musubi's GPU — if any of:
+
+- VRAM OOM / model-eviction events >1 per week
+- Sweep wall-time exceeds schedule window (hourly >15 min, daily >2 hours)
+- TEI error rate >5 % during sweep windows
+- Hybrid-search P95 latency regresses >2x during sweep windows
+- Operator review: 2+ consecutive thumbs-down on generated digests / concepts
+- Operator judgment at Day 14 that Qwen 3 4B quality is insufficient
+
+Full decision, alternatives, and trigger table: [[13-decisions/0019-qwen-on-musubi-gpu-phase-1]].
+
+## Why Qwen 3 4B (not Qwen 2.5 7B)
+
+The prior version of this spec named Qwen 2.5 7B Q4 (~4.8 GB). On a 10 GB card alongside three TEI services, that left ~0.4 GB headroom — fragile under real load. Qwen 3 4B Q4 (~2.5 GB) lands at ~1 GB headroom, which is the minimum for stable operation with KV-cache growth across all four services.
+
+Qwen 3 4B benchmarks as approaching Qwen 2.5 7B quality on synthesis-class tasks per published evals. Subjective quality at this size is acceptable for Phase 1; see Phase 2 criteria for the quality-fail escalation path.
 
 ## Service layout
 
@@ -51,12 +72,13 @@ Four GPU services, all co-resident:
 - Port: 8012
 - Batch cross-encoder: ~40 pairs/batch at ~100ms.
 
-### Ollama (Qwen2.5-7B-Instruct Q4)
+### Ollama (Qwen 3 4B Q4_K_M) — Phase 1
 
-- Container: `ollama/ollama:0.4.0-cuda`
-- Model: `qwen2.5:7b-instruct-q4_K_M`
-- Port: 11434
-- Use: concept synthesis, curated rendering, maturation enrichment.
+- Container: `ollama/ollama:latest-cuda` (verify Blackwell / Ada compute capability support for whichever Ollama tag is current)
+- Model: `qwen3:4b` (explicit: `qwen3:4b-instruct-q4_K_M`)
+- Port: 11434 (bound to `127.0.0.1` — self-contained per Phase 1 topology; not exposed on the VLAN)
+- Env: `OLLAMA_KEEP_ALIVE=24h`, `OLLAMA_MAX_LOADED_MODELS=1` — single-model residency; no spare capacity to swap in a second model on the 10 GB card.
+- Use: concept synthesis, curated rendering, maturation enrichment, reflection digest, future promotion rationale.
 - Always-loaded (long cold-start otherwise).
 
 ## GPU sharing strategy
@@ -91,7 +113,7 @@ At compose up:
 1. TEI dense boots. Downloads weights on first run (~1.3 GB).
 2. TEI sparse boots in parallel.
 3. TEI reranker boots next.
-4. Ollama boots last and pulls Qwen2.5-7B Q4 on first run (~4.7 GB).
+4. Ollama boots last and pulls Qwen 3 4B Q4 on first run (~2.4 GB).
 
 Each service has a `/health` endpoint; Compose waits for healthy before Core comes up.
 
@@ -143,7 +165,7 @@ Given April 2026 model quality:
 
 - BGE-M3 beats or matches Gemini text-embedding-004 on multilingual retrieval benchmarks.
 - SPLADE++ V3 is state of the art for learned sparse (no Gemini equivalent).
-- Qwen2.5-7B Q4 is good enough for the specific tasks we use it for (structured extraction, concept naming, brief renders). We're not trying to do open-ended reasoning with it.
+- Qwen 3 4B Q4 is good enough for the specific tasks we use it for (structured extraction, concept naming, brief renders). We're not trying to do open-ended reasoning with it. If Phase 2 triggers on quality, the escalation path in ADR-0019 moves Qwen off-host rather than compromising here.
 
 Trade-off: latency. Local calls are 10-50ms for encoding, ~2s for LLM inference on Q4. A hosted API would be similar for encoding, faster for LLM — but with network and privacy costs.
 

--- a/docs/architecture/13-decisions/0019-qwen-on-musubi-gpu-phase-1.md
+++ b/docs/architecture/13-decisions/0019-qwen-on-musubi-gpu-phase-1.md
@@ -1,0 +1,126 @@
+---
+title: "ADR-0019: Qwen 3 4B on musubi.mey.house GPU (Phase 1)"
+section: 13-decisions
+type: adr
+status: accepted
+tags: [section/decisions, status/accepted, type/adr, llm, gpu, deployment]
+updated: 2026-04-19
+---
+
+# ADR-0019: Qwen 3 4B on musubi.mey.house GPU (Phase 1)
+
+## Status
+
+Accepted (phase-gated).
+
+## Context
+
+Musubi's lifecycle sweeps (maturation, synthesis, reflection, future promotion) and future hot-path retrieval need an LLM. The spec at `08-deployment/gpu-inference-topology.md` originally named Qwen 2.5 7B Q4 co-resident with TEI dense + sparse + reranker on a single GPU.
+
+Two material facts reshape the decision:
+
+1. **Target host is `musubi.mey.house`** — purpose-built dedicated bare-metal server with an RTX 3080 (10 GB VRAM), not shared. Dedicated to Musubi + dependent services.
+2. **Operator has two other GPU hosts** in the homelab — `photo-club.mey.house` (5070 Ti 16 GB) and `av-club.mey.house` (5090 32 GB) — currently load-balancing image-gen. Photo-Club is a viable fallback LLM host if needed.
+
+The original 7B placement would leave ~0.4 GB headroom on the 10 GB card — workable, but fragile under real load.
+
+## Decision
+
+**Phase 1 (initial deploy):** Run **Qwen 3 4B Q4_K_M** (~2.5 GB) co-resident with the three TEI services on musubi.mey.house's 3080. Keep the full stack self-contained on one box.
+
+**Phase 2 (triggered by objective criteria; see below):** If Phase 1 fails on any criterion, move Qwen to Photo-Club (5070 Ti 16 GB) as a dedicated LLM host reachable over the `mey.house` VLAN, OR upgrade musubi's GPU.
+
+This is a phase-gated decision, not a permanent choice. The point is to ship the simplest viable configuration, measure, and upgrade on evidence.
+
+## VRAM budget (Phase 1)
+
+| Service | Resident |
+|---|---|
+| TEI-dense (BGE-M3) | ~2.3 GB |
+| TEI-sparse (SPLADE++ V3) | ~0.5 GB |
+| TEI-reranker (BGE-reranker-v2-m3) | ~2.0 GB |
+| Qwen 3 4B Q4_K_M | ~2.5 GB |
+| KV cache + CUDA context (shared) | ~1.5-2.0 GB |
+| **Total committed** | **~8.8-9.3 GB** |
+| **Headroom** | **0.7-1.2 GB** |
+
+Tight but workable.
+
+## Phase 2 trigger criteria
+
+Phase 2 triggers if **any** of the following happens during normal operation over a 14-day monitoring window starting at the first real capture:
+
+| Criterion | Measurement | Threshold |
+|---|---|---|
+| VRAM OOM / eviction | Ollama logs + `dmesg` for `nvidia`/CUDA OOMs | >1 per week |
+| Sweep wall-time exceeds schedule window | Hourly maturation >15 min; daily synthesis/reflection >2 hours | Any occurrence |
+| TEI availability during sweeps | TEI call errors coincident with Ollama activity | >5% error rate in sweep windows |
+| Retrieval latency regression | P95 `hybrid_search` latency during sweep windows vs. baseline | >2x regression |
+| Synthesis / reflection quality | Operator review of generated concepts + daily digest | 2+ consecutive thumbs-down |
+| Qwen 3 4B quality floor | Shallow rationales; missed obvious contradictions | Operator judgment at Day 14 |
+
+Mechanical criteria (first four) trigger immediate Phase 2 consideration. Quality criteria are bounded in time — evaluated no later than Day 14 after first real capture.
+
+## Phase 2 options (when triggered)
+
+Listed in preference order:
+
+1. **Move Qwen to Photo-Club** (repurpose from image gen)
+   - Qwen 3 8B or Qwen 2.5 7B Q4 comfortably fits with room for a second (uncensored / Dolphin-class) model alongside
+   - All TEI stays on musubi; musubi's 10 GB becomes comfortable (~5 GB headroom)
+   - Ollama exposed on `photo-club.mey.house:11434`; musubi reaches it via VLAN
+   - Cost: ~50 % loss of parallel image-gen burst throughput (AV-Club alone handles image gen)
+
+2. **Upgrade musubi's GPU** (e.g. 4090 24 GB or similar)
+   - Preserves single-box topology
+   - Enables larger Qwen (14B Q4 fits)
+   - Cost: hardware spend + downtime
+
+3. **External LLM API** (Anthropic / OpenAI / Gemini) for specific sweeps
+   - Lowest infra change
+   - Cost: per-call pricing (marginal for sweep volume); personal-data privacy trade-off
+
+## Consequences
+
+**Positive:**
+
+- Self-contained initial deploy; no VLAN dependencies for Musubi's core loop.
+- Cheapest, fastest path to first smoke test on real hardware.
+- Reversible — `Settings.ollama_url` config change + container re-point is the entire Phase 2 code cost.
+- Qwen 3 4B quality is benchmarked as "approaching Qwen 2.5 7B" on synthesis-class tasks per public evals; realistic quality floor for the workload.
+
+**Negative:**
+
+- Tight VRAM headroom (~1 GB) leaves no slack for growth (larger TEI batch sizes, retrieval-deep hot-path LLM, multi-model experiments).
+- Qwen 3 4B may produce shallower synthesis / reflection prose than Qwen 2.5 7B baseline; quality evaluation is subjective and requires operator review.
+- Mechanical failure (OOM, latency spike) forces Phase 2 mid-deployment.
+
+**Neutral:**
+
+- None of this decision blocks any in-flight slice work. `OllamaClient` + `Settings.ollama_url` abstractions make the LLM placement a pure configuration concern.
+
+## Alternatives considered
+
+1. **Qwen 2.5 7B Q4 on 3080 (original spec)** — ~0.4 GB headroom; too fragile for real load. Rejected for Phase 1.
+2. **Qwen 2.5 7B on CPU (Ollama CPU mode)** — frees VRAM fully but sweeps become minute-scale; retrieval-deep hot-path would be untenable. Rejected for Phase 1.
+3. **Multi-host topology from day one** (Photo-Club as dedicated LLM) — cleanest architecture but premature teardown of image-gen parallelism without evidence it's needed. Deferred to Phase 2.
+4. **External LLM API** (Anthropic / OpenAI / Gemini) — sidesteps VRAM entirely but puts personal thought content through third-party APIs. Deferred pending privacy review.
+5. **Smaller models (Gemma 3 4B, Phi-3.5-mini)** — similar size to Qwen 3 4B but weaker on synthesis-class tasks per public evals. Qwen 3 4B chosen as the highest-quality option at this VRAM budget.
+
+## Decision owners
+
+- Phase 1 monitoring + evaluation: operator.
+- Phase 2 trigger call: operator, advised by reviewer agent (Claude Code reviewer session).
+
+## References
+
+- `08-deployment/gpu-inference-topology.md` — canonical VRAM + service topology spec; updated to match this ADR.
+- `.agent-context.local.md` — operator-only, gitignored; contains real hostnames + endpoints.
+- ADR-0015 — monorepo; locks the single-repo assumption this decision is scoped to.
+
+## Review trigger
+
+Re-evaluate this ADR at Day 14 after first real capture on musubi.mey.house. Document the outcome in the ADR's `status` field:
+
+- `accepted` (current) — Phase 1 is the steady state.
+- `superseded` — Phase 2 triggered; link to the superseding ADR.


### PR DESCRIPTION
No tracking Issue: operator-side deployment-decision recording.

## Summary

Records the Phase 1 LLM placement decision so it's objective before the first deploy. Two files:

- **ADR-0019** — Qwen 3 4B Q4 on musubi.mey.house's 3080 for Phase 1. Six Phase 2 trigger criteria. Phase 2 options ordered: move to photo-club.mey.house over VLAN → upgrade musubi's GPU → external API.
- **08-deployment/gpu-inference-topology.md** — updated VRAM budget (was Qwen 2.5 7B, now Qwen 3 4B), service layout, loading order, 'Why local' rationale. Cross-refs ADR-0019 for the fallback path.

## Why now

Phase 2 triggers are objective only if defined before Phase 1 runs. Otherwise 'is Qwen 3 4B good enough?' becomes a vibes question at Day 14 instead of a checklist pass. This PR locks in the six mechanical + quality criteria so evaluation is unambiguous.

## Test plan

- [x] \`make agent-check\` exits clean (no ✗ errors; only pre-existing H1/title warnings).
- [ ] CI passes on this PR.
- [ ] Both documents render cleanly in Obsidian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)