### PR TITLE
docs(adr): 0022 extension ecosystem — language-based monorepo boundary

### DIFF
--- a/docs/architecture/07-interfaces/openclaw-adapter.md
+++ b/docs/architecture/07-interfaces/openclaw-adapter.md
@@ -4,7 +4,7 @@ section: 07-interfaces
 tags: [adapter, browser, interfaces, openclaw, section/interfaces, status/complete, type/spec]
 type: spec
 status: complete
-updated: 2026-04-17
+updated: 2026-04-19
 up: "[[07-interfaces/index]]"
 reviewed: false
 ---
@@ -12,7 +12,9 @@ reviewed: false
 
 Integrates Musubi into the OpenClaw browser extension. Captures web-browsing context as episodic memories, surfaces retrieval results inline in web pages, and sends/receives thoughts across the user's other presences.
 
-**Independent project.** Repo: `musubi-openclaw-adapter`. Embedded into the OpenClaw extension's background service worker (TypeScript) + a small Python side-car for any heavy lifting (optional).
+**Implementation lives in a sibling repo:** `github.com/ericmey/openclaw-musubi` (TypeScript browser extension). Per [[13-decisions/0022-extension-ecosystem-naming]] (ADR-0022), non-Python integrations live in external `<system>-musubi` repos so that their toolchain (pnpm, tsc, vitest) and host-system release cadence (Chrome Web Store, Firefox Add-ons) don't mix with Musubi's Python monorepo.
+
+This spec describes the **contract** the extension implements against Musubi's canonical API. The contract lives with Musubi (here); the implementation lives in `openclaw-musubi`. TypeScript types are generated from `openapi.yaml` (in this repo) via `openapi-typescript`, giving the extension compile-time safety against the canonical API without hand-maintaining a parallel type file. Optional Python side-car for heavy lifting (e.g., full-page extraction) is out of initial scope; if needed, it would ship as a future `packages/musubi-openclaw-sidecar/` workspace subpackage in this repo.
 
 ## What OpenClaw is
 

