### PR TITLE
chore(operator): ship .operator/scripts/claimable.py + scaffolding

### DIFF
--- a/.operator/README.md
+++ b/.operator/README.md
@@ -1,0 +1,93 @@
+# `.operator/` — operator-side scaffolding
+
+Process scaffolding used by the human operator (Eric) + the reviewer-role Claude session to drive the multi-agent fleet. None of this is consumed by slice-worker agents during a slice — it's tooling for the layer above the slice work.
+
+## Current contents
+
+```
+.operator/
+├── README.md                                   ← you are here
+├── backlog.md                                  ← scripting targets, prioritised
+├── scripts/
+│   └── claimable.py                            ← enumerate slices + claim-readiness + brief-block emitter
+└── prompts/
+    ├── slice-start.md.template                 ← brief sent to an agent to start a new slice
+    └── followup-next-slice.md.template         ← after clean merge: docs touch-up + next slice
+```
+
+## Why this exists
+
+Across the multi-agent rounds in this session, operator-role work — brief assembly, review verdict narration, next-slice handoffs, cross-slice tracking — was done from scratch each time. Same patterns kept repeating:
+
+1. Brief author looks up Issue number + spec path + owns_paths from memory → gets it wrong → agent catches the mismatch at claim time → operator-side reconcile PR lands to fix it.
+2. "Is slice X claimable right now?" is a manual dep-check walk through ~30 slice files.
+3. Merge → frontmatter flip → cleanup → next-slice prompt is a five-step ritual per agent handoff.
+
+Codifying these:
+- Makes each round's agent prompts consistent (the **"clockwork"** pattern Eric asked for).
+- Extracts the slot structure so future agents — or a future orchestrator agent — can render them mechanically.
+- Forms the operator-side bridge to `~/Projects/musubi-orchestrator-brief.md`: specifically the Tier 1 "mechanical plumbing" layer.
+
+## The scripts
+
+### `scripts/claimable.py`
+
+Operator's first line of defense against brief-vs-reality mismatches.
+
+```bash
+# list all slices with claim-readiness + Issue number:
+python3 .operator/scripts/claimable.py
+
+# filter to only slices claimable right now (all deps done):
+python3 .operator/scripts/claimable.py list --only-claimable
+
+# emit the slice-specific brief-block for pasting into an agent prompt:
+python3 .operator/scripts/claimable.py brief slice-lifecycle-promotion
+
+# sanity-check a slice file against ground truth (Issue match, spec file
+# existence, owns_paths sibling-convention drift, depends-on consistency):
+python3 .operator/scripts/claimable.py verify slice-retrieval-fast
+```
+
+Reads `docs/architecture/_slices/slice-*.md` + `gh issue list --label slice`. Cross-references to produce a single source of truth for:
+
+- What's claimable right now (strict: deps all `status: done` on v2 or their Issue is CLOSED).
+- Issue number for each slice (parsed from GitHub Issue titles matching `slice: slice-xxx`).
+- Spec file paths (resolved from frontmatter wikilinks; flagged if missing on disk).
+- Owned + forbidden paths (parsed from slice file sections).
+- Sibling-convention drift (flags e.g. `fast_path.py` when siblings are `hybrid.py` / `scoring.py` / `rerank.py`).
+- Parallel agents (from `status: in-progress` / `in-review` slices).
+
+**Use it every time you're about to write an agent brief.** The `brief` subcommand emits a pre-filled block ready to paste — no hand-authored Issue numbers or path references.
+
+Deps: Python 3.12+ · PyYAML · `gh` CLI on PATH.
+
+## The prompt templates
+
+`prompts/slice-start.md.template` and `prompts/followup-next-slice.md.template` capture the structure operator-side briefs converged to after ~10 rounds of manual iteration. Slot syntax is `{{double-braces}}`; each template ends with a `## Slots` reference section documenting what each slot expects.
+
+Currently hand-filled. Future integration: `claimable.py brief <slice-id>` populates the slot values so the full prompt renders mechanically.
+
+## How this directory is meant to evolve
+
+Per the backlog (`backlog.md`), the roadmap is:
+
+1. **`claimable.py`** (shipped) — claim-readiness + brief-block emitter.
+2. **`merge-flow.py`** — post-merge ritual: flip slice frontmatter to `done`, close Issue if still open, clean up orphan branches, update work-log.
+3. **`render-prompt.py`** — composes claimable.py + the prompt templates into a fully-formed agent session prompt.
+4. **`board.py`** — daily digest / weekly status view.
+
+Each script is operator-side, idempotent, safe to re-run. None modify vault content except `merge-flow.py` (which only makes commits the operator would make anyway).
+
+## Conventions
+
+- **Shebang + chmod +x.** Scripts are runnable as `.operator/scripts/<name>.py` from repo root. `python3` required.
+- **No ambient state.** Scripts read the repo + `gh` API; no `~/.musubi-operator/` caches, no database. Everything derivable.
+- **Stderr for warnings, stdout for pasteable output.** Makes `brief` output safely redirectable to clipboard / session prompt.
+- **Exit codes:** 0 = clean, 1 = policy violation (use for CI gating later), 2 = usage error.
+
+## Not to be confused with
+
+- `.agent-brief.*.local.md` files at repo root — those are the **filled** briefs (gitignored, copied into each agent session). The `.operator/prompts/` templates are what filled briefs are derived from.
+- `docs/architecture/_tools/` — vault-hygiene tooling consumed by agents during a slice (`make agent-check`, `make tc-coverage`). Different audience, different concern.
+- `~/Projects/musubi-orchestrator-brief.md` — the "next project" design for a real orchestrator agent. This directory is the manual-precursor: the mechanical operations the future orchestrator will automate.

