### PR TITLE
chore(slice): reconcile slice-ingestion-capture owns_paths (src/ prefix)

### DIFF
--- a/docs/architecture/_slices/slice-ingestion-capture.md
+++ b/docs/architecture/_slices/slice-ingestion-capture.md
@@ -25,13 +25,16 @@ blocks: ["[[_slices/slice-adapter-mcp]]", "[[_slices/slice-adapter-livekit]]"]
 
 ## Owned paths (you MAY write here)
 
-- `musubi/ingestion/capture.py`
+- `src/musubi/ingestion/capture.py`
 - `tests/ingestion/test_capture.py`
 
 ## Forbidden paths (you MUST NOT write here — open a cross-slice ticket if needed)
 
-- `musubi/lifecycle/`
-- `musubi/planes/`
+- `src/musubi/lifecycle/`
+- `src/musubi/planes/`
+- `src/musubi/api/`
+- `src/musubi/retrieve/`
+- `src/musubi/types/`
 
 ## Depends on
 


### PR DESCRIPTION
No tracking Issue: operator-side slice-file reconcile. Fourth of its kind this session — same pre-src/-monorepo drift as fast / deep / blended.

Surfaced by vscode-cc-sonnet47 during claim-time on slice-ingestion-capture. Applying the precedent from PR #72 / #81 / commit 0e5c51a.

Test plan:
- [x] \`make agent-check\` clean.
- [ ] CI passes.