### PR TITLE
feat(ops): slice-ops-first-deploy

### DIFF
--- a/deploy/kong/musubi-prod.yml
+++ b/deploy/kong/musubi-prod.yml
@@ -1,0 +1,79 @@
+_format_version: "3.0"
+_transform: true
+
+services:
+  - name: musubi-core
+    url: http://<musubi-ip>:8100
+    tags: [musubi-prod]
+    retries: 2
+    connect_timeout: 2000
+    write_timeout: 30000
+    read_timeout: 30000
+    routes:
+      - name: musubi-api-v1
+        hosts: ["<musubi-host>"]
+        paths: ["/v1"]
+        protocols: [https]
+        strip_path: false
+        tags: [musubi-prod]
+      - name: musubi-healthz
+        hosts: ["<musubi-host>"]
+        paths: ["/healthz"]
+        protocols: [https]
+        strip_path: false
+        tags: [musubi-prod]
+    plugins:
+      - name: openid-connect
+        tags: [musubi-prod]
+        config:
+          issuer: "https://auth.<homelab-domain>/.well-known/openid-configuration"
+          auth_methods: ["bearer"]
+          audience: ["musubi-api"]
+          scopes_required: ["musubi:access"]
+          upstream_access_token_header: "Authorization"
+      - name: rate-limiting
+        tags: [musubi-prod]
+        config:
+          minute: 300
+          hour: 5000
+          policy: local
+      - name: cors
+        tags: [musubi-prod]
+        config:
+          origins: ["https://claude.ai", "http://localhost:*"]
+          credentials: true
+      - name: file-log
+        tags: [musubi-prod]
+        config:
+          path: /var/log/kong/musubi-api.log
+          reopen: true
+
+  - name: musubi-mcp
+    url: http://<musubi-ip>:8200
+    tags: [musubi-prod]
+    retries: 2
+    connect_timeout: 2000
+    write_timeout: 30000
+    read_timeout: 30000
+    routes:
+      - name: musubi-mcp-http
+        hosts: ["<musubi-host>"]
+        paths: ["/mcp"]
+        protocols: [https]
+        strip_path: false
+        tags: [musubi-prod]
+    plugins:
+      - name: openid-connect
+        tags: [musubi-prod]
+        config:
+          issuer: "https://auth.<homelab-domain>/.well-known/openid-configuration"
+          auth_methods: ["bearer"]
+          audience: ["musubi-mcp"]
+          scopes_required: ["mcp:access"]
+          upstream_access_token_header: "Authorization"
+      - name: rate-limiting
+        tags: [musubi-prod]
+        config:
+          minute: 120
+          hour: 2000
+          policy: local

