### PR TITLE
fix(_operator): handoff-audit accepts chore(slice): handoff prefix

### DIFF
--- a/.operator/scripts/handoff-audit.py
+++ b/.operator/scripts/handoff-audit.py
@@ -299,6 +299,17 @@ def check_feat_commit_present(pr: PRInfo, s: Slice, commits: list[dict]) -> Chec
 
 _CANONICAL_KINDS = ["chore(slice)", "chore(lock)", "test", "feat", "docs(slice)"]
 
+# The handoff commit (frontmatter flip to in-review + work-log entry) can be
+# either `docs(slice): handoff ...` or `chore(slice): handoff ...` — both are
+# in active use this session (Nyla uses chore(slice), VS Code uses docs(slice)).
+# The check recognises either form by subject-substring match so the canonical-
+# shape check doesn't false-fail on a valid handoff prefix.
+_HANDOFF_PREFIXES = ("docs(slice): handoff", "chore(slice): handoff")
+
+
+def _has_handoff_commit(subjects: list[str]) -> bool:
+    return any(s.startswith(_HANDOFF_PREFIXES) for s in subjects)
+
 
 def check_canonical_shape(pr: PRInfo, commits: list[dict]) -> CheckResult:
     """Approximate canonical 7-commit shape present. Warn on deviation."""
@@ -316,19 +327,28 @@ def check_canonical_shape(pr: PRInfo, commits: list[dict]) -> CheckResult:
             False,
             "missing feat commit — hard fail (tested separately in feat_commit_present)",
         )
-    if "docs(slice)" in missing:
+    # Handoff commit check: accept either `docs(slice): handoff ...` or
+    # `chore(slice): handoff ...`. The existence of the handoff commit is what
+    # matters; its conventional-commit type prefix is operator style.
+    handoff_present = _has_handoff_commit(subjects)
+    if not handoff_present:
         return CheckResult(
             "canonical_shape",
             False,
-            "missing docs(slice) handoff commit — required for frontmatter flip + "
-            "coverage-matrix work-log entry. Agent likely skipped the dedicated "
-            "handoff commit and rolled the flip into feat or something else.",
+            "missing handoff commit — required for frontmatter flip + "
+            "coverage-matrix work-log entry. Expected a commit whose subject "
+            "starts with `docs(slice): handoff` or `chore(slice): handoff`. "
+            "Agent likely rolled the flip into feat or something else.",
         )
-    if missing:
+    # `docs(slice)` / `chore(slice)` missing from the canonical-kinds report is
+    # fine once we've confirmed the handoff commit exists above — it just means
+    # the agent used the alternate prefix. Don't warn on either in that case.
+    soft_missing = [k for k in missing if k not in ("docs(slice)", "chore(slice)")]
+    if soft_missing:
         return CheckResult(
             "canonical_shape",
             True,  # warn, don't fail
-            f"canonical-7-commit-shape deviation (soft): missing {missing}. "
+            f"canonical-7-commit-shape deviation (soft): missing {soft_missing}. "
             f"Commits present: {', '.join(sorted(kinds_found.keys()))}",
         )
     return CheckResult("canonical_shape", True)

--- a/docs/architecture/00-index/agent-handoff.md
+++ b/docs/architecture/00-index/agent-handoff.md
@@ -64,6 +64,23 @@ How coding agents coordinate without stepping on each other. This is a *protocol
 - Check [[00-index/definition-of-done]] line-by-line before requesting review.
 - Any CI failure reverts you to step 5.
 
+#### Canonical commit shape at handoff
+
+`.operator/scripts/handoff-audit.py` looks for a specific commit graph in your PR. In order:
+
+1. `chore(slice): take <slice-id>` — claim commit (label flip, Issue assignee).
+2. `chore(slice): flip <slice-id> to in-progress` — frontmatter status update.
+3. `chore(lock): add lock for <slice-id>` — presence lock file.
+4. `test(<scope>): initial test contract for <slice-id>` — the test file from step 4 above.
+5. `feat(<scope>): <what you built>` — the implementation. Touches `owns_paths`.
+6. **Handoff commit** — frontmatter flip to `in-review` + work-log entry + any reviewer-note block. Subject **must** start with one of:
+   - `docs(slice): handoff <slice-id> to in-review`
+   - `chore(slice): handoff <slice-id> to in-review`
+   Both prefixes are accepted by the audit (`docs(slice)` and `chore(slice)` are equally valid handoff-commit types). Pick one consistent with your agent's conventional-commit style and stick with it across the slice.
+7. `chore(lock): release <slice-id>` — remove the lock file.
+
+Deviations from this graph are soft-warned; missing feat or missing handoff commit are hard failures. Squash-merge collapses all seven into a single `feat(<scope>): <slice title>` on v2, but the pre-merge audit checks the unsquashed graph on your branch.
+
 #### Reviewer notes — where they land
 
 PR review comments are transient: once the PR merges, they fade into the PR timeline and are no longer discoverable to the next agent picking up the slice. To keep reviewer findings durable, reviewers use the following homes:


### PR DESCRIPTION
## Summary

- \`canonical_shape\` check hardcoded \`docs(slice):\` as the only valid handoff-commit prefix; \`chore(slice): handoff\` is equally valid and was costing VS Code an extra CI round on PR #96.
- Refactored check to accept either \`docs(slice): handoff\` or \`chore(slice): handoff\` via subject-startswith match.
- Codified the accepted prefixes in \`agent-handoff.md §6\` so the next agent sees the rule in the canonical doc, not by failing the audit.

## Test plan

- [x] Manual run against PR #96 (chore → docs history): canonical_shape passes.
- [x] Manual run against PR #95 (chore throughout): canonical_shape passes.
- [ ] Next slice PR handoff: confirm either prefix works cleanly.