### PR TITLE
fix(operator): detect file-owned paths in handoff audit

### DIFF
--- a/.operator/scripts/handoff-audit.py
+++ b/.operator/scripts/handoff-audit.py
@@ -156,13 +156,28 @@ def load_pr(pr_number: int) -> PRInfo:
     )
 
 
-def ensure_branch_fetched(head_ref: str) -> None:
-    """Make sure origin/<head_ref> is up to date locally."""
+def ensure_pr_head_fetched(pr_number: int, head_ref: str) -> str:
+    """Fetch the PR head and return the local ref to audit.
+
+    For merged or deleted branches, `origin/<head_ref>` can be stale or absent.
+    GitHub keeps `refs/pull/<n>/head`, so prefer that authoritative ref and
+    fall back to the branch ref only when the PR ref cannot be fetched.
+    """
+    pr_ref = f"refs/remotes/origin/pr/{pr_number}-head"
+    fetched = subprocess.run(
+        ["git", "fetch", "origin", f"+pull/{pr_number}/head:{pr_ref}"],
+        check=False,
+        capture_output=True,
+    )
+    if fetched.returncode == 0:
+        return pr_ref
+
     subprocess.run(
         ["git", "fetch", "origin", head_ref],
         check=False,
         capture_output=True,
     )
+    return f"origin/{head_ref}"
 
 
 def git_ls_tree(ref: str, path: str = "") -> set[str]:
@@ -177,6 +192,19 @@ def git_ls_tree(ref: str, path: str = "") -> set[str]:
     return {line.strip() for line in out.splitlines() if line.strip()}
 
 
+def git_object_type(ref: str, path: str) -> str | None:
+    """Return git object type for `path` at `ref`, or None if absent."""
+    try:
+        return subprocess.run(
+            ["git", "cat-file", "-t", f"{ref}:{path}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except subprocess.CalledProcessError:
+        return None
+
+
 def git_commits_between(base_ref: str, head_ref: str) -> list[dict]:
     """Return commits reachable from head but not base, as dicts."""
     try:
@@ -185,7 +213,7 @@ def git_commits_between(base_ref: str, head_ref: str) -> list[dict]:
                 "git",
                 "log",
                 "--format=%H%x09%s",
-                f"origin/{base_ref}..origin/{head_ref}",
+                f"origin/{base_ref}..{head_ref}",
             ],
             check=True,
             capture_output=True,
@@ -223,44 +251,46 @@ def _path_is_under(path: str, owns_paths: list[str]) -> bool:
     for raw in owns_paths:
         # normalize: strip leading "./", accept both "src/musubi/x" and "musubi/x"
         o = raw.strip().lstrip("./")
-        # If owns entry ends with .py or is a specific file: exact or prefix match
-        if o.endswith((".py", ".yaml", ".yml")) and (path == o or path.endswith("/" + o)):
+        if path == o or path == "src/" + o:
             return True
-        # If owns entry is a directory: prefix match
         if o.endswith("/") and (path.startswith(o) or path.startswith("src/" + o)):
             return True
-        if not o.endswith("/"):
-            # Treat as prefix regardless
-            if path.startswith(o + "/") or path.startswith("src/" + o + "/"):
-                return True
-            # And loose exact match
-            if path == o or path == "src/" + o:
-                return True
     return False
 
 
 # ---- Checks ------------------------------------------------------------------
 
 
-def check_owns_paths_exist(pr: PRInfo, s: Slice, branch_tree: set[str]) -> CheckResult:
+def check_owns_paths_exist(s: Slice, branch_tree: set[str], head_ref: str) -> CheckResult:
     """Every owns_path file or dir is present in the branch's git tree."""
     missing: list[str] = []
     for raw in s.owns_paths:
         o = raw.strip().lstrip("./")
-        # For specific files: check exact or with src/ prefix
         candidates = [o, f"src/{o}"] if not o.startswith("src/") else [o]
-        if any(o.endswith(ext) for ext in (".py", ".yaml", ".yml")):
-            if not any(c in branch_tree for c in candidates):
-                missing.append(o)
+
+        found = False
+        for candidate in candidates:
+            object_type = git_object_type(head_ref, candidate.rstrip("/"))
+            if object_type == "blob":
+                found = True
+                break
+            if object_type == "tree":
+                prefixes = [f"{candidate.rstrip('/')}/"]
+                if any(any(t.startswith(pre) for t in branch_tree) for pre in prefixes):
+                    found = True
+                    break
+
+        if found:
             continue
-        # Directory: check if ANY file under it exists
-        if o.endswith("/"):
-            o = o.rstrip("/")
-        prefixes = [f"{o}/", f"src/{o}/"]
+
+        # If the path itself is absent, it may still be a directory-like owns
+        # entry omitted from git's tree because only child files are tracked.
+        base_candidates = [candidate.rstrip("/") for candidate in candidates]
+        prefixes = [f"{candidate}/" for candidate in base_candidates]
         if not any(any(t.startswith(pre) for t in branch_tree) for pre in prefixes):
             # No file under this directory → might be a new directory whose
             # creation the agent forgot to commit. Flag as missing.
-            missing.append(f"{o}/ (directory; no files under it)")
+            missing.append(raw)
     if missing:
         return CheckResult(
             "owns_paths_exist",
@@ -387,7 +417,7 @@ def check_merge_state(pr: PRInfo) -> CheckResult:
     )
 
 
-def check_frontmatter_in_review(pr: PRInfo, s: Slice, branch_tree: set[str]) -> CheckResult:
+def check_frontmatter_in_review(s: Slice, branch_tree: set[str], head_ref: str) -> CheckResult:
     """Slice frontmatter on branch tip should be `status: in-review`."""
     slice_rel = str(s.path.relative_to(REPO_ROOT))
     if slice_rel not in branch_tree:
@@ -397,7 +427,7 @@ def check_frontmatter_in_review(pr: PRInfo, s: Slice, branch_tree: set[str]) -> 
             f"slice file not in branch tree: {slice_rel}",
         )
     try:
-        content = _run(["git", "show", f"origin/{pr.head_ref}:{slice_rel}"])
+        content = _run(["git", "show", f"{head_ref}:{slice_rel}"])
     except subprocess.CalledProcessError:
         return CheckResult(
             "frontmatter_in_review",
@@ -491,7 +521,7 @@ def run_audit(pr_number: int) -> int:
     print(f"  draft: {pr.is_draft}  mergeState: {pr.merge_state}")
     print()
 
-    ensure_branch_fetched(pr.head_ref)
+    head_ref = ensure_pr_head_fetched(pr.number, pr.head_ref)
     slices = load_slices()
     for sid, s in slices.items():
         s.issue = load_issues().get(sid) if s.issue is None else s.issue
@@ -517,15 +547,15 @@ def run_audit(pr_number: int) -> int:
     print()
 
     # Branch tree + commits
-    branch_tree = git_ls_tree(f"origin/{pr.head_ref}")
-    commits = git_commits_between(pr.base_ref, pr.head_ref)
+    branch_tree = git_ls_tree(head_ref)
+    commits = git_commits_between(pr.base_ref, head_ref)
 
     results: list[CheckResult] = [
-        check_owns_paths_exist(pr, s, branch_tree),
+        check_owns_paths_exist(s, branch_tree, head_ref),
         check_feat_commit_present(pr, s, commits),
         check_canonical_shape(pr, commits),
         check_merge_state(pr),
-        check_frontmatter_in_review(pr, s, branch_tree),
+        check_frontmatter_in_review(s, branch_tree, head_ref),
         check_pr_body_closes(pr, s),
         check_ci_pass(pr),
     ]

--- a/tests/ops/test_handoff_audit.py
+++ b/tests/ops/test_handoff_audit.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parent.parent.parent / ".operator" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+spec = importlib.util.spec_from_file_location(
+    "handoff_audit",
+    str(SCRIPTS / "handoff-audit.py"),
+)
+assert spec is not None
+assert spec.loader is not None
+handoff_audit = importlib.util.module_from_spec(spec)
+sys.modules["handoff_audit"] = handoff_audit
+spec.loader.exec_module(handoff_audit)
+
+
+def _pr_info() -> Any:
+    return handoff_audit.PRInfo(
+        number=1,
+        head_ref="tools/example",
+        head_sha="abc123",
+        base_ref="v2",
+        title="tools: example",
+        body="Closes #1.",
+        merge_state="CLEAN",
+        is_draft=False,
+        state="OPEN",
+        checks_pass=True,
+        checks_detail="check: pass",
+    )
+
+
+def _slice(owns_paths: list[str]) -> Any:
+    return handoff_audit.Slice(
+        id="slice-example",
+        path=Path("docs/architecture/_slices/slice-example.md"),
+        title="Example",
+        status="in-review",
+        owner="codex-gpt5",
+        phase="8 Ops",
+        depends_on=[],
+        blocks=[],
+        owns_paths=owns_paths,
+        forbidden_paths=[],
+        specs=[],
+    )
+
+
+def test_owns_paths_exist_accepts_file_paths_with_any_extension_or_no_extension() -> None:
+    """Regression: .md, .toml, Makefile, and Dockerfile are files, not dirs."""
+    owned_files = [
+        "deploy/runbooks/first-deploy.md",
+        "pyproject.toml",
+        "Makefile",
+        "Dockerfile",
+    ]
+
+    def object_type(_ref: str, path: str) -> str | None:
+        return "blob" if path in owned_files else None
+
+    with patch("handoff_audit.git_object_type", side_effect=object_type):
+        result = handoff_audit.check_owns_paths_exist(
+            _slice(owned_files),
+            set(owned_files),
+            "origin/pr/1-head",
+        )
+
+    assert result.ok is True
+
+
+def test_owns_paths_exist_reports_missing_file_paths_as_missing_files() -> None:
+    with patch("handoff_audit.git_object_type", return_value=None):
+        result = handoff_audit.check_owns_paths_exist(
+            _slice(["deploy/runbooks/first-deploy.md"]),
+            set(),
+            "origin/pr/1-head",
+        )
+
+    assert result.ok is False
+    assert "deploy/runbooks/first-deploy.md" in result.detail
+    assert "directory; no files under it" not in result.detail
+
+
+def test_path_is_under_matches_specific_files_without_extension_guessing() -> None:
+    owns_paths = ["Makefile", "pyproject.toml", "deploy/runbooks/first-deploy.md"]
+
+    assert handoff_audit._path_is_under("Makefile", owns_paths) is True
+    assert handoff_audit._path_is_under("pyproject.toml", owns_paths) is True
+    assert handoff_audit._path_is_under("deploy/runbooks/first-deploy.md", owns_paths) is True
+    assert handoff_audit._path_is_under("deploy/runbooks/other.md", owns_paths) is False


### PR DESCRIPTION
Fixes the handoff-audit file-owned path detection bug surfaced in .operator/backlog.md.

## Summary
- Fetches PR head refs via refs/pull/<n>/head so merged/deleted branch audits do not depend on stale local branch refs.
- Uses git object type checks to distinguish owned files from owned directories without extension guessing.
- Adds regression tests for .md, .toml, Makefile, and Dockerfile owned paths.

## Verification
- uv run pytest tests/ops/test_handoff_audit.py -q
- uv run python3 .operator/scripts/handoff-audit.py 114
- uv run python3 .operator/scripts/handoff-audit.py 121
- make check