--- a/docs/architecture/13-decisions/0022-extension-ecosystem-naming.md
+++ b/docs/architecture/13-decisions/0022-extension-ecosystem-naming.md
@@ -1,0 +1,195 @@
+---
+title: "ADR 0022: Extension ecosystem — non-Python integrations live in sibling `<system>-musubi` repos; Python integrations live in-monorepo as workspace subpackages"
+section: 13-decisions
+type: adr
+status: accepted
+date: 2026-04-19
+deciders: [Eric]
+tags: [section/decisions, status/accepted, type/adr, monorepo, ecosystem, adapters, extensions, packaging]
+updated: 2026-04-19
+up: "[[13-decisions/index]]"
+reviewed: false
+extends: "[[13-decisions/0015-monorepo-supersedes-multi-repo]]"
+---
+
+# ADR 0022: Extension ecosystem — non-Python integrations live in sibling `<system>-musubi` repos; Python integrations live in-monorepo as workspace subpackages
+
+**Status:** accepted
+**Date:** 2026-04-19
+**Deciders:** Eric
+
+## Goal
+
+Musubi should have **as many official interfaces as tools that might use it**, each one Musubi-sanctioned and consuming the canonical API. The more official surfaces exist, the less temptation there is for any external service to bypass the API and reach into Qdrant (or any other storage) directly. Interface proliferation is a feature; the *locations* of those interfaces need a rule that scales.
+
+## Context
+
+[[13-decisions/0015-monorepo-supersedes-multi-repo]] established that Musubi is a single Python monorepo at `github.com/ericmey/musubi` with all components under `src/musubi/`. ADR-0015 did not take a position on components whose **implementation language is not Python** — an OpenClaw browser extension in TypeScript, a future Obsidian plugin in TS/Electron, a future VS Code extension in Node, a hypothetical Rust TUI, etc. The question surfaced 2026-04-19 when `slice-adapter-openclaw` needed its owns_paths reconciled to post-monorepo layout and it became obvious that TypeScript source cannot live inside a Python package at `src/musubi/adapters/openclaw/`.
+
+A related but separable concern surfaced in parallel: **how do Python integrations whose runtime is not the Musubi deploy target get distributed?** Example: the LiveKit adapter is Python but runs inside a LiveKit Agents worker process deployed on a different machine. Copying adapter source into every consumer's repo is a DX disaster; installing the full Musubi server wheel into a LiveKit worker pulls ~150 MB of deps it never touches.
+
+An earlier draft proposed a **runtime criterion** (external-runtime components move external regardless of language) to unify the two concerns. That criterion was rejected after weighing distribution mechanics — **uv workspace subpackages** solve the Python distribution problem cleanly *without* moving source out of the monorepo. The language criterion is sharper and correctly partitions the real pain point: TypeScript-in-a-Python-monorepo is genuinely broken (different toolchain, different package manager, different CI needs); Python-in-a-Python-monorepo-that-happens-to-be-installed-elsewhere is not broken.
+
+## Decision
+
+### Rule: source location is determined by implementation language.
+
+**If the implementation is Python,** source lives in the Musubi monorepo under `src/musubi/adapters/<name>/` (or future workspace subpackage `packages/musubi-<name>/`). When the component is installed into a runtime other than Musubi's deploy target (e.g., a LiveKit Agents worker), it's published as its own wheel — see §Distribution below.
+
+**If the implementation is not Python,** source lives in a separate sibling repository named:
+
+```
+github.com/ericmey/<system>-musubi
+```
+
+where `<system>` names the host system the component targets.
+
+### Worked examples
+
+| Component | Language | Source location | Install into consumer |
+|---|---|---|---|
+| Musubi server | Python | `src/musubi/` → future `packages/musubi-server/` | Operator deploys on `musubi.mey.house` |
+| Musubi Python SDK | Python | `src/musubi/sdk/` → future `packages/musubi-client/` | `pip install musubi-client` |
+| MCP server (remote HTTP + SSE) | Python | `src/musubi/adapters/mcp/` → future `packages/musubi-mcp/` | Deploys with Musubi; Kong-fronts it |
+| MCP local stdio plugin *(if ever built)* | Python | `packages/musubi-mcp-stdio/` *(future subpackage)* | `pip install musubi-mcp-stdio` on agent host |
+| LiveKit adapter | Python | `src/musubi/adapters/livekit/` → future `packages/musubi-livekit/` | `pip install musubi-livekit` into LiveKit worker |
+| OpenClaw browser extension | TypeScript | **`github.com/ericmey/openclaw-musubi`** | Chrome Web Store / Firefox Add-ons / sideload |
+| Obsidian plugin *(future, if built)* | TypeScript | **`github.com/ericmey/obsidian-musubi`** | Obsidian Community Plugins |
+| VS Code extension *(future, if built)* | TypeScript | **`github.com/ericmey/vscode-musubi`** | VS Code Marketplace |
+
+### Naming rationale for external repos
+
+The `<system>-musubi` order reads as "the Musubi integration for `<system>`," framing the component as a citizen of the host system's ecosystem first, a Musubi consumer second. That reflects the reality — the component belongs to the host system's packaging, release, and review process (browser-extension store review, Obsidian Community Plugins process, VS Code Marketplace) — and makes the separate-cadence expectation legible from the name alone. It inverts ADR-0011's `musubi-<system>-adapter` naming, which framed these as Musubi pieces that knew about hosts; that framing stopped making sense once the component ships on a host-system schedule independent of Musubi's.
+
+## Distribution: uv workspace subpackages for Python
+
+Today Musubi is a **single-wheel** repo: one `pyproject.toml` at the root publishes one wheel (`musubi`). Installing `musubi` into a LiveKit worker pulls the full server — ~150 MB of deps the worker never touches.
+
+To let external Python consumers install only what they need, Musubi will restructure into a **uv workspace** publishing multiple wheels from the same repo:
+
+```
+musubi/                                     ← repo root
+├── pyproject.toml                          ← workspace root (publishes nothing)
+├── packages/
+│   ├── musubi-server/                      ← the server Musubi deploys
+│   │   ├── pyproject.toml                  ← publishes "musubi" wheel
+│   │   └── src/musubi/                     ← api, planes, retrieve, lifecycle, ingestion
+│   ├── musubi-client/                      ← the SDK
+│   │   ├── pyproject.toml                  ← publishes "musubi-client" wheel
+│   │   └── src/musubi/sdk/
+│   ├── musubi-livekit/                     ← LiveKit adapter
+│   │   ├── pyproject.toml                  ← publishes "musubi-livekit" wheel
+│   │   └── src/musubi/adapters/livekit/
+│   └── musubi-mcp/                         ← MCP server(s)
+│       ├── pyproject.toml                  ← publishes "musubi-mcp" wheel
+│       └── src/musubi/adapters/mcp/
+```
+
+Each `pyproject.toml` declares its own version, deps, and target. Python's **PEP 420 implicit namespace packages** let multiple wheels contribute to the same `musubi.*` namespace — imports like `from musubi.adapters.livekit import SlowThinker` work unchanged regardless of whether the consumer has one wheel installed or many.
+
+### Consumer install path (LiveKit worker example)
+
+```toml
+# In the LiveKit worker's pyproject.toml:
+[project]
+dependencies = [
+  "livekit-agents>=1.0",
+  "musubi-livekit>=0.1.0",
+]
+```
+
+```bash
+uv add musubi-livekit   # from PyPI once published
+# or, pre-PyPI:
+uv add "git+https://github.com/ericmey/musubi.git@musubi-livekit-v0.1.0#subdirectory=packages/musubi-livekit"
+```
+
+Either path installs **only** `musubi-livekit` + its transitive deps (`musubi-client`, `httpx`, `pydantic`, plus `livekit-agents` that the worker requested). The full Musubi server wheel never lands on the worker machine. Total install ~15 MB.
+
+### Versioning
+
+Each subpackage releases on its own cadence:
+
+- `musubi` (server) versions independently.
+- `musubi-client` (SDK) versions when the canonical API changes.
+- `musubi-livekit`, `musubi-mcp` pin `musubi-client>=X.Y,<X.(Y+1)`; release when their own code changes or when the SDK requires it.
+
+Git tags scope per-subpackage: `musubi-v1.2.0`, `musubi-livekit-v0.1.0`, `musubi-mcp-v0.3.2`. CI builds and publishes the specific wheel whose tag was pushed.
+
+### Timing
+
+**The restructure is not part of this ADR.** It's queued as [[_slices/slice-ops-workspace-packaging]] for when demand materialises — LiveKit worker wants a thin `pip install musubi-livekit`, or the SDK wants independent PyPI publishing, or similar. Until then, consumers can use the git-URL-with-subdirectory install pattern against the current `src/musubi/adapters/<name>/` tree. The ADR establishes the destination; the slice executes the move.
+
+## Consequences
+
+### Positive
+
+- **Language-appropriate tooling per repo.** Musubi's `make check` stays Python-only. TS repos keep their own pnpm/tsc/vitest stack.
+- **Host-system-appropriate release cadence.** TS repos ship on browser-store / marketplace schedules. Python subpackages ship on per-package semver.
+- **Clean DX for external Python consumers.** LiveKit-worker dev runs `uv add musubi-livekit`, imports `from musubi.adapters.livekit`. No Musubi source in their repo. Identical to consuming any pip-installable library.
+- **Clean DX for external TS consumers.** OpenClaw dev clones `openclaw-musubi`, uses pnpm, publishes to the browser store. No Python toolchain touches them.
+- **Atomic cross-cutting changes for Python.** Changing a plane type + SDK + LiveKit adapter lands in one Musubi PR. The monorepo wins where it wins; external repos handle what must be external.
+- **Interface proliferation stays sanctioned.** Every external consumer, regardless of repo location, goes through the canonical API. No direct Qdrant access. ADR-0011's interface-discipline decision is preserved.
+- **Ecosystem is visible at the namespace level.** `github.com/ericmey/*-musubi` enumerates the non-Python surfaces at a glance.
+
+### Negative
+
+- **Cross-repo changes for non-Python integrations are multi-PR.** Breaking an API field forces an OpenClaw repo update. Accepted because (a) host-release cadence is independent anyway, (b) most API changes are additive.
+- **Workspace restructure is a real migration.** Moving `src/musubi/` into `packages/musubi-server/src/musubi/` + carving subpackages is real operator work. Deferred to `slice-ops-workspace-packaging`. Current monolithic layout works fine until first consumer demands thin install.
+- **Naming-convention discipline depends on the operator.** No automation stops someone from creating `musubi-openclaw` instead of `openclaw-musubi`. Mitigation: this ADR is the canonical record.
+- **Adapter specs stay in Musubi even for non-Python components.** `docs/architecture/07-interfaces/openclaw-adapter.md` is Musubi's spec of the contract; implementation in the external repo consumes that spec. Readers need to know to look at two places. Mitigation: each spec names the implementing repo in its opening paragraph.
+
+### Neutral
+
+- **ADR-0011 naming (`musubi-<system>-adapter`) is superseded on repo-name axis only** — the interface-discipline decisions stand.
+- **Transport choice (HTTP/SSE, gRPC, h2c, unix sockets) for in-VLAN consumers** is orthogonal — tracked as a future backlog ADR when the first concrete in-VLAN Python consumer materialises.
+- **`slice-adapter-livekit` (done 2026-04-19, PR #96) and `slice-adapter-mcp` (done 2026-04-19, PR #95)** stay in-monorepo at their current paths. Distribution to external runtimes is handled by the future workspace restructure, not by moving source.
+
+## Alternatives considered
+
+### A) Broad framing — runtime criterion (rejected earlier today)
+
+External repos for every component whose runtime is not Musubi's deploy target, Python or otherwise. Under this rule, LiveKit adapter moves to `livekit-musubi`, stdio MCP moves to `mcp-musubi`, only the HTTP MCP server stays in-monorepo.
+
+**Rejected.** Forces an avoidable repo split for Python components whose distribution problem is cleanly solved by uv workspace subpackages. The extra bootstrap cost (multiple external repos each with its own slice machinery + CI + release pipeline) outweighs the coordination cost of keeping Python unified. Also: PR #96 (slice-adapter-livekit) landed in-monorepo 2026-04-19; retiring it immediately after merging would discard working code, and the argument for retirement (distribution to external runtimes) turned out to be solvable in-place.
+
+### B) Polyglot monorepo
+
+Top-level `extensions/` directory in Musubi for TS extensions; pnpm workspace for TS co-existing with uv workspace for Python.
+
+**Rejected.** Pays polyglot-tooling cost on every PR (bigger CI matrix, two package managers, unrelated dep surfaces) for a benefit that's mostly illusory — TS components ship on host-system-store schedules that make atomic cross-language merges meaningless. Blurs the "Musubi is a Python service" mental model for operators and agents.
+
+### C) Python SDK on npm (first-party TS SDK)
+
+Publish `@musubi/client` alongside `musubi-client` so TS consumers get an official client instead of generating types from `openapi.yaml`.
+
+**Deferred.** Worth doing if/when 2+ active TS consumers exist. Premature for one (`openclaw-musubi`). Until then, `openapi-typescript` against `openapi.yaml` gives strongly-typed HTTP calls without maintaining a second SDK surface.
+
+### D) Each external repo as a git submodule inside Musubi
+
+Check out `openclaw-musubi` as a submodule under `external/openclaw/` so `git clone --recurse-submodules` gets the whole ecosystem.
+
+**Rejected.** Submodules are a well-known DX footgun; recursive-clone behaviour is easy to get wrong; submodule commits are harder to review than merge commits.
+
+## Mechanics triggered by this ADR (this PR)
+
+1. **`slice-adapter-openclaw` (Issue #5) is retired.** TypeScript browser extension moves to `github.com/ericmey/openclaw-musubi` (future operator action outside this monorepo). Slice file flips to `status: retired` with a superseded-by pointer. Issue #5 closed with a comment linking this ADR.
+2. **No change to `slice-adapter-livekit` (done) or `slice-adapter-mcp` (done).** Both stay in-monorepo at their current paths.
+3. **`07-interfaces/openclaw-adapter.md` updated** — repo name `musubi-openclaw-adapter` → `openclaw-musubi`; opening paragraph names the implementing repo. Commit carries `spec-update:` trailer.
+4. **`_tools/check.py`** gains `"retired"` as a valid slice status so retired slices don't trip vault hygiene.
+5. **`slice-ops-workspace-packaging` stubbed** — new slice file in `ready` status tracking the future uv-workspace restructure. Not claimable until a concrete consumer needs thin installs.
+6. **Backlog Issue filed** — future ADR for gRPC / h2c / Unix-socket transport. Carries `area:api`, `priority:low`, `type:followup` labels.
+
+## References
+
+- [[13-decisions/0011-canonical-api-and-adapters]] — original 8-repo interface-discipline ADR; superseded on repo-layout by 0015 and this ADR.
+- [[13-decisions/0015-monorepo-supersedes-multi-repo]] — the Python-monorepo decision this ADR extends (language criterion is the extension).
+- [[13-decisions/0016-vault-in-monorepo]] — precedent for "extend 0015, don't supersede".
+- [[13-decisions/0021-mcp-server-library]] — Nyla's sibling ADR adopting Anthropic's `mcp` package (unrelated to this ADR; shares nothing but the session date).
+- [[07-interfaces/mcp-adapter]] — MCP spec; implementation in-monorepo.
+- [[07-interfaces/livekit-adapter]] — LiveKit spec; implementation in-monorepo.
+- [[07-interfaces/openclaw-adapter]] — OpenClaw spec (contract only; implementation in `openclaw-musubi`).
+- [[_slices/slice-adapter-openclaw]] — retired by this ADR.
+- [[_slices/slice-adapter-mcp]] — done; stays in-monorepo.
+- [[_slices/slice-adapter-livekit]] — done; stays in-monorepo.
+- [[_slices/slice-ops-workspace-packaging]] — stubbed by this ADR.

--- a/docs/architecture/_slices/slice-adapter-openclaw.md
+++ b/docs/architecture/_slices/slice-adapter-openclaw.md
@@ -1,73 +1,66 @@
 ---
-title: "Slice: OpenClaw adapter"
+title: "Slice: OpenClaw adapter (RETIRED)"
 slice_id: slice-adapter-openclaw
 section: _slices
 type: slice
-status: ready
+status: retired
 owner: unassigned
 phase: "6 Lifecycle"
-tags: [section/slices, status/ready, type/slice]
-updated: 2026-04-17
+tags: [section/slices, status/retired, type/slice]
+updated: 2026-04-19
 reviewed: false
-depends-on: ["[[_slices/slice-sdk-py]]", "[[_slices/slice-retrieval-deep]]"]
+depends-on: []
 blocks: []
+superseded-by: "github.com/ericmey/openclaw-musubi"
+retired-by: "[[13-decisions/0022-extension-ecosystem-naming]]"
 ---
 
-# Slice: OpenClaw adapter
+# Slice: OpenClaw adapter (RETIRED)
 
-> OpenClaw desktop extension. Blended retrieval. TypeScript.
+> **This slice is retired.** The OpenClaw adapter is a TypeScript browser extension. Per [[13-decisions/0022-extension-ecosystem-naming]] (ADR-0022), non-Python integrations live in sibling `<system>-musubi` repos.
 
-**Phase:** 6 Lifecycle · **Status:** `ready` · **Owner:** `unassigned`
+**Phase:** 6 Lifecycle · **Status:** `retired` · **Owner:** `unassigned`
 
-## Specs to implement
+## Where the implementation lives now
 
-- [[07-interfaces/openclaw-adapter]]
+**`github.com/ericmey/openclaw-musubi`** — future repo, created when the extension work begins. That repo will own:
 
-## Owned paths (you MAY write here)
+- All TypeScript source for the OpenClaw browser extension.
+- `manifest.json` + host-system packaging (Chrome Web Store, Mozilla Add-ons, etc.).
+- Extension-local tests + docs.
 
-- `musubi-openclaw/`
+It will consume Musubi's canonical API via HTTPS, using types generated from `openapi.yaml` (in this repo) via `openapi-typescript`. No direct Qdrant access. Interface discipline from [[13-decisions/0011-canonical-api-and-adapters]] preserved.
 
-## Forbidden paths (you MUST NOT write here — open a cross-slice ticket if needed)
+## What stays in this repo
 
-- `musubi/`
-- `musubi-sdk-py/`
+The **spec** at [[07-interfaces/openclaw-adapter]] stays in Musubi's vault. Specs describe contracts; contracts are Musubi's responsibility regardless of where implementations run. When `openclaw-musubi` is built, its work draws from that spec.
 
-## Depends on
+## Retirement rationale
 
-- [[_slices/slice-sdk-py]]
-- [[_slices/slice-retrieval-deep]]
+See [[13-decisions/0022-extension-ecosystem-naming]] §Decision for the full reasoning. Short version:
 
-Start this slice only after every upstream slice has `status: done`.
-
-## Unblocks
-
-- _(no downstream slices)_
-
-## Definition of Done
-
-![[00-index/definition-of-done]]
-
-Plus slice-specific:
-
-- [ ] Every Test Contract item in the linked spec(s) is a passing test.
-- [ ] Branch coverage ≥ 85% on owned paths (90% for `musubi/planes/**` and `musubi/retrieve/**`).
-- [ ] Slice frontmatter flipped from `ready` → `in-progress` → `in-review` → `done`.
-- [ ] Spec `status:` updated if prose changed (`spec-update: <path>` commit trailer).
-- [ ] Lock file removed from `_inbox/locks/`.
+- OpenClaw is TypeScript. Per ADR-0022, non-Python integrations live in external `<system>-musubi` repos because (a) their toolchain is not Python's, (b) their release cadence is host-system-controlled (browser-extension store review), and (c) polyglot monorepo tooling pays cost on every Python PR for no offsetting benefit.
+- Adjacent Python adapters (`slice-adapter-livekit`, `slice-adapter-mcp`) stay in-monorepo at `src/musubi/adapters/<name>/` because their distribution problem (installing into an external runtime) is solvable via uv workspace subpackages without moving source out.
 
 ## Work log
-
-Agents append one entry per work session. Format:
-`### YYYY-MM-DD HH:MM — <agent-id> — <what changed>`
 
 ### 2026-04-17 — generator — slice created
 
 - Seeded from the roadmap + guardrails matrix.
 
+### 2026-04-19 — operator — slice retired per ADR-0022
+
+- [[13-decisions/0022-extension-ecosystem-naming]] accepted 2026-04-19.
+- OpenClaw adapter is the flagship non-Python component that drove the ADR.
+- Issue #5 closed with link to ADR.
+- Slice flipped to `status: retired`; `depends-on` + `blocks` cleared; `superseded-by` set to the external repo URL.
+- No in-monorepo code was written for this slice prior to retirement.
+- The spec at [[07-interfaces/openclaw-adapter]] was updated in the same PR with a `spec-update:` trailer: repo name `musubi-openclaw-adapter` → `openclaw-musubi`, implementation-location paragraph added, TS-consumer installation notes added.
+
 ## Cross-slice tickets opened by this slice
 
-- _(none yet)_
+- _(none)_
 
 ## PR links
 
-- _(none yet)_
+- `docs(adr): 0022 extension ecosystem` — retirement PR (see ADR-0022's §Mechanics).

--- a/docs/architecture/_slices/slice-ops-workspace-packaging.md
+++ b/docs/architecture/_slices/slice-ops-workspace-packaging.md
@@ -1,0 +1,122 @@
+---
+title: "Slice: Workspace packaging — restructure into per-component wheels"
+slice_id: slice-ops-workspace-packaging
+section: _slices
+type: slice
+status: ready
+owner: unassigned
+phase: "8 Ops"
+tags: [section/slices, status/ready, type/slice, packaging, distribution]
+updated: 2026-04-19
+reviewed: false
+depends-on: []
+blocks: []
+stubbed-by: "[[13-decisions/0022-extension-ecosystem-naming]]"
+---
+
+# Slice: Workspace packaging — restructure into per-component wheels
+
+> Restructure Musubi into a uv workspace publishing multiple wheels from the same repo. Enables external consumers (LiveKit workers, future MCP stdio, downstream Python agents) to `pip install musubi-<component>` and pull only what they need.
+
+**Phase:** 8 Ops · **Status:** `ready` · **Owner:** `unassigned`
+
+> **Note: this slice is queued, not urgent.** Claim it when a real consumer needs thin installs. Current triggers: (1) a LiveKit worker dev wants `uv add musubi-livekit` without pulling the full server stack, (2) the SDK needs independent PyPI publishing for external agents, (3) `mcp-musubi` stdio plugin work starts and needs a shared package namespace. Until one of these materialises, the current single-wheel layout works fine.
+
+## Specs to implement
+
+- [[13-decisions/0015-monorepo-supersedes-multi-repo]] §Decision (the monorepo policy this slice operationalises)
+- [[13-decisions/0022-extension-ecosystem-naming]] §Distribution (the subpackage + wheel pattern)
+
+## Owned paths (you MAY write here)
+
+- `pyproject.toml` (repo root; demoted to workspace-root, publishes nothing)
+- `packages/` (new top-level directory containing subpackage projects)
+- `Makefile` (update targets to run across workspace)
+- `.github/workflows/` (add per-package build+publish workflows)
+- `uv.lock` (regenerates under workspace layout)
+
+## Forbidden paths (you MUST NOT write here — open a cross-slice ticket if needed)
+
+- **All source code under `src/musubi/`** — this slice MOVES files, it doesn't modify them. `git mv`-only. Any content edit to a .py file is out of scope; open a follow-up slice.
+- Test files under `tests/` — pytest wiring gets updated (pointer paths), actual test code doesn't.
+- `docs/architecture/` — specs don't change; only the packaging layout.
+- `openapi.yaml`, `proto/` — unaffected.
+
+## Depends on
+
+- _(none — packaging restructure is a self-contained operator task)_
+
+## Unblocks
+
+- `slice-mcp-stdio` (future, if built): cleanly ships as `musubi-mcp-stdio` wheel without server deps.
+- External PyPI publishing of `musubi-client`.
+- `pip install musubi-livekit` for LiveKit workers without pulling server stack.
+
+## Proposed target layout
+
+```
+musubi/                                     ← repo root
+├── pyproject.toml                          ← workspace root (publishes nothing)
+├── packages/
+│   ├── musubi-server/
+│   │   ├── pyproject.toml                  ← publishes "musubi" wheel
+│   │   └── src/musubi/
+│   │       ├── api/, planes/, retrieve/, lifecycle/, ingestion/, types/, ...
+│   ├── musubi-client/
+│   │   ├── pyproject.toml                  ← publishes "musubi-client" wheel
+│   │   └── src/musubi/sdk/
+│   ├── musubi-livekit/
+│   │   ├── pyproject.toml                  ← publishes "musubi-livekit" wheel
+│   │   └── src/musubi/adapters/livekit/
+│   └── musubi-mcp/
+│       ├── pyproject.toml                  ← publishes "musubi-mcp" wheel
+│       └── src/musubi/adapters/mcp/
+├── tests/                                  ← stays at repo root; each package's pyproject
+│   ├── api/, planes/, retrieve/, ...       ←   declares which test paths it covers via
+│   ├── sdk/                                ←   pytest config, keeping tests unified
+│   ├── adapters/
+│   └── ...
+├── deploy/, docs/, openapi.yaml, proto/    ← unchanged
+└── Makefile                                ← updated targets: `uv sync --all-packages`, etc.
+```
+
+Python's PEP 420 implicit namespace packages let multiple wheels contribute to `musubi.*` — imports like `from musubi.adapters.livekit import SlowThinker` work unchanged regardless of whether one wheel or many are installed.
+
+## Definition of Done
+
+![[00-index/definition-of-done]]
+
+Plus slice-specific:
+
+- [ ] `packages/musubi-server/`, `packages/musubi-client/`, `packages/musubi-livekit/`, `packages/musubi-mcp/` all exist with working `pyproject.toml` per package.
+- [ ] `uv sync --all-packages` at repo root resolves the full workspace and installs all packages editably.
+- [ ] `make check` runs ruff + mypy + pytest + coverage across all packages (single invocation, same targets as today).
+- [ ] `uv build --package musubi-livekit` produces a wheel with **only** LiveKit adapter code — verify by `python -m zipfile -l dist/musubi_livekit-*.whl` shows no `api/`, `planes/`, `retrieve/` entries.
+- [ ] Consumer install path works: in a fresh virtualenv on a separate machine, `pip install "git+https://github.com/ericmey/musubi.git@v2#subdirectory=packages/musubi-livekit"` installs `musubi-livekit` + transitive `musubi-client` + `httpx` + `pydantic` only. Verified with `pip list` — no `qdrant-client`, `fastapi`, etc.
+- [ ] GitHub Actions workflow builds + publishes the correct wheel on a per-package git tag (e.g., `musubi-livekit-v0.1.0` triggers only `musubi-livekit` publish).
+- [ ] No source code changes — `git log --stat` on the feat commit shows only renames (`R100`) and `pyproject.toml` adds. Any `.py` file with `+` / `-` outside `pyproject.toml` is out of scope; land in a follow-up.
+- [ ] Branch coverage unchanged on all owned code (moving files shouldn't reduce coverage).
+- [ ] `make check` green on local + CI; all existing tests pass.
+- [ ] Documentation: `docs/architecture/08-deployment/packaging.md` added explaining the workspace layout, per-package publish workflow, and consumer install patterns.
+- [ ] Slice frontmatter flipped from `ready` → `in-progress` → `in-review` → `done`.
+- [ ] Lock file removed from `_inbox/locks/`.
+
+## Work log
+
+Agents append one entry per work session. Format:
+`### YYYY-MM-DD HH:MM — <agent-id> — <what changed>`
+
+### 2026-04-19 — operator — slice stubbed per ADR-0022
+
+- [[13-decisions/0022-extension-ecosystem-naming]] §Distribution commits Musubi to a uv-workspace layout for per-component wheel publishing.
+- This slice operationalises that decision when a real consumer needs thin installs.
+- Stubbed in `ready` state; not priority-queued until a concrete trigger materialises (see note at top).
+- Agent picking this up: budget ~half a day for the mechanical move + ~half a day for CI publish plumbing + testing. Consult the consumer (LiveKit worker dev, etc.) to confirm their expected install command before starting, so the subpackage boundary matches demand.
+
+## Cross-slice tickets opened by this slice
+
+- _(none yet)_
+
+## PR links
+
+- _(none yet)_

--- a/docs/architecture/_tools/check.py
+++ b/docs/architecture/_tools/check.py
@@ -240,7 +240,7 @@ def check_slices(rep: Report) -> None:
     # 3. status transitions
     for _sid, s in slices.items():
         status = s["fm"].get("status")
-        if status not in {"ready", "in-progress", "in-review", "blocked", "done"}:
+        if status not in {"ready", "in-progress", "in-review", "blocked", "done", "retired"}:
             rep.err(str(s["path"].relative_to(VAULT)), f"invalid slice status '{status}'")
 
     # 4. locks correspond to in-progress slices (and vice versa)


### PR DESCRIPTION
Extends ADR-0015 with a rule for components whose implementation language is not Python. Narrow framing — language is the hard constraint; Python subpackages can coexist in-monorepo via uv workspaces.

## Decision summary

**Non-Python integrations** (OpenClaw browser extension, future Obsidian plugin, future VS Code extension) → live in sibling \`<system>-musubi\` repos. Their toolchain and release cadence is host-system-controlled.

**Python integrations** (LiveKit adapter, MCP server, future MCP stdio) → live in this monorepo at \`src/musubi/adapters/<name>/\`. Distribution to external runtimes (LiveKit worker, agent host, etc.) via future uv-workspace subpackages publishing per-component wheels.

## Mechanics landed in this PR

1. **Retire \`slice-adapter-openclaw\`** → implementation moves to \`github.com/ericmey/openclaw-musubi\` (future operator action). Contract spec stays here.
2. **Spec update** on \`07-interfaces/openclaw-adapter.md\` with \`spec-update:\` trailer — rename, implementation-location paragraph, openapi-typescript generation note.
3. **Stub \`slice-ops-workspace-packaging\`** — queued for when a concrete Python consumer needs thin installs (LiveKit worker wanting \`pip install musubi-livekit\` without server stack, etc.). Not claimable until demand materialises.
4. **Add \`retired\` as valid slice status** in \`_tools/check.py\`.

## No code changes

\`src/musubi/\` untouched. PR #96 (slice-adapter-livekit) and PR #95 (slice-adapter-mcp) both stay in-monorepo at their current paths.

## Numbering note

Originally drafted as 0021; Nyla's \`slice-adapter-mcp\` PR #95 landed 0021-mcp-server-library first. Renumbered to 0022. Zero content conflict.

## Rejected alternative

The earlier draft proposed a runtime criterion (external-runtime → external repo regardless of language). Rejected after weighing distribution mechanics — Python workspace subpackages cleanly solve thin-install without moving source. Language criterion is sharper and survives future non-Python additions (Rust, Go, etc.).

## Related

- [[13-decisions/0015-monorepo-supersedes-multi-repo]] — the Python-monorepo decision this extends.
- [[13-decisions/0021-mcp-server-library]] — Nyla's sibling ADR; different concern; shares only the session date.