--- a/deploy/runbooks/first-deploy.md
+++ b/deploy/runbooks/first-deploy.md
@@ -1,0 +1,208 @@
+# First Deploy Runbook
+
+This is the operator procedure for bringing up the first production Musubi
+host. Hostnames and addresses are placeholders; resolve `<musubi-host>`,
+`<musubi-ip>`, `<ansible-host>`, `<kong-gateway>`, and `<homelab-domain>` from
+the local, gitignored operator context before running commands.
+
+## 1. Pre-flight
+
+**Command:**
+
+```bash
+ssh <ansible-host> 'cd ~/Projects/musubi && git switch v2 && git pull --ff-only'
+ssh <musubi-host> 'id && docker --version || true'
+```
+
+**Expected output:** the control node is on `v2`; the target accepts SSH; Docker
+may be absent before bootstrap.
+
+**Failure modes:** if SSH fails, fix operator access or host firewall before
+continuing. If the repo is dirty on the control node, stop and inspect the diff.
+
+**Destructive:** no
+
+## 2. Snapshot target
+
+**Command:**
+
+```bash
+ssh <musubi-host> 'sudo zfs snapshot <pool>/musubi@pre-first-deploy'
+ssh <musubi-host> 'sudo zfs list -t snapshot | grep pre-first-deploy'
+```
+
+**Expected output:** a `pre-first-deploy` snapshot is listed for the target
+dataset.
+
+**Failure modes:** if the host does not use ZFS, take the equivalent hypervisor
+snapshot or disk image and record the snapshot identifier in the deploy notes.
+
+**Destructive:** yes
+
+**Rollback:** use `sudo zfs rollback <pool>/musubi@pre-first-deploy` or restore
+the recorded hypervisor snapshot before retrying the deploy.
+
+## 3. Run ansible playbook
+
+**Command:**
+
+```bash
+cd ~/Projects/musubi
+ansible-galaxy collection install -r deploy/ansible/requirements.yml
+ansible-playbook -i deploy/ansible/inventory.yml deploy/ansible/bootstrap.yml
+ansible-playbook -i deploy/ansible/inventory.yml deploy/ansible/config.yml --ask-vault-pass
+```
+
+**Expected output:** Ansible ends with `failed=0`; `/var/lib/musubi`,
+`/etc/musubi`, Docker, NVIDIA runtime, and vault-templated config exist on the
+target.
+
+**Failure modes:** package failures usually mean apt mirror or NVIDIA repo
+trouble; fix and rerun. Vault failures mean the operator secret source is not
+available on the control node.
+
+**Destructive:** yes
+
+**Rollback:** rerun after fixing idempotent failures, or roll back the host
+snapshot from step 2 if host packages or filesystem state are suspect.
+
+## 4. Bring up compose stack
+
+**Command:**
+
+```bash
+ssh <musubi-host> 'cd /etc/musubi && sudo docker compose --env-file .env.production -f docker-compose.yml config --quiet'
+ssh <musubi-host> 'cd /etc/musubi && sudo docker compose --env-file .env.production -f docker-compose.yml up -d --wait --timeout 300'
+```
+
+**Expected output:** Compose config validates; `qdrant`, all TEI services,
+`ollama`, and `core` report healthy within five minutes on a warm model cache.
+
+**Failure modes:** model cache misses can exceed the warm-cache budget; watch
+`docker compose logs ollama tei-dense tei-sparse tei-reranker`. Config failures
+usually point at missing vault-rendered env values.
+
+**Destructive:** yes
+
+**Rollback:** run `docker compose down`, restore the previous
+`/etc/musubi/docker-compose.yml` and `.env.production`, then retry or roll back
+the host snapshot.
+
+## 5. Install systemd units
+
+**Command:**
+
+```bash
+sudo install -m 0644 deploy/systemd/*.service /etc/systemd/system/
+ssh <musubi-host> 'sudo systemctl daemon-reload && sudo systemctl enable --now musubi-api musubi-lifecycle-worker musubi-vault-sync'
+ssh <musubi-host> 'systemctl --no-pager --failed'
+```
+
+**Expected output:** `systemctl --failed` lists no Musubi services; journal tags
+`musubi-api`, `musubi-lifecycle-worker`, and `musubi-vault-sync` are visible.
+
+**Failure modes:** if a unit fails immediately, inspect
+`journalctl -u <unit> -n 100 --no-pager`. Most first-deploy failures are missing
+environment files or an unstarted Docker service.
+
+**Destructive:** yes
+
+**Rollback:** `sudo systemctl disable --now musubi-api musubi-lifecycle-worker
+musubi-vault-sync` and remove the unit files from `/etc/systemd/system/`.
+
+## 6. Configure Kong
+
+**Command:**
+
+```bash
+deck gateway validate deploy/kong/musubi-prod.yml
+deck gateway sync deploy/kong/musubi-prod.yml
+```
+
+**Expected output:** decK validates the file and reports only intended creates
+or updates for the Musubi `/v1` and `/mcp` routes.
+
+**Failure modes:** validation failures are YAML or plugin-shape problems. Sync
+failures usually mean the Kong admin endpoint or credentials are wrong.
+
+**Destructive:** yes
+
+**Rollback:** `deck gateway diff` against the previous declarative Kong config,
+then sync the previous known-good file.
+
+## 7. TLS certificate
+
+**Command:**
+
+```bash
+deck gateway dump --select-tag musubi-prod
+curl -I https://<musubi-host>/healthz
+```
+
+**Expected output:** Kong serves a valid certificate for `<musubi-host>` and the
+health route reaches Musubi through the gateway.
+
+**Failure modes:** certificate issuance is operator-owned. If DNS-01 or the
+internal CA is not ready, leave Kong route config staged but do not go live.
+
+**Destructive:** no
+
+## 8. Smoke verify
+
+**Command:**
+
+```bash
+MUSUBI_BASE_URL=https://<musubi-host> \
+MUSUBI_TOKEN=<operator-token> \
+deploy/smoke/verify.sh
+```
+
+**Expected output:** every smoke script emits `[PASS]`; the aggregate script
+exits `0`.
+
+**Failure modes:** `[FAIL] component ...` means readiness is degraded. Capture,
+thoughts, or metrics failures identify the surface to inspect next.
+
+**Destructive:** yes
+
+**Rollback:** stop traffic at Kong, keep the stack running for logs, and run the
+specific failing `deploy/smoke/check_*.sh` script after each fix.
+
+## 9. Rollback procedure
+
+**Command:**
+
+```bash
+ssh <kong-gateway> 'deck gateway sync /etc/kong/previous-musubi.yml'
+ssh <musubi-host> 'cd /etc/musubi && sudo docker compose down'
+ssh <musubi-host> 'sudo zfs rollback <pool>/musubi@pre-first-deploy'
+```
+
+**Expected output:** Kong no longer routes to the new Musubi upstream; containers
+are stopped; the target dataset returns to the pre-deploy snapshot.
+
+**Failure modes:** if rollback fails, leave Kong disabled and restore from the
+hypervisor snapshot or backup runbook before accepting traffic.
+
+**Destructive:** yes
+
+**Rollback:** this step is the emergency rollback path; after it succeeds,
+start again from step 1 with the observed failure fixed.
+
+## 10. Go-live checklist
+
+**Command:**
+
+```bash
+curl -fsS https://<musubi-host>/v1/ops/status
+curl -fsS https://<musubi-host>/v1/ops/metrics | head
+```
+
+**Expected output:** `/v1/ops/status` is `ok`; metrics render Prometheus text;
+the dashboard for the production host is green.
+
+**Failure modes:** do not announce go-live until DNS, OAuth client registration,
+TLS, smoke verification, backup target reachability, and observability are all
+green.
+
+**Destructive:** no

--- a/deploy/smoke/check_api.sh
+++ b/deploy/smoke/check_api.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+
+json_get "/v1/ops/health" >/dev/null && pass "api health" || fail "api health"
+
+status_json="$(json_get "/v1/ops/status")"
+STATUS_JSON="$status_json" python3 - <<'PY'
+import json
+import os
+import sys
+
+status = json.loads(os.environ["STATUS_JSON"])
+components = status.get("components", {})
+required = ("qdrant", "tei-dense", "tei-sparse", "tei-reranker", "ollama")
+ok = True
+for name in required:
+    healthy = bool(components.get(name, {}).get("healthy"))
+    if healthy:
+        print(f"[PASS] component {name}")
+    else:
+        print(f"[FAIL] component {name}")
+        ok = False
+sys.exit(0 if ok else 1)
+PY

--- a/deploy/smoke/check_capture.sh
+++ b/deploy/smoke/check_capture.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+
+content="musubi first-deploy smoke capture"
+capture_payload="$(
+  CONTENT="$content" python3 - <<'PY'
+import json
+import os
+
+print(json.dumps({
+    "namespace": os.environ.get("MUSUBI_NAMESPACE", "eric/ops/episodic"),
+    "content": os.environ["CONTENT"],
+    "tags": ["smoke", "first-deploy"],
+    "importance": 5,
+}))
+PY
+)"
+json_post "/v1/memories" "$capture_payload" >/dev/null
+
+retrieve_payload="$(
+  CONTENT="$content" python3 - <<'PY'
+import json
+import os
+
+print(json.dumps({
+    "namespace": os.environ.get("MUSUBI_NAMESPACE", "eric/ops/episodic"),
+    "query_text": os.environ["CONTENT"],
+    "mode": "fast",
+    "limit": 1,
+}))
+PY
+)"
+retrieve_json="$(json_post "/v1/retrieve" "$retrieve_payload")"
+
+if CONTENT="$content" RETRIEVE_JSON="$retrieve_json" python3 - <<'PY'
+import json
+import os
+import sys
+
+expected = os.environ["CONTENT"]
+results = json.loads(os.environ["RETRIEVE_JSON"]).get("results", [])
+sys.exit(0 if any(row.get("content") == expected for row in results) else 1)
+PY
+then
+  pass "capture round trip"
+else
+  fail "capture round trip"
+fi

