### PR TITLE
feat(observability): slice-ops-observability

### DIFF
--- a/deploy/grafana/alerts/musubi-alerts.yml
+++ b/deploy/grafana/alerts/musubi-alerts.yml
@@ -1,0 +1,141 @@
+# Prometheus alert rules for Musubi.
+# Per docs/architecture/09-operations/alerts.md.
+#
+# Two severities:
+#   - "push" (urgent, ntfy/Pushover) — broken NOW.
+#   - "email" (informational, next-morning).
+#
+# Every push alert MUST have a runbook annotation. Tested by
+# tests/observability/test_alerts.py.
+
+groups:
+  - name: musubi-push
+    rules:
+      - alert: core_5xx_high
+        expr: rate(musubi_5xx_total[5m]) / rate(musubi_http_requests_total[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: push
+        annotations:
+          summary: "Musubi Core 5xx rate above 1% for 5m"
+          runbook: "https://docs.musubi.internal/09-operations/runbooks/#core_5xx_high"
+
+      - alert: qdrant_down
+        expr: up{job="qdrant"} == 0
+        for: 2m
+        labels:
+          severity: push
+        annotations:
+          summary: "Qdrant unreachable for 2m"
+          runbook: "https://docs.musubi.internal/09-operations/runbooks/#qdrant-down"
+
+      - alert: vault_fs_full
+        expr: node_filesystem_avail_bytes{mountpoint="/var/lib/musubi"} / node_filesystem_size_bytes{mountpoint="/var/lib/musubi"} < 0.10
+        for: 5m
+        labels:
+          severity: push
+        annotations:
+          summary: "Vault filesystem under 10% free"
+          runbook: "https://docs.musubi.internal/09-operations/runbooks/#vault_fs_full"
+
+      - alert: backup_failure_24h
+        expr: time() - musubi_backup_last_success_timestamp > 86400
+        for: 24h
+        labels:
+          severity: push
+        annotations:
+          summary: "No successful Qdrant snapshot in 24h"
+          runbook: "https://docs.musubi.internal/09-operations/runbooks/#backup_failure_24h"
+
+      - alert: gpu_oom
+        expr: increase(container_oom_events_total[10m]) > 0
+        for: 1m
+        labels:
+          severity: push
+        annotations:
+          summary: "Container OOMKilled — likely GPU memory exhaustion"
+          runbook: "https://docs.musubi.internal/09-operations/runbooks/#gpu_oom"
+
+      - alert: loop_detected
+        expr: rate(musubi_vault_echo_filtered_total[1m]) * 60 > 100
+        for: 2m
+        labels:
+          severity: push
+        annotations:
+          summary: "Vault echo filter catching > 100/min — likely sync loop"
+          runbook: "https://docs.musubi.internal/09-operations/runbooks/#loop_detected"
+
+      - alert: token_signing_key_missing
+        expr: musubi_jwt_signing_key_present == 0
+        for: 1m
+        labels:
+          severity: push
+        annotations:
+          summary: "JWT signing key file missing — all auth fails"
+          runbook: "https://docs.musubi.internal/09-operations/runbooks/#token_signing_key_missing"
+
+  - name: musubi-email
+    rules:
+      - alert: lifecycle_job_failing
+        expr: increase(musubi_lifecycle_job_errors_total[1h]) >= 3
+        for: 5m
+        labels:
+          severity: email
+        annotations:
+          summary: "Lifecycle job has errored 3+ times in the last hour"
+
+      - alert: synthesis_skipped_many_clusters
+        expr: rate(musubi_lifecycle_synthesis_skipped_total[1h]) / rate(musubi_lifecycle_synthesis_attempted_total[1h]) > 0.20
+        for: 1h
+        labels:
+          severity: email
+        annotations:
+          summary: "More than 20% of synthesis clusters skipped due to LLM errors"
+
+      - alert: promotion_stale
+        expr: time() - musubi_lifecycle_last_promotion_timestamp > 172800
+        for: 1h
+        labels:
+          severity: email
+        annotations:
+          summary: "No concept promotions in 48h"
+
+      - alert: contradiction_unresolved_7d
+        expr: max(musubi_contradiction_age_seconds) > 604800
+        for: 1h
+        labels:
+          severity: email
+        annotations:
+          summary: "A contradiction has been unresolved for 7+ days"
+
+      - alert: high_provisional_backlog
+        expr: musubi_episodic_provisional_count{age_bucket="7d"} > 500
+        for: 6h
+        labels:
+          severity: email
+        annotations:
+          summary: "Provisional memory backlog over 500 entries older than 7 days"
+
+      - alert: eval_regression
+        expr: musubi_eval_ndcg10_delta < -0.05
+        for: 1h
+        labels:
+          severity: email
+        annotations:
+          summary: "Nightly eval dropped NDCG@10 by more than 5%"
+
+      - alert: disk_growth_anomaly
+        expr: deriv(node_filesystem_size_bytes{mountpoint="/var/lib/musubi"}[7d]) > 2 * deriv(node_filesystem_size_bytes{mountpoint="/var/lib/musubi"}[28d])
+        for: 6h
+        labels:
+          severity: email
+        annotations:
+          summary: "Vault disk growth this week exceeds 2x recent baseline"
+
+      - alert: snapshot_retention_purge_failed
+        expr: musubi_backup_retention_purge_failures_total > 0
+        for: 1h
+        labels:
+          severity: email
+        annotations:
+          summary: "Backup retention cron failed to delete old snapshots"

--- a/deploy/grafana/dashboards/musubi-latency.json
+++ b/deploy/grafana/dashboards/musubi-latency.json
@@ -1,0 +1,57 @@
+{
+  "title": "Musubi · Latency",
+  "uid": "musubi-latency",
+  "schemaVersion": 39,
+  "tags": ["musubi"],
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Retrieve p50/p95/p99 (fast)",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "histogram_quantile(0.50, sum by (le) (rate(musubi_retrieve_duration_ms_bucket{mode=\"fast\"}[5m])))", "legendFormat": "p50" },
+        { "expr": "histogram_quantile(0.95, sum by (le) (rate(musubi_retrieve_duration_ms_bucket{mode=\"fast\"}[5m])))", "legendFormat": "p95" },
+        { "expr": "histogram_quantile(0.99, sum by (le) (rate(musubi_retrieve_duration_ms_bucket{mode=\"fast\"}[5m])))", "legendFormat": "p99" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Retrieve p50/p95/p99 (deep)",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "histogram_quantile(0.50, sum by (le) (rate(musubi_retrieve_duration_ms_bucket{mode=\"deep\"}[5m])))", "legendFormat": "p50" },
+        { "expr": "histogram_quantile(0.95, sum by (le) (rate(musubi_retrieve_duration_ms_bucket{mode=\"deep\"}[5m])))", "legendFormat": "p95" },
+        { "expr": "histogram_quantile(0.99, sum by (le) (rate(musubi_retrieve_duration_ms_bucket{mode=\"deep\"}[5m])))", "legendFormat": "p99" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Capture p50/p95/p99",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "histogram_quantile(0.50, sum by (le) (rate(musubi_capture_duration_ms_bucket[5m])))", "legendFormat": "p50" },
+        { "expr": "histogram_quantile(0.95, sum by (le) (rate(musubi_capture_duration_ms_bucket[5m])))", "legendFormat": "p95" },
+        { "expr": "histogram_quantile(0.99, sum by (le) (rate(musubi_capture_duration_ms_bucket[5m])))", "legendFormat": "p99" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Rerank p95",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "histogram_quantile(0.95, sum by (le) (rate(tei_request_duration_ms_bucket{service=\"reranker\"}[5m])))" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Ollama generation p95",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "histogram_quantile(0.95, sum by (purpose, le) (rate(ollama_generation_ms_bucket[5m])))", "legendFormat": "{{purpose}}" }
+      ]
+    }
+  ]
+}

--- a/deploy/grafana/dashboards/musubi-lifecycle.json
+++ b/deploy/grafana/dashboards/musubi-lifecycle.json
@@ -1,0 +1,51 @@
+{
+  "title": "Musubi · Lifecycle",
+  "uid": "musubi-lifecycle",
+  "schemaVersion": 39,
+  "tags": ["musubi"],
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": { "from": "now-24h", "to": "now" },
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Job runtimes (stacked by job)",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "sum by (job) (rate(musubi_lifecycle_job_duration_seconds_sum[5m]) / rate(musubi_lifecycle_job_duration_seconds_count[5m]))", "legendFormat": "{{job}}" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Job error rate",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "sum by (job) (rate(musubi_lifecycle_job_errors_total[5m]))", "legendFormat": "{{job}}" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Promotion queue length",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "musubi_lifecycle_promotion_queue_length" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Concept attempts over time",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "sum by (result) (rate(musubi_promotion_total[5m]))", "legendFormat": "{{result}}" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Contradictions unresolved (current)",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "musubi_contradictions_unresolved_count" }
+      ]
+    }
+  ]
+}

--- a/deploy/grafana/dashboards/musubi-overview.json
+++ b/deploy/grafana/dashboards/musubi-overview.json
@@ -1,0 +1,91 @@
+{
+  "title": "Musubi · Overview",
+  "uid": "musubi-overview",
+  "schemaVersion": 39,
+  "tags": ["musubi"],
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Capture rate (per minute, by plane)",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "sum by (plane) (rate(musubi_capture_total[1m]))", "legendFormat": "{{plane}}" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Retrieval rate (per minute, by mode)",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "sum by (mode) (rate(musubi_retrieve_total[1m]))", "legendFormat": "{{mode}}" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Error rate (per minute, by code)",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "sum by (code) (rate(musubi_errors_total[1m]))", "legendFormat": "{{code}}" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Promotions (last 24h)",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "sum(increase(musubi_promotion_total{result=\"success\"}[24h]))" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Demotions (last 24h)",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "sum(increase(musubi_lifecycle_events_total{to_state=\"demoted\"}[24h]))" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Contradictions (last 24h)",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "sum(increase(musubi_lifecycle_events_total{to_state=\"contradicted\"}[24h]))" }
+      ]
+    },
+    {
+      "type": "gauge",
+      "title": "GPU VRAM (used / total MB)",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "gpu_vram_used_mb" }
+      ]
+    },
+    {
+      "type": "gauge",
+      "title": "Vault disk used %",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "100 * (1 - (node_filesystem_avail_bytes{mountpoint=\"/var/lib/musubi\"} / node_filesystem_size_bytes{mountpoint=\"/var/lib/musubi\"}))" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Silent — single-retrieval p95 (informational, not alerted)",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "histogram_quantile(0.95, sum by (le) (rate(musubi_retrieve_duration_ms_bucket[5m])))" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Silent — dedup rate (informational, not alerted)",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "rate(musubi_capture_dedup_total{action=\"merged\"}[5m]) / rate(musubi_capture_total[5m])" }
+      ]
+    }
+  ]
+}

--- a/deploy/grafana/dashboards/musubi-vault.json
+++ b/deploy/grafana/dashboards/musubi-vault.json
@@ -1,0 +1,43 @@
+{
+  "title": "Musubi · Vault",
+  "uid": "musubi-vault",
+  "schemaVersion": 39,
+  "tags": ["musubi"],
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": { "from": "now-24h", "to": "now" },
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Vault events per minute (by kind)",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "sum by (kind) (rate(musubi_vault_events_total[1m]))", "legendFormat": "{{kind}}" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Vault sync latency p95 (vault event → qdrant update)",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "histogram_quantile(0.95, sum by (le) (rate(musubi_vault_sync_latency_ms_bucket[5m])))" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Echo filter rate",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "rate(musubi_vault_echo_filtered_total[1m])" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Reconcile diff count (over time)",
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "targets": [
+        { "expr": "musubi_vault_reconcile_diff_count" }
+      ]
+    }
+  ]
+}

--- a/deploy/grafana/provisioning/datasources/datasources.yml
+++ b/deploy/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,27 @@
+# Grafana datasource provisioning for Musubi.
+# Per docs/architecture/09-operations/observability.md § Stack.
+
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+
+  - name: Loki
+    type: loki
+    uid: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false
+
+  - name: Tempo
+    type: tempo
+    uid: tempo
+    access: proxy
+    url: http://tempo:3200
+    editable: false

--- a/deploy/loki/loki.yml
+++ b/deploy/loki/loki.yml
@@ -1,0 +1,43 @@
+# Loki single-binary config for the Musubi single-host deployment.
+# Per docs/architecture/09-operations/observability.md § Logs.
+#
+# Co-resident with Grafana on the musubi host. Receives structured-JSON
+# log lines from journald via promtail; keeps 30 days of retention to
+# match Prometheus.
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  path_prefix: /var/lib/loki
+  storage:
+    filesystem:
+      chunks_directory: /var/lib/loki/chunks
+      rules_directory: /var/lib/loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 720h
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+
+compactor:
+  working_directory: /var/lib/loki/compactor
+  retention_enabled: true
+  delete_request_store: filesystem

--- a/deploy/prometheus/alertmanager.yml
+++ b/deploy/prometheus/alertmanager.yml
@@ -1,0 +1,35 @@
+# Alertmanager routing for Musubi alerts.
+# Per docs/architecture/09-operations/alerts.md.
+
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: default
+  group_by: [alertname]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 1h
+  routes:
+    - matchers:
+        - 'severity="push"'
+      receiver: ntfy
+      repeat_interval: 30m
+    - matchers:
+        - 'severity="email"'
+      receiver: email
+      repeat_interval: 24h
+
+receivers:
+  - name: default
+    webhook_configs:
+      - url: "http://musubi-core:8100/v1/ops/alert-sink"
+  - name: ntfy
+    webhook_configs:
+      - url: "https://ntfy.sh/musubi-alerts"
+  - name: email
+    email_configs:
+      - to: eric@example.com
+        from: alertmanager@musubi.internal
+        smarthost: smtp.example.com:587
+        require_tls: true

--- a/deploy/prometheus/prometheus.yml
+++ b/deploy/prometheus/prometheus.yml
@@ -1,0 +1,51 @@
+# Prometheus scrape config for the single-host Musubi deployment.
+# Per docs/architecture/09-operations/observability.md § Metrics.
+#
+# All scrape targets are co-resident on the musubi host (compose stack
+# from slice-ops-compose). Storage is local TSDB with a 30-day
+# retention; one host, one tenant, no remote_write. v1 scope.
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    cluster: musubi
+    host: musubi-1
+
+rule_files:
+  - "/etc/prometheus/alerts/musubi-alerts.yml"
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
+scrape_configs:
+  - job_name: musubi-core
+    metrics_path: /v1/ops/metrics
+    static_configs:
+      - targets: ["musubi-core:8100"]
+
+  - job_name: qdrant
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["qdrant:6333"]
+
+  - job_name: tei-dense
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["tei-dense:8080"]
+
+  - job_name: tei-sparse
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["tei-sparse:8080"]
+
+  - job_name: tei-reranker
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["tei-reranker:8080"]
+
+  - job_name: node-exporter
+    static_configs:
+      - targets: ["node-exporter:9100"]

--- a/deploy/tempo/tempo.yml
+++ b/deploy/tempo/tempo.yml
@@ -1,0 +1,35 @@
+# Tempo single-binary config for the Musubi single-host deployment.
+# Per docs/architecture/09-operations/observability.md § Tracing.
+#
+# OTel collection lands here when slice-sdk-py-otel-spans ships;
+# until then this is a static config that just stands the service up
+# so the compose stack doesn't error on a missing tempo container.
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+ingester:
+  trace_idle_period: 30s
+  max_block_bytes: 100000000
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 168h
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/lib/tempo/blocks
+    wal:
+      path: /var/lib/tempo/wal

--- a/docs/architecture/_inbox/cross-slice/slice-ops-observability-slice-lifecycle-job-emit.md
+++ b/docs/architecture/_inbox/cross-slice/slice-ops-observability-slice-lifecycle-job-emit.md
@@ -1,0 +1,80 @@
+---
+title: "Cross-slice: lifecycle workers emit job-start/job-end metrics"
+section: _inbox/cross-slice
+type: cross-slice
+source_slice: slice-ops-observability
+target_slice: slice-lifecycle-maturation
+status: open
+opened_by: vscode-cc-sonnet47
+opened_at: 2026-04-19
+tags: [section/inbox-cross-slice, type/cross-slice, status/open]
+updated: 2026-04-19
+---
+
+# Lifecycle workers should emit job start/end metrics
+
+## Source slice
+
+`slice-ops-observability` (PR #104).
+
+## Problem
+
+`docs/architecture/09-operations/observability.md` § Test contract
+bullet 7 (`test_lifecycle_job_start_end_emitted_to_events_table`)
+asserts the lifecycle workers (maturation, synthesis, promotion,
+reflection) emit a job-start / job-end pair to the lifecycle event
+ledger AND increment `musubi_lifecycle_job_duration_seconds` +
+`musubi_lifecycle_job_errors_total` on each run.
+
+This slice cannot land that change because:
+
+1. `src/musubi/lifecycle/` is in `forbidden_paths` for
+   `slice-ops-observability` (lifecycle is owned by the
+   slice-lifecycle-* family, all already shipped).
+2. The lifecycle event ledger surface (`LifecycleEvent`) is owned
+   by `slice-types`, also shipped — but the *emit calls* belong
+   inside the worker bodies.
+
+## Requested change
+
+For each lifecycle worker (maturation, synthesis, promotion,
+reflection), wrap the per-tick body in:
+
+```python
+from musubi.observability import default_registry
+
+_REG = default_registry()
+_DURATION = _REG.histogram(
+    "musubi_lifecycle_job_duration_seconds",
+    "lifecycle worker tick duration",
+    labelnames=("job",),
+)
+_ERRORS = _REG.counter(
+    "musubi_lifecycle_job_errors_total",
+    "lifecycle worker tick errors",
+    labelnames=("job",),
+)
+
+start = time.monotonic()
+try:
+    await tick()
+    LifecycleEvent.write(kind="job-start-end", job=<name>, ...)
+except Exception:
+    _ERRORS.labels(job=<name>).inc()
+    raise
+finally:
+    _DURATION.labels(job=<name>).observe(time.monotonic() - start)
+```
+
+The dashboard (`deploy/grafana/dashboards/musubi-lifecycle.json`) +
+the email alert `lifecycle_job_failing` already query these metric
+names — they just won't show data until the workers emit.
+
+## Acceptance
+
+- All four lifecycle workers wrap their tick body in the metric
+  + ledger pair shown above.
+- The Grafana lifecycle dashboard's "Job runtimes" + "Job error rate"
+  panels render real data on the staging compose stack.
+- `slice-ops-observability` test bullet 7 unskipped + asserts on
+  the metric increment.

--- a/docs/architecture/_inbox/locks/slice-ops-observability.lock
+++ b/docs/architecture/_inbox/locks/slice-ops-observability.lock
@@ -1,0 +1,5 @@
+agent: vscode-cc-sonnet47
+issue: 19
+started: 2026-04-19T22:30:00Z
+branch: slice/slice-ops-observability
+note: Secondary lock per agent-guardrails §Locking. Removed at handoff.

--- a/docs/architecture/_inbox/locks/slice-ops-observability.lock
+++ b/docs/architecture/_inbox/locks/slice-ops-observability.lock
@@ -1,5 +1,0 @@
-agent: vscode-cc-sonnet47
-issue: 19
-started: 2026-04-19T22:30:00Z
-branch: slice/slice-ops-observability
-note: Secondary lock per agent-guardrails §Locking. Removed at handoff.

--- a/docs/architecture/_slices/slice-ops-observability.md
+++ b/docs/architecture/_slices/slice-ops-observability.md
@@ -3,10 +3,10 @@ title: "Slice: Metrics / logs / traces"
 slice_id: slice-ops-observability
 section: _slices
 type: slice
-status: ready
-owner: unassigned
+status: in-progress
+owner: vscode-cc-sonnet47
 phase: "8 Ops"
-tags: [section/slices, status/ready, type/slice]
+tags: [section/slices, status/in-progress, type/slice]
 updated: 2026-04-19
 reviewed: false
 depends-on: ["[[_slices/slice-ops-compose]]"]
@@ -17,7 +17,7 @@ blocks: []
 
 > Structured logs (Loki), metrics (Prometheus), traces (Tempo). Alert rules and dashboards ship in repo.
 
-**Phase:** 8 Ops · **Status:** `ready` · **Owner:** `unassigned`
+**Phase:** 8 Ops · **Status:** `in-progress` · **Owner:** `vscode-cc-sonnet47`
 
 ## Specs to implement
 

--- a/docs/architecture/_slices/slice-ops-observability.md
+++ b/docs/architecture/_slices/slice-ops-observability.md
@@ -85,6 +85,13 @@ Agents append one entry per work session. Format:
 - `blocks`: removed `slice-ops-backup` (spurious — backup was done independently this session).
 - Brief path I gave VS Code said `08-deployment/observability.md`; actual spec path is `09-operations/observability.md` + `09-operations/alerts.md`. Slice file's `## Specs to implement` wikilinks were already correct; brief was wrong — noted for future render-prompt.py script (claimable.py reads specs from the slice file, so this class of error would have been auto-caught in an automated brief).
 
+### 2026-04-19 — vscode-cc-sonnet47 — take
+
+- Claimed atomically via `gh issue edit 19 --add-assignee @me` + label flip `status:ready → status:in-progress` (dual-update before writes; post-#93 frontmatter-vs-label drift is a hard `✗`).
+- Branch `slice/slice-ops-observability` off `v2` at 66d5066 (post-reconcile).
+- Caught the spec-path + owns_paths drift in the pre-claim verify pass and waited for the operator's reconcile (option a per the canonical handoff playbook). 9th drift-fix tonight; render-prompt.py automation will eliminate this class.
+- Same agent that landed slice-sdk-py + slice-adapter-livekit; the StatusResponse / ComponentStatus shape the wiring needs to populate is fresh context from those slices.
+
 ## Cross-slice tickets opened by this slice
 
 - _(none yet)_

--- a/docs/architecture/_slices/slice-ops-observability.md
+++ b/docs/architecture/_slices/slice-ops-observability.md
@@ -3,10 +3,10 @@ title: "Slice: Metrics / logs / traces"
 slice_id: slice-ops-observability
 section: _slices
 type: slice
-status: in-progress
+status: in-review
 owner: vscode-cc-sonnet47
 phase: "8 Ops"
-tags: [section/slices, status/in-progress, type/slice]
+tags: [section/slices, status/in-review, type/slice]
 updated: 2026-04-19
 reviewed: false
 depends-on: ["[[_slices/slice-ops-compose]]"]
@@ -17,7 +17,7 @@ blocks: []
 
 > Structured logs (Loki), metrics (Prometheus), traces (Tempo). Alert rules and dashboards ship in repo.
 
-**Phase:** 8 Ops · **Status:** `in-progress` · **Owner:** `vscode-cc-sonnet47`
+**Phase:** 8 Ops · **Status:** `in-review` · **Owner:** `vscode-cc-sonnet47`
 
 ## Specs to implement
 
@@ -92,10 +92,27 @@ Agents append one entry per work session. Format:
 - Caught the spec-path + owns_paths drift in the pre-claim verify pass and waited for the operator's reconcile (option a per the canonical handoff playbook). 9th drift-fix tonight; render-prompt.py automation will eliminate this class.
 - Same agent that landed slice-sdk-py + slice-adapter-livekit; the StatusResponse / ComponentStatus shape the wiring needs to populate is fresh context from those slices.
 
+### 2026-04-19 — vscode-cc-sonnet47 — handoff to in-review
+
+- Implemented `src/musubi/observability/` (5 modules: `__init__`, `registry`, `logging_setup`, `health`, `metrics_middleware`). Hand-rolled in-process Prometheus registry — Counter / Histogram / Gauge + text-format renderer — instead of pulling `prometheus-client` (kept the dep tree tight; the exposition format is small enough that hand-rolling beats an ADR for a 12-deep transitive set).
+- Wired `src/musubi/api/routers/ops.py`: `/ops/status` populates `StatusResponse.components` with one row per declared dependency (qdrant + tei-dense + tei-sparse + tei-reranker + ollama) — closes Aoi's v0.1 health-granularity ask. `/ops/metrics` serves the live `default_registry()` in Prometheus text format.
+- Touched `src/musubi/api/app.py` (NOT in slice forbidden_paths but adjacent — flagging here for the reviewer): one-line `install_metrics_middleware(app)` install + 3-line wiring of the existing correlation-id middleware's id into `request_id_var` so structured-log records carry the id end-to-end. No reshape of the existing middleware chain.
+- Shipped `deploy/{prometheus,grafana,loki,tempo}/` configs + four dashboards (overview, latency, lifecycle, vault) + the alert rule catalog. Every push alert has a runbook URL annotation and a `for:` clause; tested against the YAML directly.
+- 47 unit tests; all 10 testable Test Contract bullets pass; 4 bullets skipped against documented closure (2 cross-slice, 2 declared out-of-scope per work log). Branch coverage on owned code: 89% (gate 85%).
+- One cross-slice ticket opened: `slice-ops-observability-slice-lifecycle-job-emit.md` — lifecycle workers should wrap their tick body in the `musubi_lifecycle_job_duration_seconds` + `musubi_lifecycle_job_errors_total` instruments shipped here. Slice-sdk-py-otel-spans.md (existing ticket from slice-sdk-py) covers the OTel deferral.
+- Handoff checks: `make check` green (870 passed, 226 skipped), `make tc-coverage SLICE=slice-ops-observability` reports closure satisfied, `make agent-check` clean (warnings only — none touching this slice; the two ⚠ are about other slices flapping in parallel).
+- Flipping `status: in-review`, marking PR ready, removing the lock.
+
+### Known gaps at in-review
+
+- **OTel deferred** to slice-sdk-py-otel-spans.md (existing cross-slice ticket). Spec § Tracing describes the full Tempo wiring; the deploy/tempo/ config + dashboard panels exist as scaffolding so the compose stack stands up, but the SDK doesn't emit spans yet.
+- **Lifecycle worker emit deferred** to slice-ops-observability-slice-lifecycle-job-emit.md (new). The metrics + dashboards + email alert (`lifecycle_job_failing`) all reference the `musubi_lifecycle_job_*` family; the workers (in slice-lifecycle-* paths, forbidden here) need to wrap their ticks in the instrument-emit pattern shown in the ticket.
+- **No real backfill of `musubi_capture_total` / `musubi_retrieve_total` / `musubi_vault_*`.** The middleware emits `musubi_http_requests_total` + `musubi_http_request_duration_ms` + `musubi_5xx_total` from real traffic; the planes / retrieve / vault families need the same instrument-emit treatment in their respective slices (already-shipped) — same pattern as the lifecycle ticket. Could be one consolidated cross-slice ticket if desired; left as-is for now since the dashboards explicitly call those metrics out and the absence is a noisy "no data" hint.
+
 ## Cross-slice tickets opened by this slice
 
-- _(none yet)_
+- [[_inbox/cross-slice/slice-ops-observability-slice-lifecycle-job-emit|slice-ops-observability-slice-lifecycle-job-emit]] — lifecycle workers wrap their tick body in `musubi_lifecycle_job_*` + ledger emit; unskips Test Contract bullet 7.
 
 ## PR links
 
-- _(none yet)_
+- [#104](https://github.com/ericmey/musubi/pull/104) — `slice/slice-ops-observability` → `v2`.

--- a/src/musubi/api/app.py
+++ b/src/musubi/api/app.py
@@ -56,6 +56,7 @@ from musubi.api.routers import (
     writes_retrieve_stream,
     writes_thoughts,
 )
+from musubi.observability import install_metrics_middleware, request_id_var
 from musubi.settings import Settings
 
 log = logging.getLogger(__name__)
@@ -145,6 +146,8 @@ def create_app(*, settings: Settings | None = None) -> FastAPI:
         redoc_url=None,
     )
 
+    install_metrics_middleware(app)
+
     @app.middleware("http")
     async def correlation_id_middleware(
         request: Request,
@@ -152,6 +155,10 @@ def create_app(*, settings: Settings | None = None) -> FastAPI:
     ) -> Response:
         cid = request.headers.get(_CORRELATION_HEADER) or str(uuid.uuid4())
         request.state.correlation_id = cid
+        # Make the id available to structured-log records via the
+        # observability contextvar; reset on response so it doesn't
+        # leak into the next request handled by the same task.
+        rid_token = request_id_var.set(cid)
         try:
             response = await _wrapped_call(request, call_next)
         except APIError as exc:
@@ -168,6 +175,7 @@ def create_app(*, settings: Settings | None = None) -> FastAPI:
                 hint="check server logs with the X-Request-Id header value",
             )
         response.headers[_CORRELATION_HEADER] = cid
+        request_id_var.reset(rid_token)
         return response
 
     async def _wrapped_call(

--- a/src/musubi/api/routers/ops.py
+++ b/src/musubi/api/routers/ops.py
@@ -1,4 +1,12 @@
-"""Operational endpoints — health, status, metrics passthrough."""
+"""Operational endpoints — health, status, metrics passthrough.
+
+``/health`` is a liveness probe (always 200 if the process serves
+requests). ``/status`` is per-component readiness — populates
+:class:`StatusResponse.components` with one row per dependency
+(Qdrant + each TEI service + Ollama), satisfying Aoi's v0.1
+health-granularity ask. ``/metrics`` exposes the in-process
+Prometheus registry in text format.
+"""
 
 from __future__ import annotations
 
@@ -7,6 +15,12 @@ from qdrant_client import QdrantClient
 
 from musubi.api.dependencies import get_qdrant_client
 from musubi.api.responses import ComponentStatus, HealthResponse, StatusResponse
+from musubi.config import get_settings
+from musubi.observability import (
+    check_component_health,
+    default_registry,
+    render_text_format,
+)
 
 router = APIRouter(prefix="/v1/ops", tags=["ops"])
 
@@ -23,41 +37,51 @@ async def health() -> HealthResponse:
 async def status(
     qdrant: QdrantClient = Depends(get_qdrant_client),
 ) -> StatusResponse:
-    """Per-component readiness. Tries a cheap operation against each
-    dependency (Qdrant collections list; TEI / Ollama health checks land
-    in slice-ops-observability)."""
+    """Per-component readiness — Qdrant + every TEI service + Ollama."""
     components: dict[str, ComponentStatus] = {}
+
+    # Qdrant — list collections (cheap, no scan).
     try:
         qdrant.get_collections()
         components["qdrant"] = ComponentStatus(name="qdrant", healthy=True)
     except Exception as exc:
         components["qdrant"] = ComponentStatus(name="qdrant", healthy=False, detail=repr(exc))
-    # TEI / Ollama probes live in slice-ops-observability; these are
-    # placeholders so the response shape is stable today.
-    components["tei"] = ComponentStatus(
-        name="tei",
-        healthy=True,
-        detail="probe deferred to slice-ops-observability",
-    )
-    components["ollama"] = ComponentStatus(
-        name="ollama",
-        healthy=True,
-        detail="probe deferred to slice-ops-observability",
-    )
+
+    # TEI dense / sparse / reranker + Ollama — HTTP probe to /health.
+    try:
+        settings = get_settings()
+    except Exception as exc:
+        # Settings may fail to load in tests/CI; surface as degraded
+        # without crashing the endpoint.
+        for name in ("tei-dense", "tei-sparse", "tei-reranker", "ollama"):
+            components[name] = ComponentStatus(
+                name=name,
+                healthy=False,
+                detail=f"settings unavailable: {exc!r}",
+            )
+        overall = "degraded"
+        return StatusResponse(status=overall, components=components)
+
+    for name, base_url in (
+        ("tei-dense", str(settings.tei_dense_url)),
+        ("tei-sparse", str(settings.tei_sparse_url)),
+        ("tei-reranker", str(settings.tei_reranker_url)),
+        ("ollama", str(settings.ollama_url)),
+    ):
+        components[name] = check_component_health(
+            name=name,
+            url=base_url.rstrip("/") + "/health",
+        )
+
     overall = "ok" if all(c.healthy for c in components.values()) else "degraded"
     return StatusResponse(status=overall, components=components)
 
 
 @router.get("/metrics")
 async def metrics() -> Response:
-    """Prometheus-format metrics passthrough.
-
-    The metrics surface ships in slice-ops-observability; this route
-    returns an empty body with the correct content type so adapters can
-    point Prometheus at it without errors.
-    """
+    """Prometheus-format metrics from the in-process registry."""
     return Response(
-        content="# Musubi metrics — exporter wiring deferred to slice-ops-observability\n",
+        content=render_text_format(default_registry()),
         media_type="text/plain; version=0.0.4",
     )
 

--- a/src/musubi/observability/__init__.py
+++ b/src/musubi/observability/__init__.py
@@ -1,0 +1,54 @@
+"""Observability — metrics, structured logs, and component health probes.
+
+Per [[09-operations/observability]]. Three independent surfaces share
+one module so the API + workers can pull `from musubi.observability
+import …` without a longer dotted path:
+
+- **Metrics:** :class:`Counter` / :class:`Histogram` / :class:`Gauge`
+  via :class:`Registry`. Render the registry in Prometheus text
+  format with :func:`render_text_format`. The default process-wide
+  registry is :func:`default_registry`.
+- **Middleware:** :func:`install_metrics_middleware` adds per-endpoint
+  request counter + duration histogram + 5xx counter to a FastAPI app.
+- **Logs:** :class:`StructuredJsonFormatter` produces the spec's
+  JSON-per-line shape; :data:`request_id_var` is a contextvar each
+  log record reads to populate ``request_id``;
+  :func:`redact_token_filter` scrubs JWT-shaped strings before emit.
+- **Health:** :func:`check_component_health` probes a downstream
+  service's ``/health`` endpoint and returns a typed
+  :class:`musubi.api.responses.ComponentStatus`.
+
+OpenTelemetry tracing is intentionally OUT OF SCOPE per
+``slice-sdk-py-otel-spans.md`` — the SDK spec scopes OTel as
+opt-in; same constraint applies here.
+"""
+
+from musubi.observability.health import check_component_health
+from musubi.observability.logging_setup import (
+    StructuredJsonFormatter,
+    redact_token_filter,
+    request_id_var,
+)
+from musubi.observability.metrics_middleware import install_metrics_middleware
+from musubi.observability.registry import (
+    Counter,
+    Gauge,
+    Histogram,
+    Registry,
+    default_registry,
+    render_text_format,
+)
+
+__all__ = [
+    "Counter",
+    "Gauge",
+    "Histogram",
+    "Registry",
+    "StructuredJsonFormatter",
+    "check_component_health",
+    "default_registry",
+    "install_metrics_middleware",
+    "redact_token_filter",
+    "render_text_format",
+    "request_id_var",
+]

--- a/src/musubi/observability/health.py
+++ b/src/musubi/observability/health.py
@@ -1,0 +1,54 @@
+"""Per-component health probes.
+
+Per [[09-operations/observability]] § Inference metrics + Aoi's v0.1
+review ask: ``/ops/status`` populates ``StatusResponse.components``
+with one :class:`ComponentStatus` per dependency (TEI dense / sparse /
+reranker, Ollama, vector-store, lifecycle-worker). Each probe is a
+cheap GET against the dependency's ``/health`` endpoint; failure
+modes (timeout, connect error, 4xx, 5xx) all surface as
+``healthy=False`` with a one-line ``detail``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+
+if TYPE_CHECKING:
+    from musubi.api.responses import ComponentStatus
+
+_PROBE_TIMEOUT_S = 1.5
+"""How long to wait per probe. Status endpoints must stay fast — a
+slow probe blocks the whole /ops/status response — so we cap each
+sub-probe and let the timeout itself surface as `healthy=False`."""
+
+
+def check_component_health(
+    *,
+    name: str,
+    url: str,
+    transport: httpx.BaseTransport | None = None,
+    timeout: float = _PROBE_TIMEOUT_S,
+) -> ComponentStatus:
+    """Probe a downstream service. Returns a typed component-status row."""
+    # Local import sidesteps the circular: api.app imports
+    # observability for middleware install, observability.health needs
+    # api.responses for the response model.
+    from musubi.api.responses import ComponentStatus
+
+    try:
+        with httpx.Client(transport=transport, timeout=timeout) as client:
+            resp = client.get(url)
+    except httpx.HTTPError as exc:
+        return ComponentStatus(name=name, healthy=False, detail=repr(exc))
+    if resp.status_code >= 400:
+        return ComponentStatus(
+            name=name,
+            healthy=False,
+            detail=f"HTTP {resp.status_code} from {url}",
+        )
+    return ComponentStatus(name=name, healthy=True)
+
+
+__all__ = ["check_component_health"]

--- a/src/musubi/observability/logging_setup.py
+++ b/src/musubi/observability/logging_setup.py
@@ -1,0 +1,117 @@
+"""Structured-logging helpers — JSON formatter + request-id contextvar.
+
+Per [[09-operations/observability]] § Logs. Every log line is a single
+JSON object; correlation IDs propagate via :data:`request_id_var`
+(populated by the API's correlation-id middleware on each inbound
+request). :func:`redact_token_filter` is a logging filter that
+scrubs JWT-shaped strings out of the rendered message before emit.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from contextvars import ContextVar
+
+request_id_var: ContextVar[str | None] = ContextVar("request_id", default=None)
+"""Per-request correlation id. The API's correlation-id middleware
+sets this for the lifetime of each request; structured log records
+pull it via :class:`StructuredJsonFormatter`."""
+
+
+_BUILTIN_RECORD_FIELDS = frozenset(
+    {
+        "args",
+        "asctime",
+        "created",
+        "exc_info",
+        "exc_text",
+        "filename",
+        "funcName",
+        "levelname",
+        "levelno",
+        "lineno",
+        "message",
+        "module",
+        "msecs",
+        "msg",
+        "name",
+        "pathname",
+        "process",
+        "processName",
+        "relativeCreated",
+        "stack_info",
+        "thread",
+        "threadName",
+        "taskName",
+    }
+)
+
+
+class StructuredJsonFormatter(logging.Formatter):
+    """One JSON object per log record — the spec's exact shape."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        # Apply the redaction filter inline so emit-time scrubbing is
+        # unconditional even if the caller forgot to attach the filter.
+        redact_token_filter(record)
+        payload: dict[str, object] = {
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(record.created))
+            + f".{int(record.msecs):03d}Z",
+            "level": record.levelname.lower(),
+            "service": record.name,
+            "msg": record.getMessage(),
+        }
+        rid = request_id_var.get()
+        if rid is not None:
+            payload["request_id"] = rid
+        # Pull any extra fields the caller attached (record.namespace,
+        # record.object_id, etc.) into the top-level payload.
+        for k, v in record.__dict__.items():
+            if k in _BUILTIN_RECORD_FIELDS:
+                continue
+            if k == "message":
+                continue
+            payload.setdefault(k, v)
+        if record.exc_info is not None:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(payload, default=str)
+
+
+_TOKEN_PATTERN = re.compile(r"eyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_.-]+")
+"""JWT-shape detector: starts with ``eyJ`` (header `{"typ":...` base64url),
+followed by base64-ish chars and at least one dot. False positives
+cost log noise; false negatives cost a leaked token, so we err
+toward over-scrubbing."""
+
+
+def redact_token_filter(record: logging.LogRecord) -> bool:
+    """Logging filter — replaces JWT-shaped substrings with ``[REDACTED]``.
+
+    Returns ``True`` so the record continues through the handler
+    chain. Idempotent: running twice yields the same scrubbed message.
+    Mutates ``record.msg`` in place; if the message was a non-string
+    (e.g. an exception), it's left untouched.
+    """
+    msg = record.msg
+    if isinstance(msg, str) and _TOKEN_PATTERN.search(msg):
+        record.msg = _TOKEN_PATTERN.sub("[REDACTED]", msg)
+    # Also scrub the rendered .args path so f-string-style logging stays safe.
+    if isinstance(record.args, tuple):
+        scrubbed: list[object] = []
+        for a in record.args:
+            if isinstance(a, str) and _TOKEN_PATTERN.search(a):
+                scrubbed.append(_TOKEN_PATTERN.sub("[REDACTED]", a))
+            else:
+                scrubbed.append(a)
+        record.args = tuple(scrubbed)
+    return True
+
+
+__all__ = [
+    "StructuredJsonFormatter",
+    "redact_token_filter",
+    "request_id_var",
+]

--- a/src/musubi/observability/metrics_middleware.py
+++ b/src/musubi/observability/metrics_middleware.py
@@ -1,0 +1,81 @@
+"""FastAPI metrics middleware — per-endpoint counter + latency + 5xx.
+
+Per [[09-operations/observability]] § Core metrics (the
+``musubi_http_*`` family). Installed once on the FastAPI app via
+:func:`install_metrics_middleware`; observes every inbound request and
+emits to the supplied :class:`Registry`.
+
+The metrics surface itself (``/v1/ops/metrics``) is served by the API's
+ops router; this middleware ONLY produces the data, never serves it.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable
+
+from fastapi import FastAPI, Request, Response
+
+from musubi.observability.registry import Registry, default_registry
+
+_INSTALLED_FLAG = "_musubi_metrics_installed"
+_SELF_SKIP_PATHS: frozenset[str] = frozenset({"/v1/ops/metrics", "/metrics"})
+
+
+def install_metrics_middleware(
+    app: FastAPI,
+    *,
+    registry: Registry | None = None,
+) -> None:
+    """Install per-endpoint metrics on ``app``. Idempotent — calling
+    twice on the same app is a no-op."""
+    if getattr(app.state, _INSTALLED_FLAG, False):
+        return
+    reg = registry or default_registry()
+
+    requests_total = reg.counter(
+        "musubi_http_requests_total",
+        "HTTP requests by endpoint, method, status",
+        labelnames=("endpoint", "method", "status"),
+    )
+    duration_ms = reg.histogram(
+        "musubi_http_request_duration_ms",
+        "HTTP request duration in milliseconds",
+        labelnames=("endpoint", "method"),
+        buckets=(5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0),
+    )
+    five_xx_total = reg.counter(
+        "musubi_5xx_total",
+        "5xx responses by endpoint",
+        labelnames=("endpoint",),
+    )
+
+    @app.middleware("http")
+    async def metrics_middleware(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        path = request.url.path
+        if path in _SELF_SKIP_PATHS:
+            return await call_next(request)
+        method = request.method
+        start = time.monotonic()
+        try:
+            response = await call_next(request)
+        except Exception:
+            elapsed_ms = (time.monotonic() - start) * 1000.0
+            duration_ms.labels(endpoint=path, method=method).observe(elapsed_ms)
+            requests_total.labels(endpoint=path, method=method, status="500").inc()
+            five_xx_total.labels(endpoint=path).inc()
+            raise
+        elapsed_ms = (time.monotonic() - start) * 1000.0
+        duration_ms.labels(endpoint=path, method=method).observe(elapsed_ms)
+        requests_total.labels(endpoint=path, method=method, status=str(response.status_code)).inc()
+        if response.status_code >= 500:
+            five_xx_total.labels(endpoint=path).inc()
+        return response
+
+    app.state._musubi_metrics_installed = True
+
+
+__all__ = ["install_metrics_middleware"]

--- a/src/musubi/observability/registry.py
+++ b/src/musubi/observability/registry.py
@@ -1,0 +1,346 @@
+"""Minimal in-process Prometheus metrics registry.
+
+Hand-rolled (no `prometheus-client` dep — keeps the slice scope tight,
+avoids an ADR for a 12-deep transitive tree). Three instrument types:
+
+- :class:`Counter` — monotonic; ``inc(n=1)``.
+- :class:`Histogram` — observe(value); buckets render the standard
+  `_bucket{le=...}` + `_sum` + `_count` triple.
+- :class:`Gauge` — ``set`` / ``inc`` / ``dec``.
+
+:class:`Registry` is the collection. :func:`render_text_format` walks
+it and emits Prometheus 0.0.4 exposition format.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Any
+
+
+def _format_label_value(v: Any) -> str:
+    s = str(v)
+    return s.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _format_labels(labelnames: tuple[str, ...], values: tuple[str, ...]) -> str:
+    if not labelnames:
+        return ""
+    parts = [f'{n}="{_format_label_value(v)}"' for n, v in zip(labelnames, values, strict=True)]
+    return "{" + ",".join(parts) + "}"
+
+
+def _format_number(x: float) -> str:
+    """Trim trailing .0 so integer counters render cleanly."""
+    if x == int(x):
+        return str(int(x))
+    return repr(x)
+
+
+class _LabelsDict:
+    """A dict keyed by label-value tuple, returning a per-key counter
+    or histogram or gauge instance. Thread-safe via the parent
+    instrument's lock."""
+
+    def __init__(self, factory: Any, lock: threading.Lock) -> None:
+        self._factory = factory
+        self._lock = lock
+        self._values: dict[tuple[str, ...], Any] = {}
+
+    def get(self, key: tuple[str, ...]) -> Any:
+        with self._lock:
+            inst = self._values.get(key)
+            if inst is None:
+                inst = self._factory()
+                self._values[key] = inst
+            return inst
+
+    def items(self) -> Iterable[tuple[tuple[str, ...], Any]]:
+        with self._lock:
+            return list(self._values.items())
+
+
+class Counter:
+    """Monotonic counter."""
+
+    type_name = "counter"
+
+    def __init__(self, name: str, help_text: str, labelnames: tuple[str, ...] = ()) -> None:
+        self.name = name
+        self.help_text = help_text
+        self.labelnames = labelnames
+        self._lock = threading.Lock()
+        self._value = 0.0
+        self._labelled = _LabelsDict(lambda: _CounterInstance(), self._lock) if labelnames else None
+
+    def inc(self, amount: float = 1.0) -> None:
+        if self.labelnames:
+            raise ValueError(f"counter {self.name!r} requires .labels(...)")
+        with self._lock:
+            self._value += amount
+
+    def labels(self, **kwargs: Any) -> _CounterInstance:
+        if not self.labelnames:
+            raise ValueError(f"counter {self.name!r} has no labels")
+        if set(kwargs.keys()) != set(self.labelnames):
+            raise ValueError(
+                f"counter {self.name!r} expects labels {self.labelnames}, got {tuple(kwargs)}"
+            )
+        key = tuple(str(kwargs[n]) for n in self.labelnames)
+        assert self._labelled is not None
+        inst: _CounterInstance = self._labelled.get(key)
+        return inst
+
+    def collect(self) -> Iterable[tuple[tuple[str, ...], float]]:
+        if self.labelnames:
+            assert self._labelled is not None
+            for key, inst in self._labelled.items():
+                yield key, inst.value
+        else:
+            yield (), self._value
+
+
+class _CounterInstance:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._value = 0.0
+
+    def inc(self, amount: float = 1.0) -> None:
+        with self._lock:
+            self._value += amount
+
+    @property
+    def value(self) -> float:
+        return self._value
+
+
+@dataclass
+class _HistogramInstance:
+    buckets: tuple[float, ...]
+    bucket_counts: list[int] = field(default_factory=list)
+    count: int = 0
+    sum: float = 0.0
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def __post_init__(self) -> None:
+        if not self.bucket_counts:
+            self.bucket_counts = [0 for _ in self.buckets]
+
+    def observe(self, value: float) -> None:
+        v = max(0.0, value)
+        with self._lock:
+            self.count += 1
+            self.sum += v
+            for i, upper in enumerate(self.buckets):
+                if v <= upper:
+                    self.bucket_counts[i] += 1
+
+
+class Histogram:
+    """Histogram with caller-defined buckets. ``+Inf`` is appended."""
+
+    type_name = "histogram"
+    _DEFAULT_BUCKETS: tuple[float, ...] = (
+        5.0,
+        10.0,
+        25.0,
+        50.0,
+        100.0,
+        250.0,
+        500.0,
+        1000.0,
+        2500.0,
+        5000.0,
+    )
+
+    def __init__(
+        self,
+        name: str,
+        help_text: str,
+        labelnames: tuple[str, ...] = (),
+        buckets: tuple[float, ...] | None = None,
+    ) -> None:
+        self.name = name
+        self.help_text = help_text
+        self.labelnames = labelnames
+        self.buckets = tuple(buckets) if buckets is not None else self._DEFAULT_BUCKETS
+        self._lock = threading.Lock()
+        self._unlabelled = _HistogramInstance(buckets=self.buckets) if not labelnames else None
+        self._labelled = (
+            _LabelsDict(lambda: _HistogramInstance(buckets=self.buckets), self._lock)
+            if labelnames
+            else None
+        )
+
+    def observe(self, value: float) -> None:
+        if self.labelnames:
+            raise ValueError(f"histogram {self.name!r} requires .labels(...)")
+        assert self._unlabelled is not None
+        self._unlabelled.observe(value)
+
+    def labels(self, **kwargs: Any) -> _HistogramInstance:
+        if not self.labelnames:
+            raise ValueError(f"histogram {self.name!r} has no labels")
+        if set(kwargs.keys()) != set(self.labelnames):
+            raise ValueError(
+                f"histogram {self.name!r} expects labels {self.labelnames}, got {tuple(kwargs)}"
+            )
+        key = tuple(str(kwargs[n]) for n in self.labelnames)
+        assert self._labelled is not None
+        inst: _HistogramInstance = self._labelled.get(key)
+        return inst
+
+    def collect(self) -> Iterable[tuple[tuple[str, ...], _HistogramInstance]]:
+        if self.labelnames:
+            assert self._labelled is not None
+            yield from self._labelled.items()
+        else:
+            assert self._unlabelled is not None
+            yield (), self._unlabelled
+
+
+class Gauge:
+    """Gauge — set / inc / dec arbitrary float."""
+
+    type_name = "gauge"
+
+    def __init__(self, name: str, help_text: str, labelnames: tuple[str, ...] = ()) -> None:
+        self.name = name
+        self.help_text = help_text
+        self.labelnames = labelnames
+        self._lock = threading.Lock()
+        self._value = 0.0
+
+    def set(self, value: float) -> None:
+        with self._lock:
+            self._value = value
+
+    def inc(self, amount: float = 1.0) -> None:
+        with self._lock:
+            self._value += amount
+
+    def dec(self, amount: float = 1.0) -> None:
+        with self._lock:
+            self._value -= amount
+
+    def collect(self) -> Iterable[tuple[tuple[str, ...], float]]:
+        yield (), self._value
+
+
+_Instrument = Counter | Histogram | Gauge
+
+
+class Registry:
+    """Holds metric instruments + renders them in Prometheus text format."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._metrics: dict[str, _Instrument] = {}
+
+    def counter(
+        self, name: str, help_text: str, labelnames: tuple[str, ...] | list[str] = ()
+    ) -> Counter:
+        with self._lock:
+            existing = self._metrics.get(name)
+            if existing is not None:
+                if not isinstance(existing, Counter):
+                    raise ValueError(f"{name!r} already registered as {type(existing).__name__}")
+                return existing
+            c = Counter(name, help_text, tuple(labelnames))
+            self._metrics[name] = c
+            return c
+
+    def histogram(
+        self,
+        name: str,
+        help_text: str,
+        labelnames: tuple[str, ...] | list[str] = (),
+        buckets: tuple[float, ...] | None = None,
+    ) -> Histogram:
+        with self._lock:
+            existing = self._metrics.get(name)
+            if existing is not None:
+                if not isinstance(existing, Histogram):
+                    raise ValueError(f"{name!r} already registered as {type(existing).__name__}")
+                return existing
+            h = Histogram(name, help_text, tuple(labelnames), buckets)
+            self._metrics[name] = h
+            return h
+
+    def gauge(
+        self, name: str, help_text: str, labelnames: tuple[str, ...] | list[str] = ()
+    ) -> Gauge:
+        with self._lock:
+            existing = self._metrics.get(name)
+            if existing is not None:
+                if not isinstance(existing, Gauge):
+                    raise ValueError(f"{name!r} already registered as {type(existing).__name__}")
+                return existing
+            g = Gauge(name, help_text, tuple(labelnames))
+            self._metrics[name] = g
+            return g
+
+    def _instruments(self) -> list[_Instrument]:
+        with self._lock:
+            return list(self._metrics.values())
+
+
+def render_text_format(registry: Registry) -> str:
+    """Render the registry in Prometheus exposition format 0.0.4."""
+    lines: list[str] = []
+    for inst in registry._instruments():
+        lines.append(f"# HELP {inst.name} {inst.help_text}")
+        lines.append(f"# TYPE {inst.name} {inst.type_name}")
+        if isinstance(inst, Counter | Gauge):
+            for labels_tuple, value in inst.collect():
+                ls = _format_labels(inst.labelnames, labels_tuple)
+                lines.append(f"{inst.name}{ls} {_format_number(value)}")
+        elif isinstance(inst, Histogram):
+            for labels_tuple, hist in inst.collect():
+                # `observe` already increments every bucket where v <= upper,
+                # so bucket_counts are cumulative-by-construction. Render
+                # each bucket's count verbatim.
+                base_labels = tuple(zip(inst.labelnames, labels_tuple, strict=True))
+                for upper, count_at in zip(inst.buckets, hist.bucket_counts, strict=True):
+                    bucket_labels = (*base_labels, ("le", _format_number(upper)))
+                    bls = (
+                        "{"
+                        + ",".join(f'{k}="{_format_label_value(v)}"' for k, v in bucket_labels)
+                        + "}"
+                    )
+                    lines.append(f"{inst.name}_bucket{bls} {count_at}")
+                # +Inf bucket = total count
+                inf_labels = (*base_labels, ("le", "+Inf"))
+                ibls = (
+                    "{" + ",".join(f'{k}="{_format_label_value(v)}"' for k, v in inf_labels) + "}"
+                )
+                lines.append(f"{inst.name}_bucket{ibls} {hist.count}")
+                ls = _format_labels(inst.labelnames, labels_tuple)
+                lines.append(f"{inst.name}_count{ls} {hist.count}")
+                lines.append(f"{inst.name}_sum{ls} {_format_number(hist.sum)}")
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+_DEFAULT_REGISTRY: Registry | None = None
+_DEFAULT_REGISTRY_LOCK = threading.Lock()
+
+
+def default_registry() -> Registry:
+    """Process-wide singleton registry. The API + workers share it."""
+    global _DEFAULT_REGISTRY
+    with _DEFAULT_REGISTRY_LOCK:
+        if _DEFAULT_REGISTRY is None:
+            _DEFAULT_REGISTRY = Registry()
+        return _DEFAULT_REGISTRY
+
+
+__all__ = [
+    "Counter",
+    "Gauge",
+    "Histogram",
+    "Registry",
+    "default_registry",
+    "render_text_format",
+]

--- a/tests/observability/conftest.py
+++ b/tests/observability/conftest.py
@@ -1,0 +1,118 @@
+"""Shared fixtures for the observability test suite.
+
+Pattern mirrors tests/api/conftest.py — build a FastAPI app via
+``create_app`` then attach ``dependency_overrides`` for the ops router's
+deps so /ops/status + /ops/metrics resolve against in-memory test
+fixtures without contacting real Qdrant / TEI / Ollama.
+"""
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import AnyHttpUrl, SecretStr
+
+from musubi.api.app import create_app
+from musubi.api.dependencies import get_qdrant_client, get_settings_dep
+from musubi.settings import Settings
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    from qdrant_client import QdrantClient
+
+
+@pytest.fixture
+def obs_settings(tmp_path: Path) -> Settings:
+    return Settings.model_validate(
+        {
+            "qdrant_host": "qdrant",
+            "qdrant_api_key": SecretStr("test-qdrant-key"),
+            "tei_dense_url": AnyHttpUrl("http://tei-dense.test"),
+            "tei_sparse_url": AnyHttpUrl("http://tei-sparse.test"),
+            "tei_reranker_url": AnyHttpUrl("http://tei-reranker.test"),
+            "ollama_url": AnyHttpUrl("http://ollama.test"),
+            "embedding_model": "BAAI/bge-m3",
+            "sparse_model": "naver/splade-v3",
+            "reranker_model": "BAAI/bge-reranker-v2-m3",
+            "llm_model": "qwen2.5:7b-instruct-q4_K_M",
+            "vault_path": tmp_path / "vault",
+            "artifact_blob_path": tmp_path / "artifacts",
+            "lifecycle_sqlite_path": tmp_path / "lifecycle.sqlite",
+            "log_dir": tmp_path / "logs",
+            "jwt_signing_key": SecretStr("a-very-long-test-signing-key-for-hs256-tokens-32+bytes"),
+            "oauth_authority": AnyHttpUrl("https://auth.example.test"),
+        }
+    )
+
+
+@pytest.fixture
+def obs_qdrant() -> Iterator[QdrantClient]:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        client = QdrantClient(":memory:")
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+@pytest.fixture
+def obs_app(
+    obs_settings: Settings,
+    obs_qdrant: QdrantClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[TestClient]:
+    """A TestClient over `create_app` with /ops/* deps wired to in-memory
+    fixtures + every TEI/Ollama probe stubbed to a 200 OK transport."""
+    from musubi.api.routers import ops as ops_router_mod
+    from musubi.config import get_settings as _get_settings
+    from musubi.observability import health as health_mod
+
+    # /ops/status pulls Settings via musubi.config.get_settings(); patch
+    # the cached accessor for the duration of the test.
+    _get_settings.cache_clear()
+    monkeypatch.setattr("musubi.config.get_settings", lambda: obs_settings)
+    monkeypatch.setattr("musubi.api.routers.ops.get_settings", lambda: obs_settings)
+
+    # Health probes — replace the import the router holds.
+    real_check = health_mod.check_component_health
+
+    def _faked_check(
+        *,
+        name: str,
+        url: str,
+        transport: object | None = None,
+        timeout: float = 1.5,
+    ) -> object:
+        ok_transport = httpx.MockTransport(lambda r: httpx.Response(200, json={"status": "ok"}))
+        return real_check(name=name, url=url, transport=ok_transport, timeout=timeout)
+
+    monkeypatch.setattr(ops_router_mod, "check_component_health", _faked_check)
+
+    app = create_app(settings=obs_settings)
+    app.dependency_overrides[get_qdrant_client] = lambda: obs_qdrant
+    app.dependency_overrides[get_settings_dep] = lambda: obs_settings
+
+    with TestClient(app) as c:
+        yield c
+
+    _get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_middleware_state() -> Iterator[None]:
+    """Same isolation pattern the api/ suite uses — reset rate-limit +
+    idempotency between tests so create_app() is fresh."""
+    from musubi.api.idempotency import _GLOBAL_CACHE
+    from musubi.api.rate_limit import _GLOBAL_LIMITER
+
+    _GLOBAL_LIMITER.reset_for_test()
+    _GLOBAL_CACHE._entries.clear()
+    yield
+    _GLOBAL_LIMITER.reset_for_test()
+    _GLOBAL_CACHE._entries.clear()

--- a/tests/observability/test_alerts.py
+++ b/tests/observability/test_alerts.py
@@ -1,0 +1,134 @@
+"""Test contract for the alerts surface in
+[[09-operations/alerts]].
+
+Closure plan:
+
+- bullets 1-3 + 5-6 (alert/runbook/dashboard hygiene checks against the
+  shipped YAML/JSON files) → passing
+- bullet 4 (chaos-drill integration: kill Qdrant; expect ``qdrant_down``
+  within 3m) → declared out-of-scope in the slice work log; needs a
+  live Prometheus + Alertmanager loop. The unit-form tests verify the
+  rule shape; the live timing is the contract-test layer's job.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEPLOY = _REPO_ROOT / "deploy"
+_ALERTS_FILE = _DEPLOY / "grafana" / "alerts" / "musubi-alerts.yml"
+_ALERTMANAGER_FILE = _DEPLOY / "prometheus" / "alertmanager.yml"
+_OVERVIEW_DASHBOARD = _DEPLOY / "grafana" / "dashboards" / "musubi-overview.json"
+
+
+def _load_alert_rules() -> list[dict[str, object]]:
+    cfg = yaml.safe_load(_ALERTS_FILE.read_text())
+    rules: list[dict[str, object]] = []
+    for group in cfg.get("groups", []):
+        for rule in group.get("rules", []):
+            if "alert" in rule:
+                rules.append(rule)
+    return rules
+
+
+def test_every_push_alert_has_linked_runbook() -> None:
+    """Bullet 1 — every alert with severity=push has a runbook URL."""
+    push_alerts = [
+        r for r in _load_alert_rules()
+        if r.get("labels", {}).get("severity") == "push"
+    ]
+    assert push_alerts, "expected at least one push-severity alert"
+    for rule in push_alerts:
+        annotations = rule.get("annotations", {})
+        assert "runbook" in annotations, (
+            f"push alert {rule['alert']!r} has no runbook annotation"
+        )
+        assert annotations["runbook"].startswith("http"), (
+            f"push alert {rule['alert']!r} runbook is not a URL"
+        )
+
+
+def test_every_alert_has_for_clause_to_dedupe_flaps() -> None:
+    """Bullet 2 — every alert has a ``for:`` clause so single-tick
+    blips don't fire pages."""
+    for rule in _load_alert_rules():
+        assert "for" in rule, f"alert {rule['alert']!r} has no for: clause"
+
+
+def test_alertmanager_config_loads_without_error() -> None:
+    """Bullet 3 — the Alertmanager config file is syntactically valid YAML
+    + has the ntfy + email receivers the spec calls out."""
+    cfg = yaml.safe_load(_ALERTMANAGER_FILE.read_text())
+    assert "route" in cfg
+    receiver_names = {r["name"] for r in cfg.get("receivers", [])}
+    assert "ntfy" in receiver_names
+    assert "email" in receiver_names
+
+
+@pytest.mark.skip(reason="out-of-scope in slice work log: chaos-drill timing requires live Prometheus + Alertmanager loop; deferred to musubi-contract-tests per ADR-0011")
+def test_chaos_drill_qdrant_down_fires_within_3m() -> None:
+    """Bullet 4 — placeholder."""
+
+
+def test_backup_failure_alert_fires_after_24h_gap() -> None:
+    """Bullet 5 — surface form: the rule exists with the documented
+    24h ``for:`` window. Live firing is the chaos-drill bullet's job."""
+    backup = next(
+        (r for r in _load_alert_rules() if r["alert"] == "backup_failure_24h"), None
+    )
+    assert backup is not None, "backup_failure_24h alert is missing"
+    assert backup.get("for") == "24h"
+
+
+def test_silent_alerts_still_show_on_dashboard() -> None:
+    """Bullet 6 — the silent thresholds the spec lists ('Single retrieval > 5s',
+    'dedup rate > 30%', 'thought history search miss') surface as
+    overview-board panels even though they don't alert. Surface-form
+    check: the overview dashboard has at least one panel referencing
+    each silent metric."""
+    cfg = json.loads(_OVERVIEW_DASHBOARD.read_text())
+    panels_text = json.dumps(cfg["panels"])
+    # Silent thresholds map to dashboard tiles per the spec.
+    assert "musubi_retrieve_duration_ms" in panels_text
+    assert "musubi_capture_dedup_total" in panels_text
+
+
+# ---------------------------------------------------------------------------
+# Coverage tests — alerts hygiene beyond the contract bullets.
+# ---------------------------------------------------------------------------
+
+
+def test_every_alert_has_summary_annotation() -> None:
+    """Alertmanager templates expect a ``summary`` annotation; verify
+    every alert ships one."""
+    for rule in _load_alert_rules():
+        assert "summary" in rule.get("annotations", {}), (
+            f"alert {rule['alert']!r} missing summary"
+        )
+
+
+def test_alertmanager_routes_push_severity_to_ntfy() -> None:
+    cfg = yaml.safe_load(_ALERTMANAGER_FILE.read_text())
+    routes = cfg["route"].get("routes", [])
+    push_routes = [
+        r for r in routes
+        if any('severity="push"' in m for m in r.get("matchers", []))
+    ]
+    assert push_routes, "no push-routing rule found in alertmanager config"
+    assert push_routes[0]["receiver"] == "ntfy"
+
+
+def test_alertmanager_routes_email_severity_to_email() -> None:
+    cfg = yaml.safe_load(_ALERTMANAGER_FILE.read_text())
+    routes = cfg["route"].get("routes", [])
+    email_routes = [
+        r for r in routes
+        if any('severity="email"' in m for m in r.get("matchers", []))
+    ]
+    assert email_routes, "no email-routing rule found in alertmanager config"
+    assert email_routes[0]["receiver"] == "email"

--- a/tests/observability/test_alerts.py
+++ b/tests/observability/test_alerts.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 import yaml
@@ -26,9 +27,9 @@ _ALERTMANAGER_FILE = _DEPLOY / "prometheus" / "alertmanager.yml"
 _OVERVIEW_DASHBOARD = _DEPLOY / "grafana" / "dashboards" / "musubi-overview.json"
 
 
-def _load_alert_rules() -> list[dict[str, object]]:
+def _load_alert_rules() -> list[dict[str, Any]]:
     cfg = yaml.safe_load(_ALERTS_FILE.read_text())
-    rules: list[dict[str, object]] = []
+    rules: list[dict[str, Any]] = []
     for group in cfg.get("groups", []):
         for rule in group.get("rules", []):
             if "alert" in rule:
@@ -38,16 +39,11 @@ def _load_alert_rules() -> list[dict[str, object]]:
 
 def test_every_push_alert_has_linked_runbook() -> None:
     """Bullet 1 — every alert with severity=push has a runbook URL."""
-    push_alerts = [
-        r for r in _load_alert_rules()
-        if r.get("labels", {}).get("severity") == "push"
-    ]
+    push_alerts = [r for r in _load_alert_rules() if r.get("labels", {}).get("severity") == "push"]
     assert push_alerts, "expected at least one push-severity alert"
     for rule in push_alerts:
         annotations = rule.get("annotations", {})
-        assert "runbook" in annotations, (
-            f"push alert {rule['alert']!r} has no runbook annotation"
-        )
+        assert "runbook" in annotations, f"push alert {rule['alert']!r} has no runbook annotation"
         assert annotations["runbook"].startswith("http"), (
             f"push alert {rule['alert']!r} runbook is not a URL"
         )
@@ -70,7 +66,9 @@ def test_alertmanager_config_loads_without_error() -> None:
     assert "email" in receiver_names
 
 
-@pytest.mark.skip(reason="out-of-scope in slice work log: chaos-drill timing requires live Prometheus + Alertmanager loop; deferred to musubi-contract-tests per ADR-0011")
+@pytest.mark.skip(
+    reason="out-of-scope in slice work log: chaos-drill timing requires live Prometheus + Alertmanager loop; deferred to musubi-contract-tests per ADR-0011"
+)
 def test_chaos_drill_qdrant_down_fires_within_3m() -> None:
     """Bullet 4 — placeholder."""
 
@@ -78,9 +76,7 @@ def test_chaos_drill_qdrant_down_fires_within_3m() -> None:
 def test_backup_failure_alert_fires_after_24h_gap() -> None:
     """Bullet 5 — surface form: the rule exists with the documented
     24h ``for:`` window. Live firing is the chaos-drill bullet's job."""
-    backup = next(
-        (r for r in _load_alert_rules() if r["alert"] == "backup_failure_24h"), None
-    )
+    backup = next((r for r in _load_alert_rules() if r["alert"] == "backup_failure_24h"), None)
     assert backup is not None, "backup_failure_24h alert is missing"
     assert backup.get("for") == "24h"
 
@@ -107,18 +103,13 @@ def test_every_alert_has_summary_annotation() -> None:
     """Alertmanager templates expect a ``summary`` annotation; verify
     every alert ships one."""
     for rule in _load_alert_rules():
-        assert "summary" in rule.get("annotations", {}), (
-            f"alert {rule['alert']!r} missing summary"
-        )
+        assert "summary" in rule.get("annotations", {}), f"alert {rule['alert']!r} missing summary"
 
 
 def test_alertmanager_routes_push_severity_to_ntfy() -> None:
     cfg = yaml.safe_load(_ALERTMANAGER_FILE.read_text())
     routes = cfg["route"].get("routes", [])
-    push_routes = [
-        r for r in routes
-        if any('severity="push"' in m for m in r.get("matchers", []))
-    ]
+    push_routes = [r for r in routes if any('severity="push"' in m for m in r.get("matchers", []))]
     assert push_routes, "no push-routing rule found in alertmanager config"
     assert push_routes[0]["receiver"] == "ntfy"
 
@@ -127,8 +118,7 @@ def test_alertmanager_routes_email_severity_to_email() -> None:
     cfg = yaml.safe_load(_ALERTMANAGER_FILE.read_text())
     routes = cfg["route"].get("routes", [])
     email_routes = [
-        r for r in routes
-        if any('severity="email"' in m for m in r.get("matchers", []))
+        r for r in routes if any('severity="email"' in m for m in r.get("matchers", []))
     ]
     assert email_routes, "no email-routing rule found in alertmanager config"
     assert email_routes[0]["receiver"] == "email"

--- a/tests/observability/test_observability.py
+++ b/tests/observability/test_observability.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from pathlib import Path
 from typing import Any
 
@@ -34,9 +33,6 @@ import pytest
 from fastapi.testclient import TestClient
 
 from musubi.observability import (
-    Counter,
-    Gauge,
-    Histogram,
     Registry,
     StructuredJsonFormatter,
     check_component_health,
@@ -46,7 +42,6 @@ from musubi.observability import (
     request_id_var,
 )
 
-
 # ---------------------------------------------------------------------------
 # Registry primitives — unit tests for the in-process metrics layer
 # ---------------------------------------------------------------------------
@@ -54,7 +49,9 @@ from musubi.observability import (
 
 def test_counter_increments_and_renders_text_format() -> None:
     reg = Registry()
-    c = reg.counter("musubi_capture_total", "captures by namespace + plane", labelnames=["namespace", "plane"])
+    c = reg.counter(
+        "musubi_capture_total", "captures by namespace + plane", labelnames=["namespace", "plane"]
+    )
     c.labels(namespace="eric/x/episodic", plane="episodic").inc()
     c.labels(namespace="eric/x/episodic", plane="episodic").inc()
     c.labels(namespace="eric/y/episodic", plane="episodic").inc()
@@ -133,10 +130,7 @@ def test_every_endpoint_emits_request_counter() -> None:
     client.get("/v1/probe-ok")
     client.get("/v1/probe-ok")
     text = render_text_format(reg)
-    assert (
-        'musubi_http_requests_total{endpoint="/v1/probe-ok",method="GET",status="200"} 2'
-        in text
-    )
+    assert 'musubi_http_requests_total{endpoint="/v1/probe-ok",method="GET",status="200"} 2' in text
 
 
 def test_every_endpoint_emits_latency_histogram() -> None:
@@ -145,10 +139,7 @@ def test_every_endpoint_emits_latency_histogram() -> None:
     client = TestClient(app, raise_server_exceptions=False)
     client.get("/v1/probe-ok")
     text = render_text_format(reg)
-    assert (
-        'musubi_http_request_duration_ms_count{endpoint="/v1/probe-ok",method="GET"} 1'
-        in text
-    )
+    assert 'musubi_http_request_duration_ms_count{endpoint="/v1/probe-ok",method="GET"} 1' in text
 
 
 def test_errors_increment_errors_total() -> None:
@@ -218,12 +209,16 @@ def test_log_line_never_contains_raw_token() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skip(reason="deferred to slice-sdk-py-otel-spans: opentelemetry-api opt-in per spec; cross-slice ticket _inbox/cross-slice/slice-sdk-py-otel-spans.md")
+@pytest.mark.skip(
+    reason="deferred to slice-sdk-py-otel-spans: opentelemetry-api opt-in per spec; cross-slice ticket _inbox/cross-slice/slice-sdk-py-otel-spans.md"
+)
 def test_otel_span_covers_retrieve_orchestration() -> None:
     """Bullet 6 — placeholder."""
 
 
-@pytest.mark.skip(reason="deferred to slice-ops-observability-slice-lifecycle-job-emit: lifecycle ledger is forbidden_paths for this slice; cross-slice ticket tracks the worker-side emit")
+@pytest.mark.skip(
+    reason="deferred to slice-ops-observability-slice-lifecycle-job-emit: lifecycle ledger is forbidden_paths for this slice; cross-slice ticket tracks the worker-side emit"
+)
 def test_lifecycle_job_start_end_emitted_to_events_table() -> None:
     """Bullet 7 — placeholder."""
 
@@ -233,7 +228,9 @@ def test_lifecycle_job_start_end_emitted_to_events_table() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skip(reason="out-of-scope in slice work log: needs live Grafana to load dashboard JSON; deferred to musubi-contract-tests per ADR-0011")
+@pytest.mark.skip(
+    reason="out-of-scope in slice work log: needs live Grafana to load dashboard JSON; deferred to musubi-contract-tests per ADR-0011"
+)
 def test_dashboard_json_loads_in_grafana() -> None:
     """Bullet 8 — placeholder."""
 
@@ -244,9 +241,7 @@ def test_dashboard_json_loads_in_grafana() -> None:
 
 
 def test_check_component_health_marks_reachable_service_healthy() -> None:
-    transport = httpx.MockTransport(
-        lambda r: httpx.Response(200, json={"status": "ok"})
-    )
+    transport = httpx.MockTransport(lambda r: httpx.Response(200, json={"status": "ok"}))
     component = check_component_health(
         name="tei-dense",
         url="http://tei-dense.local/health",
@@ -271,9 +266,7 @@ def test_check_component_health_marks_unreachable_service_unhealthy() -> None:
 
 
 def test_check_component_health_marks_5xx_unhealthy() -> None:
-    transport = httpx.MockTransport(
-        lambda r: httpx.Response(503, json={"error": "down"})
-    )
+    transport = httpx.MockTransport(lambda r: httpx.Response(503, json={"error": "down"}))
     component = check_component_health(
         name="tei-sparse",
         url="http://tei-sparse.local/health",
@@ -288,30 +281,22 @@ def test_check_component_health_marks_5xx_unhealthy() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_ops_metrics_returns_prometheus_text_format() -> None:
+def test_ops_metrics_returns_prometheus_text_format(obs_app: TestClient) -> None:
     """The router's /ops/metrics serves the live registry in text format."""
     from musubi.observability import default_registry
 
     default_registry().counter("musubi_test_probe_total", "test probe").inc()
-    from musubi.api.app import create_app
-
-    app = create_app()
-    client = TestClient(app)
-    resp = client.get("/v1/ops/metrics")
+    resp = obs_app.get("/v1/ops/metrics")
     assert resp.status_code == 200
     assert "text/plain" in resp.headers["content-type"]
     assert "musubi_test_probe_total" in resp.text
 
 
-def test_ops_status_populates_real_components_per_aoi_review() -> None:
+def test_ops_status_populates_real_components_per_aoi_review(obs_app: TestClient) -> None:
     """The router's /ops/status populates ComponentStatus for every
     declared dependency — the v0.1-review ask from Aoi (per-plane health
     granularity) gets exercised here."""
-    from musubi.api.app import create_app
-
-    app = create_app()
-    client = TestClient(app)
-    resp = client.get("/v1/ops/status")
+    resp = obs_app.get("/v1/ops/status")
     assert resp.status_code == 200
     body = resp.json()
     components = body["components"]
@@ -385,9 +370,9 @@ def test_metrics_middleware_skips_metrics_path_to_avoid_self_probe() -> None:
     client = TestClient(app)
     client.get("/v1/ops/metrics")
     text = render_text_format(reg)
-    assert (
-        'musubi_http_requests_total{endpoint="/v1/ops/metrics"' not in text
-    ), "metrics path must self-skip"
+    assert 'musubi_http_requests_total{endpoint="/v1/ops/metrics"' not in text, (
+        "metrics path must self-skip"
+    )
 
 
 def test_install_metrics_middleware_returns_app() -> None:
@@ -409,8 +394,13 @@ def test_render_text_format_handles_empty_registry() -> None:
 def test_structured_formatter_includes_extra_fields() -> None:
     formatter = StructuredJsonFormatter()
     record = logging.LogRecord(
-        name="musubi.test", level=logging.INFO, pathname=__file__, lineno=0,
-        msg="captured", args=(), exc_info=None,
+        name="musubi.test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=0,
+        msg="captured",
+        args=(),
+        exc_info=None,
     )
     record.namespace = "eric/x/episodic"
     record.object_id = "k" * 27

--- a/tests/observability/test_observability.py
+++ b/tests/observability/test_observability.py
@@ -1,0 +1,523 @@
+"""Test contract for slice-ops-observability.
+
+Implements the bullets from [[09-operations/observability]] § Test
+contract + the metrics/logs/traces surface they describe.
+
+Closure plan:
+
+- bullets 1-5 (per-endpoint metrics + errors + log line shape) → passing
+- bullet 6 (OTel span over retrieve orchestration) → skipped against
+  the existing cross-slice ticket ``slice-sdk-py-otel-spans.md`` —
+  OTel is opt-in per the SDK spec and adding ``opentelemetry-api`` as
+  a hard dep is out of scope for this slice too.
+- bullet 7 (lifecycle job start/end emitted to events table) → skipped
+  against new cross-slice ticket
+  ``slice-ops-observability-slice-lifecycle-job-emit.md``: writing
+  to the lifecycle event ledger touches ``src/musubi/lifecycle/``
+  which is forbidden_paths for this slice. The ledger surface is
+  already proven by slice-lifecycle-* tests; this slice subscribes
+  to it once the lifecycle workers emit on it.
+- bullet 8 (dashboard JSON loads in Grafana) → declared out-of-scope
+  in the slice work log; integration test needs a live Grafana.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from musubi.observability import (
+    Counter,
+    Gauge,
+    Histogram,
+    Registry,
+    StructuredJsonFormatter,
+    check_component_health,
+    install_metrics_middleware,
+    redact_token_filter,
+    render_text_format,
+    request_id_var,
+)
+
+
+# ---------------------------------------------------------------------------
+# Registry primitives — unit tests for the in-process metrics layer
+# ---------------------------------------------------------------------------
+
+
+def test_counter_increments_and_renders_text_format() -> None:
+    reg = Registry()
+    c = reg.counter("musubi_capture_total", "captures by namespace + plane", labelnames=["namespace", "plane"])
+    c.labels(namespace="eric/x/episodic", plane="episodic").inc()
+    c.labels(namespace="eric/x/episodic", plane="episodic").inc()
+    c.labels(namespace="eric/y/episodic", plane="episodic").inc()
+    text = render_text_format(reg)
+    assert "# HELP musubi_capture_total captures by namespace + plane" in text
+    assert "# TYPE musubi_capture_total counter" in text
+    assert 'musubi_capture_total{namespace="eric/x/episodic",plane="episodic"} 2' in text
+    assert 'musubi_capture_total{namespace="eric/y/episodic",plane="episodic"} 1' in text
+
+
+def test_histogram_buckets_and_sum() -> None:
+    reg = Registry()
+    h = reg.histogram(
+        "musubi_capture_duration_ms",
+        "duration",
+        labelnames=["plane"],
+        buckets=(10.0, 50.0, 100.0, 500.0),
+    )
+    h.labels(plane="episodic").observe(5.0)
+    h.labels(plane="episodic").observe(40.0)
+    h.labels(plane="episodic").observe(200.0)
+    text = render_text_format(reg)
+    assert 'musubi_capture_duration_ms_bucket{plane="episodic",le="10"} 1' in text
+    assert 'musubi_capture_duration_ms_bucket{plane="episodic",le="50"} 2' in text
+    assert 'musubi_capture_duration_ms_bucket{plane="episodic",le="+Inf"} 3' in text
+    assert 'musubi_capture_duration_ms_count{plane="episodic"} 3' in text
+    assert 'musubi_capture_duration_ms_sum{plane="episodic"} 245' in text
+
+
+def test_gauge_set_and_render() -> None:
+    reg = Registry()
+    g = reg.gauge("gpu_vram_used_mb", "vram used")
+    g.set(12345.0)
+    text = render_text_format(reg)
+    assert "# TYPE gpu_vram_used_mb gauge" in text
+    assert "gpu_vram_used_mb 12345" in text
+
+
+def test_unlabelled_counter_renders_without_label_block() -> None:
+    reg = Registry()
+    c = reg.counter("musubi_promotion_total", "promotions")
+    c.inc()
+    c.inc()
+    text = render_text_format(reg)
+    assert "musubi_promotion_total 2" in text
+    assert "musubi_promotion_total{" not in text
+
+
+# ---------------------------------------------------------------------------
+# Bullets 1-3 — per-endpoint metrics via middleware
+# ---------------------------------------------------------------------------
+
+
+def _app_with_metrics() -> tuple[Any, Registry]:
+    from fastapi import FastAPI, HTTPException
+
+    app = FastAPI()
+    reg = Registry()
+    install_metrics_middleware(app, registry=reg)
+
+    @app.get("/v1/probe-ok")
+    async def probe_ok() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/v1/probe-err")
+    async def probe_err() -> None:
+        raise HTTPException(status_code=500, detail="boom")
+
+    return app, reg
+
+
+def test_every_endpoint_emits_request_counter() -> None:
+    """Bullet 1 — per-endpoint request counter increments on every call."""
+    app, reg = _app_with_metrics()
+    client = TestClient(app, raise_server_exceptions=False)
+    client.get("/v1/probe-ok")
+    client.get("/v1/probe-ok")
+    text = render_text_format(reg)
+    assert (
+        'musubi_http_requests_total{endpoint="/v1/probe-ok",method="GET",status="200"} 2'
+        in text
+    )
+
+
+def test_every_endpoint_emits_latency_histogram() -> None:
+    """Bullet 2 — per-endpoint latency histogram observes on every call."""
+    app, reg = _app_with_metrics()
+    client = TestClient(app, raise_server_exceptions=False)
+    client.get("/v1/probe-ok")
+    text = render_text_format(reg)
+    assert (
+        'musubi_http_request_duration_ms_count{endpoint="/v1/probe-ok",method="GET"} 1'
+        in text
+    )
+
+
+def test_errors_increment_errors_total() -> None:
+    """Bullet 3 — 5xx responses increment musubi_5xx_total."""
+    app, reg = _app_with_metrics()
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/v1/probe-err")
+    assert resp.status_code == 500
+    text = render_text_format(reg)
+    assert 'musubi_5xx_total{endpoint="/v1/probe-err"} 1' in text
+
+
+# ---------------------------------------------------------------------------
+# Bullets 4-5 — log line shape + safety
+# ---------------------------------------------------------------------------
+
+
+def test_log_line_contains_request_id_for_api_calls(caplog: pytest.LogCaptureFixture) -> None:
+    """Bullet 4 — every API-scoped log line carries the request_id."""
+    formatter = StructuredJsonFormatter()
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    log = logging.getLogger("musubi.test.api")
+    log.addHandler(handler)
+    log.setLevel(logging.INFO)
+
+    token = request_id_var.set("trace-abc-123")
+    try:
+        record = logging.LogRecord(
+            name="musubi.test.api",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=0,
+            msg="captured memory",
+            args=(),
+            exc_info=None,
+        )
+        rendered = formatter.format(record)
+    finally:
+        request_id_var.reset(token)
+    payload = json.loads(rendered)
+    assert payload["request_id"] == "trace-abc-123"
+    assert payload["msg"] == "captured memory"
+    assert payload["level"] == "info"
+    assert "ts" in payload
+
+
+def test_log_line_never_contains_raw_token() -> None:
+    """Bullet 5 — token-shaped strings are scrubbed before emission."""
+    record = logging.LogRecord(
+        name="musubi.test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=0,
+        msg="auth header was Bearer eyJhbGciOiJIUzI1NiJ9.payload.signature",
+        args=(),
+        exc_info=None,
+    )
+    f = redact_token_filter
+    assert f(record) is True  # filter passes the record through
+    assert "eyJhbGciOiJIUzI1NiJ9" not in record.msg
+    assert "[REDACTED]" in record.msg
+
+
+# ---------------------------------------------------------------------------
+# Bullets 6-7 — telemetry surfaces deferred to follow-on slices
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skip(reason="deferred to slice-sdk-py-otel-spans: opentelemetry-api opt-in per spec; cross-slice ticket _inbox/cross-slice/slice-sdk-py-otel-spans.md")
+def test_otel_span_covers_retrieve_orchestration() -> None:
+    """Bullet 6 — placeholder."""
+
+
+@pytest.mark.skip(reason="deferred to slice-ops-observability-slice-lifecycle-job-emit: lifecycle ledger is forbidden_paths for this slice; cross-slice ticket tracks the worker-side emit")
+def test_lifecycle_job_start_end_emitted_to_events_table() -> None:
+    """Bullet 7 — placeholder."""
+
+
+# ---------------------------------------------------------------------------
+# Bullet 8 — integration; out-of-scope per work log
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skip(reason="out-of-scope in slice work log: needs live Grafana to load dashboard JSON; deferred to musubi-contract-tests per ADR-0011")
+def test_dashboard_json_loads_in_grafana() -> None:
+    """Bullet 8 — placeholder."""
+
+
+# ---------------------------------------------------------------------------
+# Component health probes
+# ---------------------------------------------------------------------------
+
+
+def test_check_component_health_marks_reachable_service_healthy() -> None:
+    transport = httpx.MockTransport(
+        lambda r: httpx.Response(200, json={"status": "ok"})
+    )
+    component = check_component_health(
+        name="tei-dense",
+        url="http://tei-dense.local/health",
+        transport=transport,
+    )
+    assert component.healthy is True
+    assert component.name == "tei-dense"
+
+
+def test_check_component_health_marks_unreachable_service_unhealthy() -> None:
+    def boom(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("dns failed")
+
+    transport = httpx.MockTransport(boom)
+    component = check_component_health(
+        name="ollama",
+        url="http://ollama.local/health",
+        transport=transport,
+    )
+    assert component.healthy is False
+    assert "ConnectError" in component.detail
+
+
+def test_check_component_health_marks_5xx_unhealthy() -> None:
+    transport = httpx.MockTransport(
+        lambda r: httpx.Response(503, json={"error": "down"})
+    )
+    component = check_component_health(
+        name="tei-sparse",
+        url="http://tei-sparse.local/health",
+        transport=transport,
+    )
+    assert component.healthy is False
+    assert "503" in component.detail
+
+
+# ---------------------------------------------------------------------------
+# /ops/status + /ops/metrics router wiring
+# ---------------------------------------------------------------------------
+
+
+def test_ops_metrics_returns_prometheus_text_format() -> None:
+    """The router's /ops/metrics serves the live registry in text format."""
+    from musubi.observability import default_registry
+
+    default_registry().counter("musubi_test_probe_total", "test probe").inc()
+    from musubi.api.app import create_app
+
+    app = create_app()
+    client = TestClient(app)
+    resp = client.get("/v1/ops/metrics")
+    assert resp.status_code == 200
+    assert "text/plain" in resp.headers["content-type"]
+    assert "musubi_test_probe_total" in resp.text
+
+
+def test_ops_status_populates_real_components_per_aoi_review() -> None:
+    """The router's /ops/status populates ComponentStatus for every
+    declared dependency — the v0.1-review ask from Aoi (per-plane health
+    granularity) gets exercised here."""
+    from musubi.api.app import create_app
+
+    app = create_app()
+    client = TestClient(app)
+    resp = client.get("/v1/ops/status")
+    assert resp.status_code == 200
+    body = resp.json()
+    components = body["components"]
+    # Must enumerate every dependency the spec calls out.
+    expected = {"qdrant", "tei-dense", "tei-sparse", "tei-reranker", "ollama"}
+    assert expected.issubset(set(components.keys())), (
+        f"expected at least {expected}, got {set(components.keys())}"
+    )
+    # Each component must carry a name + healthy + (possibly empty) detail.
+    for name, c in components.items():
+        assert c["name"] == name
+        assert isinstance(c["healthy"], bool)
+
+
+# ---------------------------------------------------------------------------
+# Coverage tests
+# ---------------------------------------------------------------------------
+
+
+def test_registry_text_format_emits_help_and_type_only_once_per_metric() -> None:
+    reg = Registry()
+    c = reg.counter("foo_total", "foo events", labelnames=["k"])
+    c.labels(k="a").inc()
+    c.labels(k="b").inc()
+    text = render_text_format(reg)
+    assert text.count("# HELP foo_total") == 1
+    assert text.count("# TYPE foo_total counter") == 1
+
+
+def test_structured_json_formatter_includes_logger_name() -> None:
+    formatter = StructuredJsonFormatter()
+    record = logging.LogRecord(
+        name="musubi.api.routers.episodic",
+        level=logging.WARNING,
+        pathname=__file__,
+        lineno=0,
+        msg="rate-limit hit",
+        args=(),
+        exc_info=None,
+    )
+    payload = json.loads(formatter.format(record))
+    assert payload["service"] == "musubi.api.routers.episodic"
+    assert payload["level"] == "warning"
+
+
+def test_redact_token_filter_idempotent() -> None:
+    """Running the filter twice yields the same scrubbed message."""
+    msg = "Authorization: Bearer eyJfoo.bar.baz"
+    record = logging.LogRecord(
+        name="x", level=logging.INFO, pathname=__file__, lineno=0, msg=msg, args=(), exc_info=None
+    )
+    redact_token_filter(record)
+    once = record.msg
+    redact_token_filter(record)
+    assert record.msg == once
+
+
+def test_metrics_middleware_skips_metrics_path_to_avoid_self_probe() -> None:
+    """Hitting /v1/ops/metrics must not increment the request counter
+    for itself (would make the gauge wobble during scrape)."""
+    app, reg = _app_with_metrics()
+
+    from fastapi import FastAPI
+
+    inner: FastAPI = app
+
+    @inner.get("/v1/ops/metrics")
+    async def ops_metrics_route() -> str:
+        return render_text_format(reg)
+
+    client = TestClient(app)
+    client.get("/v1/ops/metrics")
+    text = render_text_format(reg)
+    assert (
+        'musubi_http_requests_total{endpoint="/v1/ops/metrics"' not in text
+    ), "metrics path must self-skip"
+
+
+def test_install_metrics_middleware_returns_app() -> None:
+    """The installer is idempotent — calling it twice keeps the same registry."""
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    reg = Registry()
+    install_metrics_middleware(app, registry=reg)
+    install_metrics_middleware(app, registry=reg)
+    # No exception means the install was idempotent.
+
+
+def test_render_text_format_handles_empty_registry() -> None:
+    reg = Registry()
+    assert render_text_format(reg) == ""
+
+
+def test_structured_formatter_includes_extra_fields() -> None:
+    formatter = StructuredJsonFormatter()
+    record = logging.LogRecord(
+        name="musubi.test", level=logging.INFO, pathname=__file__, lineno=0,
+        msg="captured", args=(), exc_info=None,
+    )
+    record.namespace = "eric/x/episodic"
+    record.object_id = "k" * 27
+    payload = json.loads(formatter.format(record))
+    assert payload["namespace"] == "eric/x/episodic"
+    assert payload["object_id"] == "k" * 27
+
+
+def test_counter_inc_amount_param() -> None:
+    """Counters support inc(n) for batch increments."""
+    reg = Registry()
+    c = reg.counter("batch_total", "batch")
+    c.inc(5)
+    text = render_text_format(reg)
+    assert "batch_total 5" in text
+
+
+def test_histogram_observe_negative_is_recorded_in_low_bucket() -> None:
+    """Negative durations shouldn't happen, but observe defensively."""
+    reg = Registry()
+    h = reg.histogram("dur_ms", "dur", buckets=(10.0, 100.0))
+    h.observe(-1.0)  # treat as 0
+    text = render_text_format(reg)
+    # Counted in every bucket (including the 10-bucket).
+    assert 'dur_ms_bucket{le="10"} 1' in text
+
+
+def test_gauge_inc_dec() -> None:
+    reg = Registry()
+    g = reg.gauge("queue_depth", "depth")
+    g.inc()
+    g.inc()
+    g.dec()
+    text = render_text_format(reg)
+    assert "queue_depth 1" in text
+
+
+def test_check_component_health_marks_4xx_unhealthy() -> None:
+    transport = httpx.MockTransport(lambda r: httpx.Response(404))
+    component = check_component_health(
+        name="weird", url="http://weird.local/health", transport=transport
+    )
+    assert component.healthy is False
+
+
+# ---------------------------------------------------------------------------
+# Deploy/* artifacts — config files exist + load
+# ---------------------------------------------------------------------------
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEPLOY = _REPO_ROOT / "deploy"
+
+
+def test_prometheus_config_loads() -> None:
+    """deploy/prometheus/prometheus.yml parses as YAML + has scrape_configs."""
+    import yaml
+
+    cfg = yaml.safe_load((_DEPLOY / "prometheus" / "prometheus.yml").read_text())
+    assert "scrape_configs" in cfg
+    job_names = {j["job_name"] for j in cfg["scrape_configs"]}
+    assert "musubi-core" in job_names
+    assert "qdrant" in job_names
+
+
+def test_loki_config_loads() -> None:
+    import yaml
+
+    cfg = yaml.safe_load((_DEPLOY / "loki" / "loki.yml").read_text())
+    assert "auth_enabled" in cfg
+
+
+def test_tempo_config_loads() -> None:
+    import yaml
+
+    cfg = yaml.safe_load((_DEPLOY / "tempo" / "tempo.yml").read_text())
+    assert "server" in cfg or "distributor" in cfg or "storage" in cfg
+
+
+def test_grafana_overview_dashboard_loads() -> None:
+    """The musubi-overview dashboard JSON parses as the spec calls out
+    the four boards explicitly."""
+    cfg = json.loads((_DEPLOY / "grafana" / "dashboards" / "musubi-overview.json").read_text())
+    assert "panels" in cfg
+    assert cfg.get("title", "").startswith("Musubi")
+
+
+def test_grafana_latency_dashboard_loads() -> None:
+    cfg = json.loads((_DEPLOY / "grafana" / "dashboards" / "musubi-latency.json").read_text())
+    assert "panels" in cfg
+
+
+def test_grafana_lifecycle_dashboard_loads() -> None:
+    cfg = json.loads((_DEPLOY / "grafana" / "dashboards" / "musubi-lifecycle.json").read_text())
+    assert "panels" in cfg
+
+
+def test_grafana_vault_dashboard_loads() -> None:
+    cfg = json.loads((_DEPLOY / "grafana" / "dashboards" / "musubi-vault.json").read_text())
+    assert "panels" in cfg
+
+
+def test_grafana_datasources_provisioning_loads() -> None:
+    import yaml
+
+    cfg = yaml.safe_load(
+        (_DEPLOY / "grafana" / "provisioning" / "datasources" / "datasources.yml").read_text()
+    )
+    names = {d["name"] for d in cfg["datasources"]}
+    assert {"Prometheus", "Loki"}.issubset(names)


### PR DESCRIPTION
Closes #19.

Draft — work in progress per [docs/architecture/_slices/slice-ops-observability.md](docs/architecture/_slices/slice-ops-observability.md).

Closes the Phase 8 observability gap per [docs/architecture/09-operations/observability.md](docs/architecture/09-operations/observability.md) + [docs/architecture/09-operations/alerts.md](docs/architecture/09-operations/alerts.md):

- New `src/musubi/observability/` module: structured-log JSON formatter, Prometheus metrics registry, OTel tracer setup.
- Wires `src/musubi/api/routers/ops.py` `/ops/status` to populate `StatusResponse.components` with real per-component health (TEI dense / TEI sparse / reranker / Ollama / vector-store / lifecycle-worker) — closes Aoi's v0.1 health-granularity ask for OpenClaw at the same time.
- `/ops/metrics` Prometheus exposition wired to the live registry.
- `deploy/{prometheus,grafana,loki,tempo}/` configs + dashboards + alert rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)