--- a/.operator/backlog.md
+++ b/.operator/backlog.md
@@ -1,0 +1,134 @@
+# `.operator/` scripting backlog
+
+Ordered by priority. Each entry: what it does, why it's worth scripting, rough scope estimate.
+
+## Shipped
+
+### ✅ `scripts/claimable.py`
+
+Enumerates all slices, cross-references with `gh issue list`, flags claim-readiness, emits pasteable brief-blocks, sanity-checks slice files against ground truth.
+
+**Motivation:** three brief-vs-reality mismatches caught by agents (wrong Issue number, wrong spec path, owns_paths sibling-convention drift) within 24 hours of agent work. Every one of them should have been caught by a mechanical tool, not by an attentive agent pausing at claim time.
+
+**Status:** v1 shipped 2026-04-19. Future enhancements noted inline below.
+
+---
+
+## Next up
+
+### `scripts/merge-flow.py`
+
+**Priority: high.** The post-merge ritual I run manually on every slice PR, automated:
+
+1. Merge the PR (via `gh pr merge --squash --admin`).
+2. Flip slice frontmatter `status: in-review → done`, `tags: status/in-review → status/done`, `reviewed: false → true`, `updated` to today's date.
+3. Update the `**Phase:** X · **Status:** \`<x>\`` inline line in the slice markdown.
+4. Commit + push to v2.
+5. Close the Issue if it didn't auto-close via `Closes #N` in PR body.
+6. Delete any orphan branches on origin matching `slice/<slice-id>`.
+7. Audit + warn if the PR touched paths outside the slice's `owns_paths`.
+
+**Motivation:** operator-time sink. Happens ~once per slice landed; ~20 times this session alone. Each run is 4-6 hand-curated git/gh calls that occasionally slip.
+
+**Estimate:** ~250 lines. One Python file + integration test that exercises it against a fake PR on a throwaway branch.
+
+### `scripts/render-prompt.py`
+
+**Priority: medium-high.** Compose `claimable.py brief <slice-id>` output + `prompts/slice-start.md.template` into a fully-formed agent session prompt.
+
+**CLI:**
+
+```bash
+python3 .operator/scripts/render-prompt.py start \
+  --agent codex-gpt5 \
+  --clone-path ~/Projects/musubi-codex \
+  --slice slice-retrieval-fast
+
+# → single markdown block, ready to paste to agent session
+```
+
+Reads slot values from:
+- Slice frontmatter + `claimable.py` output (Issue number, owns/forbidden/specs/depends).
+- Operator-provided args (agent name, id, clone path).
+- Runtime inference (parallel agents from in-progress slice states).
+
+**Motivation:** brief writing has been my highest-drift operator task. Templating + slot-filling closes the loop.
+
+**Estimate:** ~150 lines on top of claimable.py's library functions.
+
+### `scripts/board.py`
+
+**Priority: medium.** Daily/on-demand status report for the whole slice DAG. Replaces my manual "v2 HEAD + open PRs + in-progress slices + claimable slices" investigations that I keep running.
+
+**Output:**
+
+```
+=== Musubi Board — 2026-04-19 17:45 UTC ===
+
+v2 HEAD:  1c075e1 docs(deploy): ADR-0019 (PR #66)
+
+Open PRs:    3
+  #70 [READY] slice-api-v0-read         | vscode-cc-sonnet47 | 2 commits, CI green
+  #13 [DRAFT] slice-lifecycle-promotion | gemini-3-1-pro-nyla | 5 commits, CI green
+  #27 [DRAFT] slice-retrieval-deep      | gemini-2-0-flash   | 3 commits, CI pending
+
+Claimable now: 3
+  slice-lifecycle-promotion     #13
+  slice-retrieval-deep          #27
+  slice-ops-ansible             #16
+
+In-flight (not PR'd): 0
+
+Stuck Issues: 0  (none with status:blocked)
+
+Slice DAG health:
+  done=16 · in-review=2 · ready=16
+  2 slices in `in-review` limbo (no recent activity): slice-config, slice-plane-episodic
+```
+
+**Motivation:** operator-facing daily morning check. Also useful as input to a future orchestrator's scheduled polling loop.
+
+**Estimate:** ~120 lines.
+
+---
+
+## Deferred
+
+### `scripts/coverage-diff.py`
+
+Compares per-module coverage on the current PR against the 90% plane/retrieve floor and the 85% general floor. Surfaces "you dropped below 90% on `src/musubi/planes/foo`" as a hard fail, which `make check` currently only partially reports.
+
+**Priority: low.** Annoying papercut; not a bug-prevention tool.
+
+### `scripts/adr-new.py`
+
+`python3 adr-new.py "some decision"` → creates `docs/architecture/13-decisions/00NN-some-decision.md` with frontmatter + section skeleton + correct NN numbering based on existing ADRs.
+
+**Priority: low.** Fixed-cost per ADR; only ~5 ADRs/year probably.
+
+### Enhancements to `claimable.py`
+
+- `--json` output mode for machine consumption.
+- Flag when an agent owns multiple in-progress slices (caught by accident this session).
+- Flag in-review limbo (slice is in-review but >48h without commits on its branch).
+- Detect phantom Issue claims (label flipped but no matching frontmatter update).
+- Cache `gh issue list` for 5 minutes to avoid rate-limit churn on repeat invocations.
+
+---
+
+## Not scripting (manual operator work remains)
+
+These are judgment calls that resist automation:
+
+- Writing reviewer Should-fix vs Nit classifications on PRs.
+- Deciding which coaching prompt fits a given agent misstep.
+- Choosing the next slice to recommend for each agent given strengths.
+- Orchestrator-level rebalancing (if one agent is blocked, move them).
+
+Automating these lives in the orchestrator agent itself (per `~/Projects/musubi-orchestrator-brief.md`), not in `.operator/scripts/`.
+
+---
+
+## How to add a new entry
+
+When you catch yourself doing a task by hand ≥ 3 times, promote it to this backlog. Note the trigger frequency + scope estimate. If it's urgent (blocks current work), move it to "Next up". Otherwise it lives in "Deferred" until another operator uses it and confirms priority.