--- a/deploy/smoke/check_observability.sh
+++ b/deploy/smoke/check_observability.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+
+metrics="$(json_get "/v1/ops/metrics")"
+
+if METRICS="$metrics" python3 - <<'PY'
+import os
+import sys
+
+text = os.environ["METRICS"]
+sys.exit(0 if "# HELP " in text and "# TYPE " in text else 1)
+PY
+then
+  pass "prometheus text"
+else
+  fail "prometheus text"
+fi
+
+if METRICS="$metrics" python3 - <<'PY'
+import os
+import re
+import sys
+
+families = set(re.findall(r"^# HELP ([a-zA-Z_:][a-zA-Z0-9_:]*) ", os.environ["METRICS"], re.M))
+sys.exit(0 if len(families) >= 2 else 1)
+PY
+then
+  pass "metric families"
+else
+  fail "metric families"
+fi

--- a/deploy/smoke/check_thoughts.sh
+++ b/deploy/smoke/check_thoughts.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+
+content="musubi first-deploy smoke thought"
+send_payload="$(
+  CONTENT="$content" python3 - <<'PY'
+import json
+import os
+
+presence = os.environ.get("MUSUBI_PRESENCE", "eric/ops-smoke")
+print(json.dumps({
+    "namespace": os.environ.get("MUSUBI_THOUGHT_NAMESPACE", "eric/ops/thought"),
+    "from_presence": presence,
+    "to_presence": presence,
+    "content": os.environ["CONTENT"],
+    "channel": "smoke",
+    "importance": 5,
+}))
+PY
+)"
+json_post "/v1/thoughts/send" "$send_payload" >/dev/null
+
+check_payload="$(
+  python3 - <<'PY'
+import json
+import os
+
+print(json.dumps({
+    "namespace": os.environ.get("MUSUBI_THOUGHT_NAMESPACE", "eric/ops/thought"),
+    "presence": os.environ.get("MUSUBI_PRESENCE", "eric/ops-smoke"),
+}))
+PY
+)"
+check_json="$(json_post "/v1/thoughts/check" "$check_payload")"
+
+if CONTENT="$content" CHECK_JSON="$check_json" python3 - <<'PY'
+import json
+import os
+import sys
+
+expected = os.environ["CONTENT"]
+items = json.loads(os.environ["CHECK_JSON"]).get("items", [])
+sys.exit(0 if any(item.get("content") == expected for item in items) else 1)
+PY
+then
+  pass "thoughts round trip"
+else
+  fail "thoughts round trip"
+fi

--- a/deploy/smoke/lib.sh
+++ b/deploy/smoke/lib.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MUSUBI_BASE_URL="${MUSUBI_BASE_URL:-http://127.0.0.1:8100}"
+MUSUBI_TOKEN="${MUSUBI_TOKEN:-}"
+MUSUBI_NAMESPACE="${MUSUBI_NAMESPACE:-eric/ops/episodic}"
+MUSUBI_THOUGHT_NAMESPACE="${MUSUBI_THOUGHT_NAMESPACE:-eric/ops/thought}"
+MUSUBI_PRESENCE="${MUSUBI_PRESENCE:-eric/ops-smoke}"
+
+AUTH_ARGS=()
+if [[ -n "$MUSUBI_TOKEN" ]]; then
+  AUTH_ARGS=(-H "Authorization: Bearer ${MUSUBI_TOKEN}")
+fi
+
+pass() {
+  printf '[PASS] %s\n' "$1"
+}
+
+fail() {
+  printf '[FAIL] %s\n' "$1"
+  return 1
+}
+
+json_post() {
+  local path="$1"
+  local payload="$2"
+  curl -fsS "${AUTH_ARGS[@]}" -H "Content-Type: application/json" \
+    -X POST "${MUSUBI_BASE_URL}${path}" --data "$payload"
+}
+
+json_get() {
+  local path="$1"
+  curl -fsS "${AUTH_ARGS[@]}" "${MUSUBI_BASE_URL}${path}"
+}

--- a/deploy/smoke/verify.sh
+++ b/deploy/smoke/verify.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK_DIR="${SMOKE_CHECK_DIR:-$SCRIPT_DIR}"
+checks=(
+  check_api.sh
+  check_capture.sh
+  check_thoughts.sh
+  check_observability.sh
+)
+
+failed=0
+for check in "${checks[@]}"; do
+  if bash "${CHECK_DIR}/${check}"; then
+    :
+  else
+    failed=1
+  fi
+done
+
+exit "$failed"

--- a/deploy/systemd/musubi-api.service
+++ b/deploy/systemd/musubi-api.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Musubi API service
+Requires=docker.service
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=musubi
+Group=musubi
+WorkingDirectory=/opt/musubi/current
+EnvironmentFile=/etc/musubi/.env.production
+ExecStart=/usr/bin/env uv run uvicorn musubi.api.app:create_app --factory --host 127.0.0.1 --port 8100
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=musubi-api
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/musubi-lifecycle-worker.service
+++ b/deploy/systemd/musubi-lifecycle-worker.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Musubi lifecycle worker
+Requires=docker.service
+After=network-online.target docker.service musubi-api.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=musubi
+Group=musubi
+WorkingDirectory=/opt/musubi/current
+EnvironmentFile=/etc/musubi/.env.production
+ExecStart=/usr/bin/env uv run python -m musubi.lifecycle.scheduler
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=musubi-lifecycle-worker
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/musubi-vault-sync.service
+++ b/deploy/systemd/musubi-vault-sync.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Musubi vault sync watcher
+Requires=docker.service
+After=network-online.target docker.service musubi-api.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=musubi
+Group=musubi
+WorkingDirectory=/opt/musubi/current
+EnvironmentFile=/etc/musubi/.env.production
+ExecStart=/usr/bin/env uv run python -m musubi.vault.watcher
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=musubi-vault-sync
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/architecture/09-operations/runbooks.md
+++ b/docs/architecture/09-operations/runbooks.md
@@ -12,6 +12,17 @@ reviewed: false
 
 Step-by-step procedures for each alert and common operator actions. Read-while-half-asleep format: numbered steps, copy-pasteable commands.
 
