### PR TITLE
chore(slice): reconcile slice-retrieval-fast paths (fast.py, not fast_path.py)

### DIFF
--- a/docs/architecture/_slices/slice-retrieval-fast.md
+++ b/docs/architecture/_slices/slice-retrieval-fast.md
@@ -25,13 +25,18 @@ blocks: ["[[_slices/slice-adapter-livekit]]"]
 
 ## Owned paths (you MAY write here)
 
-- `musubi/retrieve/fast_path.py`
-- `tests/retrieve/test_fast_path.py`
+- `src/musubi/retrieve/fast.py`
+- `tests/retrieve/test_fast.py`
 
 ## Forbidden paths (you MUST NOT write here — open a cross-slice ticket if needed)
 
-- `musubi/planes/`
-- `musubi/api/`
+- `src/musubi/retrieve/hybrid.py`    (owned by slice-retrieval-hybrid, done)
+- `src/musubi/retrieve/scoring.py`   (owned by slice-retrieval-scoring, done)
+- `src/musubi/retrieve/rerank.py`    (owned by slice-retrieval-rerank, done)
+- `src/musubi/retrieve/deep.py`      (owned by slice-retrieval-deep, in-flight — Hana)
+- `src/musubi/planes/`
+- `src/musubi/api/`
+- `src/musubi/types/`
 
 ## Depends on
 


### PR DESCRIPTION
No tracking Issue: operator-side slice-file reconcile surfaced by codex-gpt5 during claim-time brief verification.

## Summary

slice-retrieval-fast's owned paths drifted from the sibling convention. Reconciling:

- `musubi/retrieve/fast_path.py` → `src/musubi/retrieve/fast.py`
- `tests/retrieve/test_fast_path.py` → `tests/retrieve/test_fast.py`
- Forbidden paths tightened to name all four sibling modules + the standard planes/api/types forbiddens.

## Why

Every sibling in \`src/musubi/retrieve/\` uses the single-concise-noun convention (hybrid.py, rerank.py, scoring.py). \`fast_path.py\` was the outlier.

## Test plan

- [x] \`make agent-check\` exits clean (no ✗ errors).
- [ ] CI passes.
- [ ] After merge: Codex can cleanly claim #28 against the corrected layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)