--- a/.operator/prompts/followup-next-slice.md.template
+++ b/.operator/prompts/followup-next-slice.md.template
@@ -1,0 +1,75 @@
+# followup-next-slice prompt template
+
+> Used when a PR has merged (cleanly or with a small follow-up commit) and the agent is ready to take another slice. Fill every `{{slot}}` before pasting. Slots documented at bottom.
+
+```
+{{agent_name}} on Musubi:
+
+PR #{{merged_pr_number}} merged. {{just_finished_slice_id}} is now status: done on v2 (commits {{merge_commit_sha}} + {{flip_commit_sha}}). Issue #{{just_finished_issue_number}} auto-closed. {{unblocked_downstream_summary}}
+
+{{optional_strengths_callout}}
+
+Pick up your next slice. Recommended candidates (both depend only on now-done slices):
+
+{{next_slice_candidates_list}}
+
+Pick the one you prefer and claim atomically:
+
+    cd {{clone_path}}
+    git switch v2 && git pull --ff-only
+    gh issue edit <N> --add-assignee @me --add-label "status:in-progress" --remove-label "status:ready"
+    gh issue view <N> --json assignees
+
+In the same PR, flip the slice frontmatter status: ready -> in-progress, owner: {{agent_id}}. Commit: chore(slice): take <slice-id>.
+
+Branch + draft PR immediately (first line of body is "Closes #<N>."):
+
+    git switch -c slice/<slice-id>
+    git push -u origin slice/<slice-id>
+    gh pr create --draft --base v2 --title "<type>(<scope>): <slice-id>" \
+      --body "Closes #<N>.
+
+Draft — work in progress per docs/architecture/_slices/<slice-id>.md."
+
+Test-first. First implementation commit is the test file — every bullet from the spec's ## Test contract as a pytest function with the verbatim name.
+
+Run the five handoff checks before flipping to ready-for-review (see {{entrypoint_file}} §Before handoff):
+
+  1. make check exits 0
+  2. make tc-coverage SLICE=<slice-id> exits 0
+  3. make agent-check — distinguish ✗ errors from ⚠ warnings
+  4. gh pr checks <pr> green remotely
+  5. PR body first line is "Closes #<N>."
+
+{{module_coverage_reminder}}
+
+### Parallel agents right now
+
+{{parallel_agents_block}}
+
+Your path will be <owns-path-of-new-slice>; verify no overlap with the list above.
+
+When stuck, drop docs/architecture/_inbox/questions/<slice-id>-<slug>.md (full frontmatter: title, section, type, status, tags, updated), flip slice + Issue to blocked, comment the Issue with the link, stop.
+
+{{optional_closing_remark}}
+```
+
+## Slots
+
+| Slot | Example | Notes |
+|---|---|---|
+| `{{agent_name}}` | `Codex (GPT-5)` | Same meaning as in slice-start. |
+| `{{agent_id}}` | `codex-gpt5` | Same. |
+| `{{clone_path}}` | `~/Projects/musubi-codex` | Same. |
+| `{{entrypoint_file}}` | `CLAUDE.md`, `AGENTS.md`, `GEMINI.md` | Same. |
+| `{{merged_pr_number}}` | `50` | The PR that just merged. |
+| `{{just_finished_slice_id}}` | `slice-retrieval-hybrid` | |
+| `{{just_finished_issue_number}}` | `29` | |
+| `{{merge_commit_sha}}` | `667b99e` | Short SHA of the squash-merge commit on v2. |
+| `{{flip_commit_sha}}` | `cfd42c6` | Short SHA of the frontmatter-flip commit on v2. Omit `+ flip_commit_sha` clause if no flip was needed. |
+| `{{unblocked_downstream_summary}}` | `Downstream slice-retrieval-fast + slice-retrieval-deep are now unblocked.` | One sentence naming what this merge unblocked. |
+| `{{optional_strengths_callout}}` | `Excellent work this round — 98% coverage, textbook server-side RRF.` | Optional one-line positive feedback. Omit if not warranted. |
+| `{{next_slice_candidates_list}}` | `  - slice-retrieval-rerank (#31) — BGE reranker pass ...\n  - slice-retrieval-scoring (#32) — downstream scoring ...` | 1-3 options with one-line rationale each. Include depends-on status. |
+| `{{module_coverage_reminder}}` | `Symmetric coverage: src/musubi/retrieve/** has a 90% branch floor (not just 85%). Run uv run coverage report --include='src/musubi/retrieve/*' before handoff.` | Scoped to the agent's next-slice path family. Omit if slice isn't in a 90%-floor tree. |
+| `{{parallel_agents_block}}` | See `parallel-agents-block.snippet.md` | Current state of other agents in the round. |
+| `{{optional_closing_remark}}` | `Good work.` / `Strong round; cite the block/unblock discipline.` | Optional. Omit if redundant. |

