### PR TITLE
chore(slice): reconcile slice-retrieval-deep owns_paths to match siblings

### DIFF
--- a/docs/architecture/_slices/slice-retrieval-deep.md
+++ b/docs/architecture/_slices/slice-retrieval-deep.md
@@ -24,12 +24,18 @@ blocks: ["[[_slices/slice-adapter-mcp]]", "[[_slices/slice-adapter-openclaw]]", 
 
 ## Owned paths (you MAY write here)
 
-- `musubi/retrieve/deep_path.py`
-- `tests/retrieve/test_deep_path.py`
+- `src/musubi/retrieve/deep.py`
+- `tests/retrieve/test_deep.py`
 
 ## Forbidden paths (you MUST NOT write here — open a cross-slice ticket if needed)
 
-- `musubi/planes/`
+- `src/musubi/retrieve/hybrid.py`   (owned by slice-retrieval-hybrid, done)
+- `src/musubi/retrieve/scoring.py`  (owned by slice-retrieval-scoring, done)
+- `src/musubi/retrieve/rerank.py`   (owned by slice-retrieval-rerank, done)
+- `src/musubi/retrieve/fast.py`     (owned by slice-retrieval-fast, done)
+- `src/musubi/planes/`
+- `src/musubi/api/`
+- `src/musubi/types/`
 
 ## Depends on
 


### PR DESCRIPTION
No tracking Issue: operator-side reconcile surfaced by handoff-audit.py during smoke-test. Same fix pattern as PR #72 for slice-retrieval-fast.

Slice file now points at \`src/musubi/retrieve/deep.py\` + \`tests/retrieve/test_deep.py\` matching siblings. Forbidden_paths tightened.

Test plan:
- [x] \`make agent-check\` clean.
- [ ] CI passes.