+## First deploy
+
+The authored first-deploy procedure lives in `deploy/runbooks/first-deploy.md`.
+It binds the Ansible bootstrap, Compose stack, systemd units, Kong route sync,
+TLS handoff, smoke verification, rollback, and go-live checklist into one
+operator-facing sequence.
+
+Success criteria: every step in the first-deploy runbook has an expected-output
+block; `deploy/smoke/verify.sh` exits 0; Kong routes `/v1` and `/mcp`; rollback
+instructions are present for every destructive step.
+
 ## Qdrant down
 
 **Alert:** `qdrant_down` (Qdrant `/healthz` failing for 2m)
@@ -212,6 +223,22 @@ musubi-cli index rebuild --collection musubi_curated --source vault
 
 Never run this on `musubi_episodic` or `musubi_concept` — they are canonical.
 
+## Quarterly game-day drills
+
+Cycle through one operations drill each quarter so recovery paths stay fresh:
+
+1. Q1 — `Qdrant down`: restore a Qdrant snapshot into a scratch environment and
+   verify `/v1/ops/status`.
+2. Q2 — `Restore from snapshot`: run the full restore playbook against a scratch
+   target and execute `deploy/smoke/verify.sh`.
+3. Q3 — `Backup failure 24h`: simulate a missing snapshot target and verify the
+   manual backup path.
+4. Q4 — `First deploy`: rehearse the rollback section from
+   `deploy/runbooks/first-deploy.md` against a disposable VM.
+
+Success criteria: the drill owner records the runbook used, the command log, the
+observed recovery time, and any follow-up Issue before closing the drill.
+
 ## Test contract
 
 **Module under test:** the runbooks (readiness, not code)
@@ -219,4 +246,4 @@ Never run this on `musubi_episodic` or `musubi_concept` — they are canonical.
 1. `test_every_alert_has_a_runbook_section`
 2. `test_runbooks_reference_real_files_and_commands` (lint)
 3. `test_each_runbook_lists_success_criteria`
-4. `test_quarterly_game-day_drills_cycle_through_runbooks`
+4. `test_quarterly_game_day_drills_cycle_through_runbooks`

--- a/docs/architecture/_inbox/locks/slice-ops-first-deploy.lock
+++ b/docs/architecture/_inbox/locks/slice-ops-first-deploy.lock
@@ -1,6 +1,0 @@
----
-slice_id: slice-ops-first-deploy
-owner: codex-gpt5
-claimed: 2026-04-19
-issue: 116
----

--- a/docs/architecture/_inbox/locks/slice-ops-first-deploy.lock
+++ b/docs/architecture/_inbox/locks/slice-ops-first-deploy.lock
@@ -1,0 +1,6 @@
+---
+slice_id: slice-ops-first-deploy
+owner: codex-gpt5
+claimed: 2026-04-19
+issue: 116
+---

--- a/docs/architecture/_slices/slice-ops-first-deploy.md
+++ b/docs/architecture/_slices/slice-ops-first-deploy.md
@@ -3,10 +3,10 @@ title: "Slice: First-deploy runbook + validation"
 slice_id: slice-ops-first-deploy
 section: _slices
 type: slice
-status: in-progress
+status: in-review
 owner: codex-gpt5
 phase: "8 Ops"
-tags: [section/slices, status/in-progress, type/slice, ops, deploy, phase-2]
+tags: [section/slices, status/in-review, type/slice, ops, deploy, phase-2]
 updated: 2026-04-19
 reviewed: false
 depends-on: ["[[_slices/slice-ops-ansible]]", "[[_slices/slice-ops-compose]]", "[[_slices/slice-ops-backup]]", "[[_slices/slice-ops-observability]]"]
@@ -17,7 +17,7 @@ blocks: []
 
 > Authors the step-by-step first-deploy procedure for `musubi.mey.house`, the systemd units + Kong config stitching the shipped Ansible/compose/backup/observability work together, and the post-deploy smoke + verify scripts. Ships the operator runbook; operator (Eric) executes the deploy with the runbook open.
 
-**Phase:** 8 Ops · **Status:** `in-progress` · **Owner:** `codex-gpt5`
+**Phase:** 8 Ops · **Status:** `in-review` · **Owner:** `codex-gpt5`
 
 ## Why this slice exists
 
@@ -186,10 +186,39 @@ Those are operator actions with the runbook open.
 
 - Claimed Issue #116 and flipped slice frontmatter from `ready` to `in-progress`.
 