--- a/.operator/prompts/slice-start.md.template
+++ b/.operator/prompts/slice-start.md.template
@@ -1,0 +1,126 @@
+# slice-start prompt template
+
+> Copy the block below to the operator. The operator pastes it directly to the agent as the opening message. Fill every `{{slot}}` before pasting; they are documented in the `## Slots` section at the bottom.
+
+```
+{{agent_name}} on Musubi:
+
+Starting {{slice_id}} (Issue #{{issue_number}}).
+
+Your isolated local clone is at {{clone_path}} (not the operator's clone at ~/Projects/musubi/). All agents this round push to the shared remote github.com:ericmey/musubi.git; each agent works from its own checkout.
+
+First commands:
+
+    cd {{clone_path}}
+    git switch v2 && git pull --ff-only
+
+Use {{agent_id}} as your agent id in work-log entries.
+
+Required reads, in order:
+
+  1. {{entrypoint_file}} at repo root — the contract includes a "Before handoff (the five checks)" section. Read it carefully; it encodes drift patterns from prior rounds.
+  2. docs/AGENT-PROCESS.md — multi-agent concurrency model.
+  3. docs/architecture/00-index/agent-guardrails.md — four non-negotiables + Closure Rule + Method-ownership rule + Dual-update rule.
+  4. docs/architecture/00-index/agent-handoff.md — includes the "Reviewer notes — where they land" subsection.
+  5. docs/architecture/00-index/conventions.md — style guide; Testing section on verbatim-bullet-name convention.
+
+Slice file: docs/architecture/_slices/{{slice_id}}.md. Read end-to-end first.
+
+Spec(s) to implement: {{spec_paths}}. Every bullet in the spec's ## Test contract section must land in one of the three Closure states at handoff.
+
+Owned paths (you MAY write here):
+{{owns_paths_list}}
+
+Forbidden paths (you MUST NOT write here):
+{{forbidden_paths_list}}
+
+Depends on (all must be status: done on v2 before you start):
+{{depends_on_list}}
+
+What you build:
+
+{{implementation_notes}}
+
+### Hard constraints
+
+1. Claim atomically via the Dual-update rule:
+
+       gh issue edit {{issue_number}} --add-assignee @me \
+         --add-label "status:in-progress" --remove-label "status:ready"
+       gh issue view {{issue_number}} --json assignees   # re-read; yield if conflicts
+
+   In the SAME PR, flip slice-file frontmatter: status: ready -> in-progress, owner: {{agent_id}}. Commit: chore(slice): take {{slice_id}}.
+
+2. Branch + draft PR immediately (first line of body is "Closes #{{issue_number}}."):
+
+       git switch -c slice/{{slice_id}}
+       git push -u origin slice/{{slice_id}}
+       gh pr create --draft --base v2 --title "{{pr_title}}" \
+         --body "Closes #{{issue_number}}.
+
+Draft — work in progress per docs/architecture/_slices/{{slice_id}}.md."
+
+3. Test-first. FIRST implementation commit is the test file — every bullet from the spec's ## Test contract as a pytest function with the verbatim name. Property tests (if any) -> hypothesis strategies.
+
+4. Then: feat commit for the implementation. Then: docs(slice) handoff commit (thin; frontmatter flip + work-log entry with coverage matrix only — NO code).
+
+5. Run the FIVE handoff checks before flipping to ready-for-review (see {{entrypoint_file}} §Before handoff):
+
+   a. uv run make check                            — exits 0
+   b. uv run make tc-coverage SLICE={{slice_id}}   — exits 0
+   c. uv run make agent-check                      — grep `^  ✗` first; only ✗ errors block, ⚠ warnings don't
+   d. gh pr checks <pr-number>                     — remote green, not just local
+   e. PR body first line is "Closes #{{issue_number}}." — exact keyword
+
+6. Module-scope coverage floor: {{coverage_floor_note}}
+   Run `uv run coverage report --include='{{coverage_include_glob}}'` before handoff to verify the MODULE floor, not just the repo floor.
+
+7. Do NOT push to v2 or --force anything (force-with-lease to your slice branch is OK if rebasing).
+
+8. Do NOT touch anything under docs/architecture/ except your slice file's work log + any spec you explicitly updated (with spec-update: trailer).
+
+### Handoff
+
+After all five checks pass:
+
+    # Flip frontmatter: status: in-progress -> in-review; append work-log entry with Test Contract coverage matrix.
+    git commit -am "docs(slice): handoff {{slice_id}} to in-review"
+    git push
+    gh pr ready <pr-number>
+    gh pr edit <pr-number> --add-label "status:in-review" --remove-label "status:in-progress"
+    gh issue edit {{issue_number}} --add-label "status:in-review" --remove-label "status:in-progress"
+
+Do NOT self-approve or merge. The reviewer will take it from there.
+
+### Parallel agents this round
+
+{{parallel_agents_block}}
+
+### When stuck
+
+Drop docs/architecture/_inbox/questions/{{slice_id}}-<slug>.md with full frontmatter (title, section, type, status, tags, updated). Flip slice + Issue to blocked. Comment the Issue with the link. Stop.
+
+Do NOT guess. Do NOT "just make it work."
+
+Good luck.
+```
+
+## Slots
+
+| Slot | Example | Notes |
+|---|---|---|
+| `{{agent_name}}` | `Codex (GPT-5)`, `Claude Code (VS Code)`, `Gemini 3.1 Pro on Nyla` | Human-friendly agent label. |
+| `{{agent_id}}` | `codex-gpt5`, `vscode-cc-sonnet47`, `gemini-3-1-pro-nyla` | Machine-friendly id used in work-log entries. |
+| `{{clone_path}}` | `~/Projects/musubi-codex` | Per-agent isolated clone. Not `~/Projects/musubi/` (that's the operator). |
+| `{{slice_id}}` | `slice-retrieval-rerank` | The slice filename stem. |
+| `{{issue_number}}` | `31` | GitHub Issue number for the slice. |
+| `{{entrypoint_file}}` | `CLAUDE.md`, `AGENTS.md`, `GEMINI.md` | The agent's entry doc — one of the three at repo root. |
+| `{{spec_paths}}` | `docs/architecture/05-retrieval/rerank.md` | Comma-separated if multiple. |
+| `{{owns_paths_list}}` | `  - src/musubi/retrieve/rerank.py\n  - tests/retrieve/test_rerank.py` | Markdown bullet list; two-space indent. |
+| `{{forbidden_paths_list}}` | `  - src/musubi/planes/\n  - src/musubi/api/\n  - src/musubi/types/` | Same shape as owns. |
+| `{{depends_on_list}}` | `  - slice-types (done) — you import ...\n  - slice-embedding (done) — you depend on Embedder ...` | Bullet list; each entry names what the agent imports/uses. |
+| `{{implementation_notes}}` | free-form paragraph + optional signature sketch + design callouts | Slice-specific. Include Method-ownership decision points, distinct constants (e.g. `_POINT_NS`) if applicable. |
+| `{{pr_title}}` | `feat(retrieve): slice-retrieval-rerank` | Conventional-commits title for the PR + eventual squash commit. |
+| `{{coverage_floor_note}}` | `src/musubi/retrieve/** has a 90% branch floor per guardrails (not just 85%).` | Slice-scoped reminder. |
+| `{{coverage_include_glob}}` | `src/musubi/retrieve/*` | The `--include` pattern matching owns_paths. |
+| `{{parallel_agents_block}}` | See `parallel-agents-block.snippet.md` in this directory | List: `- <agent-name> — <slice-id> — <owns-path>.` Call out non-overlap explicitly. |

--- a/.operator/scripts/claimable.py
+++ b/.operator/scripts/claimable.py
@@ -1,0 +1,560 @@
+#!/usr/bin/env python3
+"""claimable.py — operator-side slice claim-readiness enumerator.
+
+Operator-only tool (not consumed by slice-worker agents during slice work).
+Purpose: eliminate brief-vs-reality mismatches when authoring agent prompts.
+
+Reads every `docs/architecture/_slices/slice-*.md`, cross-references with
+GitHub Issues (via `gh`), and outputs a mechanical view of what's
+actually claimable right now. Replaces the hand-authored slice references
+in agent briefs that have been caught as wrong three times in the last
+two sessions (wrong Issue number, wrong spec path, owns_paths sibling-
+convention drift, unmet depends-on).
+
+Usage:
+    # list all slices with claimable flag + Issue number:
+    python3 .operator/scripts/claimable.py
+    python3 .operator/scripts/claimable.py list --only-claimable
+
+    # emit the slice-specific brief block (paste into an agent prompt):
+    python3 .operator/scripts/claimable.py brief slice-retrieval-fast
+
+    # sanity-check a slice file against ground truth:
+    python3 .operator/scripts/claimable.py verify slice-retrieval-fast
+
+Deps: Python 3.12+ stdlib · PyYAML · `gh` CLI on PATH.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("error: requires PyYAML (uv add pyyaml / pip install pyyaml)", file=sys.stderr)
+    sys.exit(2)
+
+
+# Resolve repo root: this script lives at <repo>/.operator/scripts/claimable.py
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SLICES_DIR = REPO_ROOT / "docs" / "architecture" / "_slices"
+VAULT_ROOT = REPO_ROOT / "docs" / "architecture"
+
+
+# ---------------------------------------------------------------------------
+# Tiny ANSI helpers (no-op when not a TTY)
+# ---------------------------------------------------------------------------
+
+
+def _color(s: str, code: str) -> str:
+    return f"\033[{code}m{s}\033[0m" if sys.stdout.isatty() else s
+
+
+def green(s: str) -> str:
+    return _color(s, "32")
+
+
+def red(s: str) -> str:
+    return _color(s, "31")
+
+
+def yellow(s: str) -> str:
+    return _color(s, "33")
+
+
+def dim(s: str) -> str:
+    return _color(s, "2")
+
+
+def bold(s: str) -> str:
+    return _color(s, "1")
+
+
+def _strip_ansi(s: str) -> str:
+    return re.sub(r"\033\[[0-9;]*m", "", s)
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Issue:
+    number: int
+    title: str
+    state: str  # "OPEN" | "CLOSED"
+    labels: list[str]
+    assignees: list[str]
+
+
+@dataclass
+class Slice:
+    id: str
+    path: Path
+    title: str
+    status: str
+    owner: str
+    phase: str
+    depends_on: list[str]
+    blocks: list[str]
+    owns_paths: list[str]
+    forbidden_paths: list[str]
+    specs: list[str]  # relative file paths; suffix "(MISSING)" if not on disk
+    issue: Issue | None = None
+    claimable: bool | None = None
+    reason: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Parsers
+# ---------------------------------------------------------------------------
+
+
+_WIKILINK = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
+_BULLET_BACKTICK = re.compile(r"^\s*[-*]\s+`([^`]+)`", re.M)
+
+
+def _extract_wikilinks(text: str) -> list[str]:
+    return _WIKILINK.findall(text)
+
+
+def _slice_id_from_wikilink(link: str) -> str | None:
+    """`_slices/slice-xxx` → `slice-xxx`; returns None if not a slice link."""
+    link = link.strip()
+    if link.startswith("_slices/"):
+        return link[len("_slices/") :]
+    return None
+
+
+def _parse_frontmatter(text: str) -> tuple[dict, str]:
+    if not text.startswith("---\n"):
+        return {}, text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return {}, text
+    try:
+        fm = yaml.safe_load(text[4:end]) or {}
+    except yaml.YAMLError:
+        fm = {}
+    return fm, text[end + 5 :]
+
+
+def _slice_ids_from_yaml_list(lst: list | None) -> list[str]:
+    """Extract slice-ids from a YAML list of quoted wikilinks like '[[_slices/foo]]'."""
+    out: list[str] = []
+    for item in lst or []:
+        for link in _extract_wikilinks(item) if isinstance(item, str) else []:
+            sid = _slice_id_from_wikilink(link)
+            if sid:
+                out.append(sid)
+    return out
+
+
+def _paths_under_heading(body: str, heading: str) -> list[str]:
+    """Extract backtick-wrapped paths from bullet items under a given ## heading."""
+    m = re.search(
+        rf"^##+\s+{re.escape(heading)}.*?\n(.*?)(?=^##+\s|\Z)",
+        body,
+        re.M | re.S,
+    )
+    return _BULLET_BACKTICK.findall(m.group(1)) if m else []
+
+
+def load_slices() -> dict[str, Slice]:
+    """Parse every slice-*.md under `_slices/`."""
+    slices: dict[str, Slice] = {}
+    for p in sorted(SLICES_DIR.glob("slice-*.md")):
+        text = p.read_text()
+        fm, body = _parse_frontmatter(text)
+        if fm.get("type") != "slice":
+            continue
+
+        sid = fm.get("slice_id") or p.stem
+        depends_on = _slice_ids_from_yaml_list(fm.get("depends-on"))
+        blocks = _slice_ids_from_yaml_list(fm.get("blocks"))
+
+        # Specs: wikilinks under "## Specs to implement"
+        spec_links: list[str] = []
+        m = re.search(
+            r"^##\s+Specs to implement\s*\n(.*?)(?=^##\s|\Z)", body, re.M | re.S
+        )
+        if m:
+            spec_links = _extract_wikilinks(m.group(1))
+
+        specs: list[str] = []
+        for link in spec_links:
+            candidate = VAULT_ROOT / f"{link}.md"
+            if candidate.exists():
+                specs.append(str(candidate.relative_to(REPO_ROOT)))
+            else:
+                specs.append(f"docs/architecture/{link}.md (MISSING)")
+
+        slices[sid] = Slice(
+            id=sid,
+            path=p,
+            title=str(fm.get("title", "")).strip('"').strip(),
+            status=str(fm.get("status", "")).strip(),
+            owner=str(fm.get("owner", "")).strip(),
+            phase=str(fm.get("phase", "")).strip('"').strip(),
+            depends_on=depends_on,
+            blocks=blocks,
+            owns_paths=_paths_under_heading(body, "Owned paths"),
+            forbidden_paths=_paths_under_heading(body, "Forbidden paths"),
+            specs=specs,
+        )
+    return slices
+
+
+def load_issues() -> dict[str, Issue]:
+    """Fetch GitHub issues labeled 'slice', match to slice-ids by title."""
+    try:
+        out = subprocess.run(
+            [
+                "gh", "issue", "list",
+                "--label", "slice",
+                "--state", "all",
+                "--limit", "200",
+                "--json", "number,title,state,labels,assignees",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+        print(
+            f"warning: gh issue list unavailable; Issue column will be blank ({exc})",
+            file=sys.stderr,
+        )
+        return {}
+
+    by_slice: dict[str, Issue] = {}
+    for row in json.loads(out):
+        title: str = row["title"]
+        # Canonical title pattern: "slice: slice-xxx" or "slice: slice-xxx — <suffix>"
+        m = re.match(r"slice:\s+(slice-[a-z0-9-]+)", title)
+        if not m:
+            continue
+        sid = m.group(1)
+        # Prefer the FIRST OPEN match, otherwise last closed (handles split-slice history)
+        issue = Issue(
+            number=row["number"],
+            title=title,
+            state=row["state"],
+            labels=[lab["name"] for lab in row.get("labels", [])],
+            assignees=[a["login"] for a in row.get("assignees", [])],
+        )
+        existing = by_slice.get(sid)
+        if existing is None or (existing.state != "OPEN" and issue.state == "OPEN"):
+            by_slice[sid] = issue
+    return by_slice
+
+
+def compute_claimability(slices: dict[str, Slice]) -> None:
+    """Annotate each slice with `claimable` + reason."""
+    for s in slices.values():
+        if s.status != "ready":
+            s.claimable = False
+            s.reason = f"status={s.status}"
+            continue
+        if s.issue is None:
+            s.claimable = False
+            s.reason = "no matching Issue"
+            continue
+        if s.issue.state != "OPEN":
+            s.claimable = False
+            s.reason = f"Issue #{s.issue.number} is CLOSED"
+            continue
+
+        unmet: list[str] = []
+        for dep_id in s.depends_on:
+            dep = slices.get(dep_id)
+            if dep is None:
+                unmet.append(f"{dep_id}(missing)")
+                continue
+            if dep.status == "done":
+                continue
+            # Tolerate the race where Issue is closed but vault frontmatter
+            # hasn't been flipped to "done" yet (operator follows up within hours).
+            if (
+                dep.status == "in-review"
+                and dep.issue is not None
+                and dep.issue.state == "CLOSED"
+            ):
+                continue
+            unmet.append(f"{dep_id}({dep.status})")
+
+        if unmet:
+            s.claimable = False
+            s.reason = "deps: " + ", ".join(unmet)
+        else:
+            s.claimable = True
+            s.reason = ""
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+def cmd_list(slices: dict[str, Slice], only_claimable: bool = False) -> int:
+    headers = ("slice-id", "issue", "status", "claim", "owner", "reason")
+    rows: list[tuple[str, ...]] = []
+    for sid, s in sorted(slices.items(), key=lambda kv: (kv[1].phase, kv[0])):
+        if only_claimable and not s.claimable:
+            continue
+        issue_ref = f"#{s.issue.number}" if s.issue else "—"
+        color_map = {
+            "ready": green if s.claimable else yellow,
+            "in-progress": yellow,
+            "in-review": yellow,
+            "done": dim,
+            "blocked": red,
+        }
+        status_colored = color_map.get(s.status, lambda x: x)(s.status)
+        if s.claimable:
+            claim_mark = green("✓")
+        elif s.status == "ready":
+            claim_mark = red("✗")
+        else:
+            claim_mark = dim("—")
+        rows.append(
+            (
+                sid,
+                issue_ref,
+                status_colored,
+                claim_mark,
+                s.owner or "—",
+                s.reason,
+            )
+        )
+
+    widths = [
+        max(
+            (len(_strip_ansi(r[i])) for r in rows),
+            default=0,
+        )
+        for i in range(len(headers))
+    ]
+    widths = [max(widths[i], len(headers[i])) for i in range(len(headers))]
+
+    def fmt(cols: tuple[str, ...]) -> str:
+        out: list[str] = []
+        for i, c in enumerate(cols):
+            pad = widths[i] - len(_strip_ansi(c))
+            out.append(c + " " * pad)
+        return "  ".join(out)
+
+    print(bold(fmt(headers)))
+    print(bold(fmt(tuple("-" * w for w in widths))))
+    for r in rows:
+        print(fmt(r))
+
+    total = len(slices)
+    claimable_count = sum(1 for s in slices.values() if s.claimable)
+    by_status: dict[str, int] = {}
+    for s in slices.values():
+        by_status[s.status] = by_status.get(s.status, 0) + 1
+    print()
+    print(f"{bold('total')}: {total}   {bold('claimable-now')}: {green(str(claimable_count))}")
+    print("by status: " + ", ".join(f"{k}={v}" for k, v in sorted(by_status.items())))
+    return 0
+
+
+def cmd_brief(slices: dict[str, Slice], slice_id: str) -> int:
+    s = slices.get(slice_id)
+    if s is None:
+        print(f"error: unknown slice '{slice_id}'", file=sys.stderr)
+        print(
+            "available: " + ", ".join(sorted(slices.keys())),
+            file=sys.stderr,
+        )
+        return 2
+
+    # Surface sanity issues upfront, to stderr so brief body stays pasteable
+    for spec in s.specs:
+        if "(MISSING)" in spec:
+            print(f"warning: {spec}", file=sys.stderr)
+    if not s.issue:
+        print(
+            f"warning: no matching GitHub Issue found for '{slice_id}'",
+            file=sys.stderr,
+        )
+
+    issue_num = s.issue.number if s.issue else "???"
+
+    in_flight = [
+        (s2.id, s2.owner, s2.owns_paths[0] if s2.owns_paths else "(no owns_paths)")
+        for s2 in slices.values()
+        if s2.status in ("in-progress", "in-review") and s2.id != slice_id
+    ]
+
+    # Print as a plain text block ready to paste. No color here.
+    print(f"Slice: {s.id} (#{issue_num}).")
+    print(f"Slice file: {s.path.relative_to(REPO_ROOT)}")
+    print()
+    if s.specs:
+        print("Spec" + ("s" if len(s.specs) > 1 else "") + ":")
+        for spec in s.specs:
+            print(f"  - {spec}")
+        print()
+    if s.owns_paths:
+        print("Owned paths (you MAY write here):")
+        for p in s.owns_paths:
+            print(f"  - {p}")
+        print()
+    if s.forbidden_paths:
+        print("Forbidden paths (you MUST NOT write here):")
+        for p in s.forbidden_paths:
+            print(f"  - {p}")
+        print()
+    if s.depends_on:
+        print("Depends on:")
+        for dep_id in s.depends_on:
+            dep = slices.get(dep_id)
+            if dep is None:
+                print(f"  - {dep_id} (UNKNOWN slice)")
+            else:
+                note = dep.status
+                if (
+                    dep.status == "in-review"
+                    and dep.issue is not None
+                    and dep.issue.state == "CLOSED"
+                ):
+                    note = "done (Issue closed; frontmatter-flip race)"
+                print(f"  - {dep_id} ({note})")
+        print()
+    if s.blocks:
+        print("Unblocks:")
+        for b in s.blocks:
+            print(f"  - {b}")
+        print()
+    print("Parallel agents right now:")
+    if in_flight:
+        for pid, powner, ppath in in_flight:
+            print(f"  - {pid} — {powner or 'unclaimed'} — {ppath}")
+    else:
+        print("  (none in-progress or in-review)")
+    print()
+    if s.claimable:
+        print(f"✓ CLAIMABLE NOW — Issue #{issue_num} is OPEN and deps are met.")
+    else:
+        print(f"✗ NOT CLAIMABLE: {s.reason}")
+    return 0 if s.claimable else 1
+
+
+def cmd_verify(slices: dict[str, Slice], slice_id: str) -> int:
+    """Sanity-check a slice file against ground truth."""
+    s = slices.get(slice_id)
+    if s is None:
+        print(f"error: unknown slice '{slice_id}'", file=sys.stderr)
+        return 2
+
+    problems: list[str] = []
+
+    if s.issue is None:
+        problems.append(f"no GitHub Issue with title 'slice: {slice_id}'")
+
+    for spec in s.specs:
+        if "(MISSING)" in spec:
+            problems.append(f"spec file missing: {spec}")
+
+    for dep in s.depends_on:
+        if dep not in slices:
+            problems.append(f"depends-on references unknown slice: {dep}")
+    for b in s.blocks:
+        if b not in slices:
+            problems.append(f"blocks references unknown slice: {b}")
+
+    # Sibling-convention check on owns_paths
+    for p in s.owns_paths:
+        if p.startswith("src/musubi/") and p.endswith(".py"):
+            parts = p.split("/")
+            dirname = "/".join(parts[:-1])
+            fname = parts[-1]
+            abs_dir = REPO_ROOT / dirname
+            if not abs_dir.exists():
+                continue
+            siblings = [
+                f.name
+                for f in abs_dir.glob("*.py")
+                if f.name != "__init__.py" and f.name != fname
+            ]
+            if siblings and "_" in fname:
+                sibling_has_underscore = any("_" in sb for sb in siblings)
+                if not sibling_has_underscore:
+                    problems.append(
+                        f"sibling-convention drift: {fname} has underscore, "
+                        f"but siblings in {dirname}/ ({', '.join(siblings)}) are single-noun"
+                    )
+
+    if not problems:
+        print(green(f"✓ {slice_id}: no issues detected"))
+        return 0
+    print(red(f"✗ {slice_id}: {len(problems)} issue(s)"))
+    for p in problems:
+        print(f"  - {p}")
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="claimable.py",
+        description=(
+            "Enumerate Musubi slices and their claim-readiness. "
+            "Operator-only tool. "
+            "See .operator/scripts/claimable.py top-of-file docstring for full usage."
+        ),
+    )
+    sub = parser.add_subparsers(dest="cmd")
+
+    p_list = sub.add_parser("list", help="list all slices (default)")
+    p_list.add_argument(
+        "--only-claimable",
+        action="store_true",
+        help="filter to slices claimable right now",
+    )
+
+    p_brief = sub.add_parser(
+        "brief", help="emit pasteable brief-block for a slice"
+    )
+    p_brief.add_argument("slice_id")
+
+    p_verify = sub.add_parser(
+        "verify", help="sanity-check a slice file against ground truth"
+    )
+    p_verify.add_argument("slice_id")
+
+    args = parser.parse_args(argv)
+
+    slices = load_slices()
+    issues = load_issues()
+    for sid, s in slices.items():
+        s.issue = issues.get(sid)
+    compute_claimability(slices)
+
+    cmd = args.cmd or "list"
+    if cmd == "list":
+        return cmd_list(slices, only_claimable=getattr(args, "only_claimable", False))
+    if cmd == "brief":
+        return cmd_brief(slices, args.slice_id)
+    if cmd == "verify":
+        return cmd_verify(slices, args.slice_id)
+    parser.print_help()
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.operator/scripts/claimable.py
+++ b/.operator/scripts/claimable.py
@@ -183,9 +183,7 @@ def load_slices() -> dict[str, Slice]:
 
         # Specs: wikilinks under "## Specs to implement"
         spec_links: list[str] = []
-        m = re.search(
-            r"^##\s+Specs to implement\s*\n(.*?)(?=^##\s|\Z)", body, re.M | re.S
-        )
+        m = re.search(r"^##\s+Specs to implement\s*\n(.*?)(?=^##\s|\Z)", body, re.M | re.S)
         if m:
             spec_links = _extract_wikilinks(m.group(1))
 
@@ -218,11 +216,17 @@ def load_issues() -> dict[str, Issue]:
     try:
         out = subprocess.run(
             [
-                "gh", "issue", "list",
-                "--label", "slice",
-                "--state", "all",
-                "--limit", "200",
-                "--json", "number,title,state,labels,assignees",
+                "gh",
+                "issue",
+                "list",
+                "--label",
+                "slice",
+                "--state",
+                "all",
+                "--limit",
+                "200",
+                "--json",
+                "number,title,state,labels,assignees",
             ],
             check=True,
             capture_output=True,
@@ -283,11 +287,7 @@ def compute_claimability(slices: dict[str, Slice]) -> None:
                 continue
             # Tolerate the race where Issue is closed but vault frontmatter
             # hasn't been flipped to "done" yet (operator follows up within hours).
-            if (
-                dep.status == "in-review"
-                and dep.issue is not None
-                and dep.issue.state == "CLOSED"
-            ):
+            if dep.status == "in-review" and dep.issue is not None and dep.issue.state == "CLOSED":
                 continue
             unmet.append(f"{dep_id}({dep.status})")
 
@@ -483,9 +483,7 @@ def cmd_verify(slices: dict[str, Slice], slice_id: str) -> int:
             if not abs_dir.exists():
                 continue
             siblings = [
-                f.name
-                for f in abs_dir.glob("*.py")
-                if f.name != "__init__.py" and f.name != fname
+                f.name for f in abs_dir.glob("*.py") if f.name != "__init__.py" and f.name != fname
             ]
             if siblings and "_" in fname:
                 sibling_has_underscore = any("_" in sb for sb in siblings)
@@ -527,14 +525,10 @@ def main(argv: list[str]) -> int:
         help="filter to slices claimable right now",
     )
 
-    p_brief = sub.add_parser(
-        "brief", help="emit pasteable brief-block for a slice"
-    )
+    p_brief = sub.add_parser("brief", help="emit pasteable brief-block for a slice")
     p_brief.add_argument("slice_id")
 
-    p_verify = sub.add_parser(
-        "verify", help="sanity-check a slice file against ground truth"
-    )
+    p_verify = sub.add_parser("verify", help="sanity-check a slice file against ground truth")
     p_verify.add_argument("slice_id")
 
     args = parser.parse_args(argv)


### PR DESCRIPTION
No tracking Issue: operator-side tooling PR. First deliverable on the .operator/ scripting roadmap called for by Eric in the 2026-04-19 session after three brief-vs-reality mismatches landed as operator-side reconcile PRs.

## Summary

Operator-side scripting directory with the first mechanical tool that prevents the "brief-vs-reality" class of bug:

\`\`\`bash
# list all slices:
python3 .operator/scripts/claimable.py

# only slices genuinely claimable now (all deps done):
python3 .operator/scripts/claimable.py list --only-claimable

# emit pasteable brief-block for a slice (Issue # + spec paths + owns/forbidden + deps all verified):
python3 .operator/scripts/claimable.py brief slice-lifecycle-promotion

# sanity-check a slice file against ground truth:
python3 .operator/scripts/claimable.py verify slice-retrieval-fast
\`\`\`

Reads \`docs/architecture/_slices/slice-*.md\` + \`gh issue list --label slice\`. Cross-references to produce a single source of truth.

## What it catches

All four classes of brief-mismatch caught by agents in the last session:

| Bug class | Example | How claimable.py catches it |
|---|---|---|
| Wrong Issue number in brief | Said #8 for slice-api-v0; actual was #6 | `brief <slice-id>` prints the verified Issue number |
| Wrong spec filename | Said \`api-v0.md\`; actual is \`canonical-api.md\` | Resolves wikilinks from frontmatter; \`(MISSING)\` suffix if file doesn't exist on disk |
| Owns_paths sibling drift | \`fast_path.py\` alongside \`hybrid.py\`/\`rerank.py\`/\`scoring.py\` | \`verify\` flags underscore-filename in dir of single-noun siblings |
| Dep not satisfied | Recommended MCP slice whose deps hadn't landed | \`list\` computes strict claimability; unmet deps surface as the \`reason\` column |

## Smoke-test findings

Run against current v2 state:

- **3 strictly-claimable slices** right now: slice-lifecycle-promotion (#13), slice-retrieval-deep (#27), slice-ops-ansible (#16). Matches the VS Code / Nyla / Hana assignments (minus ops-ansible as spare).
- **In-review limbo** detected: slice-config (#8) and slice-plane-episodic (#23) have been \`status: in-review\` with OPEN Issues since session start. Their downstreams (slice-api-v0-read, slice-retrieval-fast) are blocked from strict-claimable status by this drift. Separate operator follow-up to flip both to \`done\` + close their Issues.

## Files

- \`.operator/scripts/claimable.py\` — main script, 3 subcommands (list, brief, verify). ~350 lines.
- \`.operator/README.md\` — directory overview, conventions, evolution plan.
- \`.operator/backlog.md\` — prioritised next scripts (merge-flow, render-prompt, board).
- \`.operator/prompts/*.md.template\` — existing prompt templates (unchanged from earlier work in this session; consumed by render-prompt.py in the next script).

## Test plan

- [x] \`make check\` passes (agent-check clean; no ✗ errors).
- [x] \`claimable.py list\` runs cleanly against the 34 slice files on current v2.
- [x] \`claimable.py brief slice-lifecycle-promotion\` produces a pasteable block with verified Issue number + depends-on annotations + parallel-agents view.
- [x] \`claimable.py verify slice-retrieval-fast\` passes (no drift) after the reconcile in PR #72.
- [ ] CI passes on this PR.

## Next

Per \`.operator/backlog.md\`, next scripts in priority order: \`merge-flow.py\`, \`render-prompt.py\`, \`board.py\`. Each is operator-side, idempotent, safe to re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)