+### 2026-04-20 00:23 — codex-gpt5 — handoff to in-review
+
+- Shipped the first-deploy runbook, systemd unit templates, smoke verification scripts, Kong decK production config, and mocked smoke-script tests.
+- Added the first-deploy cross-link and quarterly game-day cycle to [[09-operations/runbooks]].
+- Verification: `make check`, `make tc-coverage SLICE=slice-ops-first-deploy`.
+
+| Test Contract bullet | State | Evidence |
+|---|---|---|
+| `test_runbook_has_all_10_sections` | ✓ passing | `tests/ops/test_first_deploy_smoke.py` |
+| `test_runbook_every_command_has_expected_output_block` | ✓ passing | `tests/ops/test_first_deploy_smoke.py` |
+| `test_runbook_mentions_rollback_path_for_every_destructive_step` | ✓ passing | `tests/ops/test_first_deploy_smoke.py` |
+| `test_systemd_unit_api_has_restart_on_failure` | ✓ passing | `tests/ops/test_first_deploy_smoke.py` |
+| `test_systemd_unit_lifecycle_worker_depends_on_docker` | ✓ passing | `tests/ops/test_first_deploy_smoke.py` |
+| `test_systemd_unit_vault_sync_logs_to_journal` | ✓ passing | `tests/ops/test_first_deploy_smoke.py` |
+| `test_check_api_passes_when_all_components_healthy` | ✓ passing | `tests/ops/test_first_deploy_smoke.py` |
+| `test_check_api_fails_when_qdrant_unhealthy` | ✓ passing | `tests/ops/test_first_deploy_smoke.py` |
+| `test_check_capture_round_trip_passes_with_real_response` | ✓ passing | `tests/ops/test_first_deploy_smoke.py` |
+| `test_check_capture_fails_when_content_mismatch` | ✓ passing | `tests/ops/test_first_deploy_smoke.py` |
+| `test_check_thoughts_send_check_roundtrip` | ✓ passing | `tests/ops/test_first_deploy_smoke.py` |
+| `test_check_observability_scrapes_valid_prometheus_text` | ✓ passing | `tests/ops/test_first_deploy_smoke.py` |
+| `test_verify_sh_aggregates_all_checks` | ✓ passing | `tests/ops/test_first_deploy_smoke.py` |
+| `test_verify_sh_exits_non_zero_on_any_failure` | ✓ passing | `tests/ops/test_first_deploy_smoke.py` |
+| `test_kong_config_yaml_parses_via_deck_validate` | ✓ passing | `tests/ops/test_first_deploy_smoke.py` |
+| `test_kong_routes_cover_every_v1_endpoint_family` | ✓ passing | `tests/ops/test_first_deploy_smoke.py` |
+| `test_every_alert_has_a_runbook_section` | ✓ passing | `tests/ops/test_first_deploy_smoke.py` |
+| `test_runbooks_reference_real_files_and_commands` | ✓ passing | `tests/ops/test_first_deploy_smoke.py` |
+| `test_each_runbook_lists_success_criteria` | ✓ passing | `tests/ops/test_first_deploy_smoke.py` |
+| `test_quarterly_game_day_drills_cycle_through_runbooks` | ✓ passing | `tests/ops/test_first_deploy_smoke.py` |
+
 ## Cross-slice tickets opened by this slice
 
 - _(none yet; may open one to slice-api-rate-limits for Kong rate-limit plugin config if the in-app enforcement shape demands it)_
 
 ## PR links
 
-- _(none yet)_
+- [PR #121](https://github.com/ericmey/musubi/pull/121)

--- a/docs/architecture/_slices/slice-ops-first-deploy.md
+++ b/docs/architecture/_slices/slice-ops-first-deploy.md
@@ -3,10 +3,10 @@ title: "Slice: First-deploy runbook + validation"
 slice_id: slice-ops-first-deploy
 section: _slices
 type: slice
-status: ready
-owner: unassigned
+status: in-progress
+owner: codex-gpt5
 phase: "8 Ops"
-tags: [section/slices, status/ready, type/slice, ops, deploy, phase-2]
+tags: [section/slices, status/in-progress, type/slice, ops, deploy, phase-2]
 updated: 2026-04-19
 reviewed: false
 depends-on: ["[[_slices/slice-ops-ansible]]", "[[_slices/slice-ops-compose]]", "[[_slices/slice-ops-backup]]", "[[_slices/slice-ops-observability]]"]
@@ -17,7 +17,7 @@ blocks: []
 
 > Authors the step-by-step first-deploy procedure for `musubi.mey.house`, the systemd units + Kong config stitching the shipped Ansible/compose/backup/observability work together, and the post-deploy smoke + verify scripts. Ships the operator runbook; operator (Eric) executes the deploy with the runbook open.
 
-**Phase:** 8 Ops · **Status:** `ready` · **Owner:** `unassigned`
+**Phase:** 8 Ops · **Status:** `in-progress` · **Owner:** `codex-gpt5`
 
 ## Why this slice exists
 
@@ -181,6 +181,10 @@ Those are operator actions with the runbook open.
 - Phase 2 critical path; binds the shipped ops slices (ansible/compose/backup/observability) into a deterministic first-deploy procedure.
 - Routed to Codex: his track record owns three of the four dependency slices; this is the composition of that body of work.
 - Does NOT execute the deploy — Eric does that with the runbook open. This slice ships the authored procedure + validated scripts + systemd units + post-deploy smoke harness.
+
+### 2026-04-19 23:46 — codex-gpt5 — claimed slice
+
+- Claimed Issue #116 and flipped slice frontmatter from `ready` to `in-progress`.
 
 ## Cross-slice tickets opened by this slice
 

--- a/tests/ops/test_first_deploy_smoke.py
+++ b/tests/ops/test_first_deploy_smoke.py
@@ -15,11 +15,11 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
-import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
 RUNBOOK = ROOT / "deploy" / "runbooks" / "first-deploy.md"
+RUNBOOKS_SPEC = ROOT / "docs" / "architecture" / "09-operations" / "runbooks.md"
 SYSTEMD = ROOT / "deploy" / "systemd"
 SMOKE = ROOT / "deploy" / "smoke"
 KONG = ROOT / "deploy" / "kong" / "musubi-prod.yml"
@@ -36,6 +36,14 @@ RUNBOOK_SECTIONS = (
     "Smoke verify",
     "Rollback procedure",
     "Go-live checklist",
+)
+ALERT_RUNBOOK_SECTIONS = (
+    "Qdrant down",
+    "Core 5xx high",
+    "Vault fs full",
+    "GPU OOM",
+    "Loop detected",
+    "Backup failure 24h",
 )
 
 
@@ -68,9 +76,9 @@ def _runbook_step_blocks() -> list[str]:
 
 
 class _MockMusubi(http.server.BaseHTTPRequestHandler):
-    server: "_MockServer"
+    server: _MockServer
 
-    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+    def log_message(self, format: str, *args: object) -> None:
         return
 
     def _json(self, status: int, payload: dict[str, Any]) -> None:
@@ -89,7 +97,7 @@ class _MockMusubi(http.server.BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(encoded)
 
-    def do_GET(self) -> None:  # noqa: N802
+    def do_GET(self) -> None:
         path = urlparse(self.path).path
         if path == "/v1/ops/health":
             self._json(200, {"status": "ok"})
@@ -122,10 +130,10 @@ class _MockMusubi(http.server.BaseHTTPRequestHandler):
                     (
                         "# HELP musubi_http_requests_total HTTP requests",
                         "# TYPE musubi_http_requests_total counter",
-                        "musubi_http_requests_total{method=\"GET\"} 1",
+                        'musubi_http_requests_total{method="GET"} 1',
                         "# HELP musubi_component_healthy Component readiness",
                         "# TYPE musubi_component_healthy gauge",
-                        "musubi_component_healthy{component=\"qdrant\"} 1",
+                        'musubi_component_healthy{component="qdrant"} 1',
                     )
                 )
                 + "\n",
@@ -133,7 +141,7 @@ class _MockMusubi(http.server.BaseHTTPRequestHandler):
             return
         self._json(404, {"error": {"code": "NOT_FOUND"}})
 
-    def do_POST(self) -> None:  # noqa: N802
+    def do_POST(self) -> None:
         path = urlparse(self.path).path
         length = int(self.headers.get("Content-Length", "0"))
         body = json.loads(self.rfile.read(length) or b"{}")
@@ -200,7 +208,11 @@ def _mock_musubi(
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-        host, port = server.server_address
+        address = server.server_address
+        assert isinstance(address, tuple)
+        host, port = address[:2]
+        assert isinstance(host, str)
+        assert isinstance(port, int)
         yield f"http://{host}:{port}"
     finally:
         server.shutdown()
@@ -361,3 +373,35 @@ def test_kong_routes_cover_every_v1_endpoint_family() -> None:
 
     for family in expected:
         assert any(family == path or family.startswith(path.rstrip("/") + "/") for path in actual)
+
+
+def test_every_alert_has_a_runbook_section() -> None:
+    text = _read(RUNBOOKS_SPEC)
+    for heading in ALERT_RUNBOOK_SECTIONS:
+        assert f"## {heading}" in text
+
+
+def test_runbooks_reference_real_files_and_commands() -> None:
+    text = _read(RUNBOOKS_SPEC)
+    assert "deploy/runbooks/first-deploy.md" in text
+    assert RUNBOOK.exists()
+    assert "docker compose" in text
+    assert "ansible-playbook" in _read(RUNBOOK)
+    assert "deploy/smoke/verify.sh" in _read(RUNBOOK)
+
+
+def test_each_runbook_lists_success_criteria() -> None:
+    first_deploy = _read(RUNBOOK)
+    assert first_deploy.count("**Expected output:**") == len(RUNBOOK_SECTIONS)
+    runbooks = _read(RUNBOOKS_SPEC)
+    for heading in ALERT_RUNBOOK_SECTIONS:
+        section = runbooks.split(f"## {heading}", 1)[1].split("\n## ", 1)[0]
+        lower = section.lower()
+        assert "if" in lower or "confirm" in lower or "verify" in lower
+
+
+def test_quarterly_game_day_drills_cycle_through_runbooks() -> None:
+    text = _read(RUNBOOKS_SPEC)
+    assert "## Quarterly game-day drills" in text
+    for drill in ("Qdrant down", "Restore from snapshot", "Backup failure 24h", "First deploy"):
+        assert drill in text

--- a/tests/ops/test_first_deploy_smoke.py
+++ b/tests/ops/test_first_deploy_smoke.py
@@ -1,0 +1,363 @@
+"""Test contract for slice-ops-first-deploy."""
+
+from __future__ import annotations
+
+import contextlib
+import http.server
+import json
+import re
+import shutil
+import socketserver
+import subprocess
+import threading
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNBOOK = ROOT / "deploy" / "runbooks" / "first-deploy.md"
+SYSTEMD = ROOT / "deploy" / "systemd"
+SMOKE = ROOT / "deploy" / "smoke"
+KONG = ROOT / "deploy" / "kong" / "musubi-prod.yml"
+OPENAPI = ROOT / "openapi.yaml"
+
+RUNBOOK_SECTIONS = (
+    "Pre-flight",
+    "Snapshot target",
+    "Run ansible playbook",
+    "Bring up compose stack",
+    "Install systemd units",
+    "Configure Kong",
+    "TLS certificate",
+    "Smoke verify",
+    "Rollback procedure",
+    "Go-live checklist",
+)
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"missing {path.relative_to(ROOT)}"
+    return path.read_text()
+
+
+def _unit(name: str) -> dict[str, dict[str, str]]:
+    text = _read(SYSTEMD / name)
+    current: str | None = None
+    parsed: dict[str, dict[str, str]] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            current = line[1:-1]
+            parsed[current] = {}
+            continue
+        assert current is not None, line
+        key, value = line.split("=", 1)
+        parsed[current][key] = value
+    return parsed
+
+
+def _runbook_step_blocks() -> list[str]:
+    text = _read(RUNBOOK)
+    return re.split(r"(?m)^## \d+\. ", text)[1:]
+
+
+class _MockMusubi(http.server.BaseHTTPRequestHandler):
+    server: "_MockServer"
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        return
+
+    def _json(self, status: int, payload: dict[str, Any]) -> None:
+        encoded = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def _text(self, status: int, payload: str) -> None:
+        encoded = payload.encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "text/plain; version=0.0.4")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def do_GET(self) -> None:  # noqa: N802
+        path = urlparse(self.path).path
+        if path == "/v1/ops/health":
+            self._json(200, {"status": "ok"})
+            return
+        if path == "/v1/ops/status":
+            components = {
+                name: {"name": name, "healthy": True}
+                for name in ("qdrant", "tei-dense", "tei-sparse", "tei-reranker", "ollama")
+            }
+            if self.server.qdrant_unhealthy:
+                components["qdrant"] = {
+                    "name": "qdrant",
+                    "healthy": False,
+                    "detail": "mock outage",
+                }
+            self._json(
+                200,
+                {
+                    "status": "ok"
+                    if all(component["healthy"] for component in components.values())
+                    else "degraded",
+                    "components": components,
+                },
+            )
+            return
+        if path == "/v1/ops/metrics":
+            self._text(
+                200,
+                "\n".join(
+                    (
+                        "# HELP musubi_http_requests_total HTTP requests",
+                        "# TYPE musubi_http_requests_total counter",
+                        "musubi_http_requests_total{method=\"GET\"} 1",
+                        "# HELP musubi_component_healthy Component readiness",
+                        "# TYPE musubi_component_healthy gauge",
+                        "musubi_component_healthy{component=\"qdrant\"} 1",
+                    )
+                )
+                + "\n",
+            )
+            return
+        self._json(404, {"error": {"code": "NOT_FOUND"}})
+
+    def do_POST(self) -> None:  # noqa: N802
+        path = urlparse(self.path).path
+        length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(length) or b"{}")
+        if path == "/v1/memories":
+            self.server.last_capture = body.get("content", "")
+            self._json(202, {"object_id": "c" * 27, "state": "provisional"})
+            return
+        if path == "/v1/retrieve":
+            content = "wrong content" if self.server.content_mismatch else self.server.last_capture
+            self._json(
+                200,
+                {
+                    "results": [
+                        {
+                            "object_id": "c" * 27,
+                            "score": 1.0,
+                            "plane": "episodic",
+                            "content": content,
+                            "namespace": body.get("namespace", "eric/ops/episodic"),
+                        }
+                    ],
+                    "mode": "fast",
+                    "limit": 1,
+                },
+            )
+            return
+        if path == "/v1/thoughts/send":
+            self.server.last_thought = body.get("content", "")
+            self._json(202, {"object_id": "t" * 27})
+            return
+        if path == "/v1/thoughts/check":
+            self._json(
+                200,
+                {
+                    "items": [
+                        {
+                            "object_id": "t" * 27,
+                            "content": self.server.last_thought,
+                            "from_presence": "eric/ops-smoke",
+                        }
+                    ]
+                },
+            )
+            return
+        self._json(404, {"error": {"code": "NOT_FOUND"}})
+
+
+class _MockServer(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+
+    def __init__(self, qdrant_unhealthy: bool = False, content_mismatch: bool = False) -> None:
+        super().__init__(("127.0.0.1", 0), _MockMusubi)
+        self.qdrant_unhealthy = qdrant_unhealthy
+        self.content_mismatch = content_mismatch
+        self.last_capture = ""
+        self.last_thought = ""
+
+
+@contextlib.contextmanager
+def _mock_musubi(
+    *, qdrant_unhealthy: bool = False, content_mismatch: bool = False
+) -> Iterator[str]:
+    server = _MockServer(qdrant_unhealthy=qdrant_unhealthy, content_mismatch=content_mismatch)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        yield f"http://{host}:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _run_script(script: str, base_url: str, *extra_args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SMOKE / script), *extra_args],
+        cwd=ROOT,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "MUSUBI_BASE_URL": base_url,
+            "MUSUBI_TOKEN": "test-token",
+            "MUSUBI_NAMESPACE": "eric/ops/episodic",
+            "MUSUBI_THOUGHT_NAMESPACE": "eric/ops/thought",
+            "MUSUBI_PRESENCE": "eric/ops-smoke",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_runbook_has_all_10_sections() -> None:
+    text = _read(RUNBOOK)
+    for index, heading in enumerate(RUNBOOK_SECTIONS, start=1):
+        assert f"## {index}. {heading}" in text
+
+
+def test_runbook_every_command_has_expected_output_block() -> None:
+    for block in _runbook_step_blocks():
+        assert "**Command:**" in block
+        assert "**Expected output:**" in block
+        assert "**Failure modes:**" in block
+
+
+def test_runbook_mentions_rollback_path_for_every_destructive_step() -> None:
+    destructive_blocks = [
+        block for block in _runbook_step_blocks() if "**Destructive:** yes" in block
+    ]
+    assert destructive_blocks
+    for block in destructive_blocks:
+        assert "**Rollback:**" in block
+
+
+def test_systemd_unit_api_has_restart_on_failure() -> None:
+    service = _unit("musubi-api.service")["Service"]
+    assert service["Restart"] == "on-failure"
+    assert service["RestartSec"] == "10"
+
+
+def test_systemd_unit_lifecycle_worker_depends_on_docker() -> None:
+    unit = _unit("musubi-lifecycle-worker.service")["Unit"]
+    assert "docker.service" in unit["After"]
+    assert "docker.service" in unit["Requires"]
+
+
+def test_systemd_unit_vault_sync_logs_to_journal() -> None:
+    service = _unit("musubi-vault-sync.service")["Service"]
+    assert service["StandardOutput"] == "journal"
+    assert service["StandardError"] == "journal"
+    assert service["SyslogIdentifier"] == "musubi-vault-sync"
+
+
+def test_check_api_passes_when_all_components_healthy() -> None:
+    with _mock_musubi() as base_url:
+        result = _run_script("check_api.sh", base_url)
+    assert result.returncode == 0, result.stderr
+    assert "[PASS] api health" in result.stdout
+    assert "[PASS] component qdrant" in result.stdout
+
+
+def test_check_api_fails_when_qdrant_unhealthy() -> None:
+    with _mock_musubi(qdrant_unhealthy=True) as base_url:
+        result = _run_script("check_api.sh", base_url)
+    assert result.returncode != 0
+    assert "[FAIL] component qdrant" in result.stdout
+
+
+def test_check_capture_round_trip_passes_with_real_response() -> None:
+    with _mock_musubi() as base_url:
+        result = _run_script("check_capture.sh", base_url)
+    assert result.returncode == 0, result.stderr
+    assert "[PASS] capture round trip" in result.stdout
+
+
+def test_check_capture_fails_when_content_mismatch() -> None:
+    with _mock_musubi(content_mismatch=True) as base_url:
+        result = _run_script("check_capture.sh", base_url)
+    assert result.returncode != 0
+    assert "[FAIL] capture round trip" in result.stdout
+
+
+def test_check_thoughts_send_check_roundtrip() -> None:
+    with _mock_musubi() as base_url:
+        result = _run_script("check_thoughts.sh", base_url)
+    assert result.returncode == 0, result.stderr
+    assert "[PASS] thoughts round trip" in result.stdout
+
+
+def test_check_observability_scrapes_valid_prometheus_text() -> None:
+    with _mock_musubi() as base_url:
+        result = _run_script("check_observability.sh", base_url)
+    assert result.returncode == 0, result.stderr
+    assert "[PASS] prometheus text" in result.stdout
+    assert "[PASS] metric families" in result.stdout
+
+
+def test_verify_sh_aggregates_all_checks() -> None:
+    with _mock_musubi() as base_url:
+        result = _run_script("verify.sh", base_url)
+    assert result.returncode == 0, result.stderr
+    assert "[PASS] api health" in result.stdout
+    assert "[PASS] capture round trip" in result.stdout
+    assert "[PASS] thoughts round trip" in result.stdout
+    assert "[PASS] prometheus text" in result.stdout
+
+
+def test_verify_sh_exits_non_zero_on_any_failure() -> None:
+    with _mock_musubi(qdrant_unhealthy=True) as base_url:
+        result = _run_script("verify.sh", base_url)
+    assert result.returncode != 0
+    assert "[FAIL] component qdrant" in result.stdout
+
+
+def test_kong_config_yaml_parses_via_deck_validate() -> None:
+    config = yaml.safe_load(_read(KONG))
+    assert config["_format_version"]
+    assert "services" in config
+
+    deck = shutil.which("deck")
+    if deck is not None:
+        subprocess.run(
+            [deck, "gateway", "validate", str(KONG)],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+
+def test_kong_routes_cover_every_v1_endpoint_family() -> None:
+    openapi = yaml.safe_load(_read(OPENAPI))
+    expected = {
+        "/" + "/".join(path.strip("/").split("/")[:2])
+        for path in openapi["paths"]
+        if path.startswith("/v1/")
+    }
+    expected.add("/mcp")
+
+    config = yaml.safe_load(_read(KONG))
+    actual: set[str] = set()
+    for service in config["services"]:
+        for route in service.get("routes", []):
+            actual.update(route.get("paths", []))
+
+    for family in expected:
+        assert any(family == path or family.startswith(path.rstrip("/") + "/") for path in actual)


### PR DESCRIPTION
Closes #116.

## Summary
- Adds deploy/runbooks/first-deploy.md with the 10-step first deploy procedure, expected outputs, rollback guidance, and go-live checks.
- Adds deploy/systemd units for api, lifecycle worker, and vault sync.
- Adds deploy/smoke verification scripts plus mocked smoke-script tests.
- Adds deploy/kong/musubi-prod.yml with prod route, OAuth 2.1, and rate-limit plugin scaffolding.
- Cross-links first deploy from docs/architecture/09-operations/runbooks.md.

## Test Contract
| Test Contract bullet | State | Evidence |
|---|---|---|
| test_runbook_has_all_10_sections | ✓ passing | tests/ops/test_first_deploy_smoke.py |
| test_runbook_every_command_has_expected_output_block | ✓ passing | tests/ops/test_first_deploy_smoke.py |
| test_runbook_mentions_rollback_path_for_every_destructive_step | ✓ passing | tests/ops/test_first_deploy_smoke.py |
| test_systemd_unit_api_has_restart_on_failure | ✓ passing | tests/ops/test_first_deploy_smoke.py |
| test_systemd_unit_lifecycle_worker_depends_on_docker | ✓ passing | tests/ops/test_first_deploy_smoke.py |
| test_systemd_unit_vault_sync_logs_to_journal | ✓ passing | tests/ops/test_first_deploy_smoke.py |
| test_check_api_passes_when_all_components_healthy | ✓ passing | tests/ops/test_first_deploy_smoke.py |
| test_check_api_fails_when_qdrant_unhealthy | ✓ passing | tests/ops/test_first_deploy_smoke.py |
| test_check_capture_round_trip_passes_with_real_response | ✓ passing | tests/ops/test_first_deploy_smoke.py |
| test_check_capture_fails_when_content_mismatch | ✓ passing | tests/ops/test_first_deploy_smoke.py |
| test_check_thoughts_send_check_roundtrip | ✓ passing | tests/ops/test_first_deploy_smoke.py |
| test_check_observability_scrapes_valid_prometheus_text | ✓ passing | tests/ops/test_first_deploy_smoke.py |
| test_verify_sh_aggregates_all_checks | ✓ passing | tests/ops/test_first_deploy_smoke.py |
| test_verify_sh_exits_non_zero_on_any_failure | ✓ passing | tests/ops/test_first_deploy_smoke.py |
| test_kong_config_yaml_parses_via_deck_validate | ✓ passing | tests/ops/test_first_deploy_smoke.py |
| test_kong_routes_cover_every_v1_endpoint_family | ✓ passing | tests/ops/test_first_deploy_smoke.py |
| test_every_alert_has_a_runbook_section | ✓ passing | tests/ops/test_first_deploy_smoke.py |
| test_runbooks_reference_real_files_and_commands | ✓ passing | tests/ops/test_first_deploy_smoke.py |
| test_each_runbook_lists_success_criteria | ✓ passing | tests/ops/test_first_deploy_smoke.py |
| test_quarterly_game_day_drills_cycle_through_runbooks | ✓ passing | tests/ops/test_first_deploy_smoke.py |

## Verification
- make check
- make tc-coverage SLICE=slice-ops-first-deploy