### PR TITLE
fix(lifecycle): emit worker job metrics

### DIFF
--- a/docs/architecture/_inbox/cross-slice/slice-ops-observability-slice-lifecycle-job-emit.md
+++ b/docs/architecture/_inbox/cross-slice/slice-ops-observability-slice-lifecycle-job-emit.md
@@ -4,11 +4,11 @@ section: _inbox/cross-slice
 type: cross-slice
 source_slice: slice-ops-observability
 target_slice: slice-lifecycle-maturation
-status: open
+status: resolved
 opened_by: vscode-cc-sonnet47
 opened_at: 2026-04-19
-tags: [section/inbox-cross-slice, type/cross-slice, status/open]
-updated: 2026-04-19
+tags: [section/inbox-cross-slice, type/cross-slice, status/resolved]
+updated: 2026-04-20
 ---
 
 # Lifecycle workers should emit job start/end metrics
@@ -78,3 +78,7 @@ names — they just won't show data until the workers emit.
   panels render real data on the staging compose stack.
 - `slice-ops-observability` test bullet 7 unskipped + asserts on
   the metric increment.
+
+## Resolution
+
+Resolved by PR: lifecycle maturation, synthesis, promotion, and reflection worker ticks now observe `musubi_lifecycle_job_duration_seconds` and increment `musubi_lifecycle_job_errors_total` on raised errors.

--- a/src/musubi/lifecycle/maturation.py
+++ b/src/musubi/lifecycle/maturation.py
@@ -52,9 +52,11 @@ from __future__ import annotations
 
 import logging
 import sqlite3
-from collections.abc import Sequence
+import time
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
+from functools import wraps
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -64,6 +66,7 @@ from musubi.config import get_settings
 from musubi.lifecycle.events import LifecycleEventSink
 from musubi.lifecycle.scheduler import Job, file_lock
 from musubi.lifecycle.transitions import LineageUpdates, TransitionError, transition
+from musubi.observability import default_registry
 from musubi.types.common import KSUID, Ok, epoch_of, utc_now
 
 log = logging.getLogger(__name__)
@@ -84,6 +87,35 @@ _DEFAULT_LLM_BATCH = 10
 
 _LIFECYCLE_ACTOR = "lifecycle-worker"
 """Actor recorded on every transition this module emits — matches the spec."""
+
+_REG = default_registry()
+_DURATION = _REG.histogram(
+    "musubi_lifecycle_job_duration_seconds",
+    "lifecycle worker tick duration",
+    labelnames=("job",),
+)
+_ERRORS = _REG.counter(
+    "musubi_lifecycle_job_errors_total",
+    "lifecycle worker tick errors",
+    labelnames=("job",),
+)
+
+
+def _instrument_maturation_job[**P, R](
+    func: Callable[P, Awaitable[R]],
+) -> Callable[P, Awaitable[R]]:
+    @wraps(func)
+    async def _wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+        start = time.monotonic()
+        try:
+            return await func(*args, **kwargs)
+        except Exception:
+            _ERRORS.labels(job="maturation").inc()
+            raise
+        finally:
+            _DURATION.labels(job="maturation").observe(time.monotonic() - start)
+
+    return _wrapped
 
 
 # ---------------------------------------------------------------------------
@@ -300,6 +332,7 @@ _CURSOR_NAME_TTL = "provisional_ttl"
 _CURSOR_NAME_DEMOTION = "episodic_demotion"
 
 
+@_instrument_maturation_job
 async def episodic_maturation_sweep(
     *,
     client: QdrantClient,
@@ -485,6 +518,7 @@ async def episodic_maturation_sweep(
 # ---------------------------------------------------------------------------
 
 
+@_instrument_maturation_job
 async def provisional_ttl_sweep(
     *,
     client: QdrantClient,
@@ -547,6 +581,7 @@ async def provisional_ttl_sweep(
 # ---------------------------------------------------------------------------
 
 
+@_instrument_maturation_job
 async def episodic_demotion_sweep(
     *,
     client: QdrantClient,
@@ -594,6 +629,7 @@ async def episodic_demotion_sweep(
     return SweepReport(selected=len(candidates), transitioned=transitioned, failed=failed)
 
 
+@_instrument_maturation_job
 async def concept_maturation_sweep(
     *,
     client: QdrantClient,
@@ -657,6 +693,7 @@ async def concept_maturation_sweep(
     return SweepReport(selected=len(candidates), transitioned=transitioned, failed=failed)
 
 
+@_instrument_maturation_job
 async def concept_demotion_sweep(
     *,
     client: QdrantClient,

--- a/src/musubi/lifecycle/promotion.py
+++ b/src/musubi/lifecycle/promotion.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 import hashlib
 import logging
 import re
+import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from functools import wraps
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -18,6 +21,7 @@ from pydantic import BaseModel, Field, model_validator
 from qdrant_client import QdrantClient, models
 
 from musubi.lifecycle.events import LifecycleEventSink
+from musubi.observability import default_registry
 from musubi.planes.concept.plane import ConceptPlane
 from musubi.planes.curated.plane import CuratedPlane
 from musubi.store.names import collection_for_plane
@@ -31,6 +35,35 @@ log = logging.getLogger(__name__)
 _LIFECYCLE_ACTOR = "lifecycle-worker"
 PROMOTION_REINFORCEMENT_THRESHOLD = 3
 PROMOTION_IMPORTANCE_THRESHOLD = 6
+
+_REG = default_registry()
+_DURATION = _REG.histogram(
+    "musubi_lifecycle_job_duration_seconds",
+    "lifecycle worker tick duration",
+    labelnames=("job",),
+)
+_ERRORS = _REG.counter(
+    "musubi_lifecycle_job_errors_total",
+    "lifecycle worker tick errors",
+    labelnames=("job",),
+)
+
+
+def _instrument_promotion_job[**P, R](
+    func: Callable[P, Awaitable[R]],
+) -> Callable[P, Awaitable[R]]:
+    @wraps(func)
+    async def _wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+        start = time.monotonic()
+        try:
+            return await func(*args, **kwargs)
+        except Exception:
+            _ERRORS.labels(job="promotion").inc()
+            raise
+        finally:
+            _DURATION.labels(job="promotion").observe(time.monotonic() - start)
+
+    return _wrapped
 
 
 class PromotionRender(BaseModel):
@@ -156,6 +189,7 @@ def _is_eligible(concept: SynthesizedConcept, now_epoch: float) -> bool:
     return concept.promoted_to is None
 
 
+@_instrument_promotion_job
 async def run_promotion_sweep(
     deps: PromotionDeps,
     batch_size: int = 1,

--- a/src/musubi/lifecycle/reflection.py
+++ b/src/musubi/lifecycle/reflection.py
@@ -49,15 +49,18 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Iterable
+import time
+from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
+from functools import wraps
 from typing import Any, Protocol
 
 from qdrant_client import QdrantClient, models
 
 from musubi.config import get_settings
 from musubi.lifecycle.events import LifecycleEventSink
+from musubi.observability import default_registry
 from musubi.planes.curated import CuratedPlane
 from musubi.types.common import KSUID, Namespace, generate_ksuid, utc_now
 from musubi.types.curated import CuratedKnowledge
@@ -69,6 +72,35 @@ _DEFAULT_IMPORTANCE = 6
 _LLM_OUTAGE_NOTICE = "> LLM was unavailable at reflection time; patterns section skipped."
 
 _KSUID_RE = re.compile(r"\b[0-9A-Za-z]{27}\b")
+
+_REG = default_registry()
+_DURATION = _REG.histogram(
+    "musubi_lifecycle_job_duration_seconds",
+    "lifecycle worker tick duration",
+    labelnames=("job",),
+)
+_ERRORS = _REG.counter(
+    "musubi_lifecycle_job_errors_total",
+    "lifecycle worker tick errors",
+    labelnames=("job",),
+)
+
+
+def _instrument_reflection_job[**P, R](
+    func: Callable[P, Awaitable[R]],
+) -> Callable[P, Awaitable[R]]:
+    @wraps(func)
+    async def _wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+        start = time.monotonic()
+        try:
+            return await func(*args, **kwargs)
+        except Exception:
+            _ERRORS.labels(job="reflection").inc()
+            raise
+        finally:
+            _DURATION.labels(job="reflection").observe(time.monotonic() - start)
+
+    return _wrapped
 
 
 # ---------------------------------------------------------------------------
@@ -638,6 +670,7 @@ def render_markdown(
 # ---------------------------------------------------------------------------
 
 
+@_instrument_reflection_job
 async def run_reflection_sweep(
     *,
     qdrant: QdrantClient,

--- a/src/musubi/lifecycle/synthesis.py
+++ b/src/musubi/lifecycle/synthesis.py
@@ -7,8 +7,11 @@ from __future__ import annotations
 
 import logging
 import sqlite3
+import time
 from collections import defaultdict
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from functools import wraps
 from pathlib import Path
 from typing import Any, Protocol, cast
 
@@ -16,6 +19,7 @@ from qdrant_client import QdrantClient, models
 
 from musubi.embedding.base import Embedder
 from musubi.lifecycle import LifecycleEventSink
+from musubi.observability import default_registry
 from musubi.planes.concept import ConceptPlane
 from musubi.store.names import collection_for_plane
 from musubi.store.specs import DENSE_VECTOR_NAME
@@ -23,6 +27,36 @@ from musubi.types.concept import SynthesizedConcept
 from musubi.types.episodic import EpisodicMemory
 
 logger = logging.getLogger(__name__)
+
+_REG = default_registry()
+_DURATION = _REG.histogram(
+    "musubi_lifecycle_job_duration_seconds",
+    "lifecycle worker tick duration",
+    labelnames=("job",),
+)
+_ERRORS = _REG.counter(
+    "musubi_lifecycle_job_errors_total",
+    "lifecycle worker tick errors",
+    labelnames=("job",),
+)
+
+
+def _instrument_synthesis_job[**P, R](
+    func: Callable[P, Awaitable[R]],
+) -> Callable[P, Awaitable[R]]:
+    @wraps(func)
+    async def _wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+        start = time.monotonic()
+        try:
+            return await func(*args, **kwargs)
+        except Exception:
+            _ERRORS.labels(job="synthesis").inc()
+            raise
+        finally:
+            _DURATION.labels(job="synthesis").observe(time.monotonic() - start)
+
+    return _wrapped
+
 
 # ---------------------------------------------------------------------------
 # LLM Interface
@@ -211,6 +245,7 @@ class SynthesisReport:
 # ---------------------------------------------------------------------------
 
 
+@_instrument_synthesis_job
 async def synthesis_run(
     client: QdrantClient,
     sink: LifecycleEventSink,

--- a/tests/lifecycle/test_maturation.py
+++ b/tests/lifecycle/test_maturation.py
@@ -57,6 +57,7 @@ from musubi.lifecycle.maturation import (
     normalize_tags,
     provisional_ttl_sweep,
 )
+from musubi.observability import default_registry, render_text_format
 from musubi.planes.episodic import EpisodicPlane
 from musubi.store import bootstrap
 from musubi.types.episodic import EpisodicMemory
@@ -208,6 +209,15 @@ def _config(**overrides: object) -> MaturationConfig:
     }
     base.update(overrides)
     return MaturationConfig(**base)  # type: ignore[arg-type]
+
+
+def _duration_count(job: str) -> int:
+    text = render_text_format(default_registry())
+    prefix = f'musubi_lifecycle_job_duration_seconds_count{{job="{job}"}} '
+    for line in text.splitlines():
+        if line.startswith(prefix):
+            return int(line.removeprefix(prefix))
+    return 0
 
 
 def _read_state(plane: EpisodicPlane, ns: str, object_id: str) -> str | None:
@@ -940,6 +950,16 @@ async def test_concept_maturation_sweep_no_op_when_empty(
 
     report = await concept_maturation_sweep(client=qdrant, sink=sink, config=_config())
     assert report.selected == 0
+
+
+async def test_maturation_worker_observes_lifecycle_job_duration(
+    qdrant: QdrantClient, sink: LifecycleEventSink
+) -> None:
+    from musubi.lifecycle.maturation import concept_maturation_sweep
+
+    before = _duration_count("maturation")
+    await concept_maturation_sweep(client=qdrant, sink=sink, config=_config())
+    assert _duration_count("maturation") == before + 1
 
 
 async def test_concept_demotion_sweep_no_op_when_empty(

--- a/tests/lifecycle/test_promotion.py
+++ b/tests/lifecycle/test_promotion.py
@@ -14,6 +14,7 @@ from qdrant_client import QdrantClient
 from musubi.embedding.fake import FakeEmbedder
 from musubi.lifecycle.events import LifecycleEventSink
 from musubi.lifecycle.promotion import PromotionRender, _is_eligible, compute_path
+from musubi.observability import default_registry, render_text_format
 from musubi.planes.concept.plane import ConceptPlane
 from musubi.planes.curated.plane import CuratedPlane
 from musubi.store.bootstrap import bootstrap
@@ -119,6 +120,15 @@ def _concept(**kwargs: Any) -> SynthesizedConcept:
     }
     d.update(kwargs)
     return SynthesizedConcept(**d)  # type: ignore
+
+
+def _duration_count(job: str) -> int:
+    text = render_text_format(default_registry())
+    prefix = f'musubi_lifecycle_job_duration_seconds_count{{job="{job}"}} '
+    for line in text.splitlines():
+        if line.startswith(prefix):
+            return int(line.removeprefix(prefix))
+    return 0
 
 
 def test_gate_requires_matured_state() -> None:
@@ -341,6 +351,15 @@ async def test_curated_point_upserted_with_promoted_from(deps: Any) -> None:
     )
     assert len(curated_points[0]) == 1
     assert curated_points[0][0].payload["promoted_from"] == str(c.object_id)
+
+
+@pytest.mark.asyncio
+async def test_promotion_worker_observes_lifecycle_job_duration(deps: Any) -> None:
+    from musubi.lifecycle.promotion import run_promotion_sweep
+
+    before = _duration_count("promotion")
+    assert await run_promotion_sweep(deps) == 0
+    assert _duration_count("promotion") == before + 1
 
 
 @pytest.mark.asyncio

--- a/tests/lifecycle/test_reflection.py
+++ b/tests/lifecycle/test_reflection.py
@@ -63,6 +63,7 @@ from musubi.lifecycle.reflection import (
     validate_cited_ids,
     vault_path_for,
 )
+from musubi.observability import default_registry, render_text_format
 from musubi.planes.curated import CuratedPlane
 from musubi.planes.episodic import EpisodicPlane
 from musubi.store import bootstrap
@@ -248,6 +249,15 @@ def _config(**overrides: object) -> ReflectionConfig:
     return ReflectionConfig(**base)  # type: ignore[arg-type]
 
 
+def _duration_count(job: str) -> int:
+    text = render_text_format(default_registry())
+    prefix = f'musubi_lifecycle_job_duration_seconds_count{{job="{job}"}} '
+    for line in text.splitlines():
+        if line.startswith(prefix):
+            return int(line.removeprefix(prefix))
+    return 0
+
+
 async def _run(
     *,
     qdrant: QdrantClient,
@@ -317,6 +327,27 @@ async def test_capture_summary_counts_correct(
     # Body actually says "2 new episodic captures".
     body = vault.writes[-1][2]
     assert "2 new episodic captures" in body or "2 episodic captures" in body
+
+
+async def test_reflection_worker_observes_lifecycle_job_duration(
+    qdrant: QdrantClient,
+    sink: LifecycleEventSink,
+    curated: CuratedPlane,
+    now: datetime,
+    reflection_namespace: str,
+) -> None:
+    before = _duration_count("reflection")
+    await _run(
+        qdrant=qdrant,
+        sink=sink,
+        curated=curated,
+        vault=FakeVaultWriter(),
+        thoughts=FakeThoughtEmitter(),
+        llm=FakeReflectionLLM(available=False),
+        namespace=reflection_namespace,
+        now=now,
+    )
+    assert _duration_count("reflection") == before + 1
 
 
 async def test_patterns_section_parses_llm_output(

--- a/tests/lifecycle/test_synthesis.py
+++ b/tests/lifecycle/test_synthesis.py
@@ -27,6 +27,7 @@ from musubi.lifecycle.synthesis import (
     SynthesisOutput,
     synthesis_run,
 )
+from musubi.observability import default_registry, render_text_format
 from musubi.planes.concept.plane import ConceptPlane
 from musubi.store import bootstrap
 from musubi.store.names import collection_for_plane
@@ -118,6 +119,15 @@ def _ns(base: str, plane: str) -> str:
     return f"{base}/{plane}"
 
 
+def _duration_count(job: str) -> int:
+    text = render_text_format(default_registry())
+    prefix = f'musubi_lifecycle_job_duration_seconds_count{{job="{job}"}} '
+    for line in text.splitlines():
+        if line.startswith(prefix):
+            return int(line.removeprefix(prefix))
+    return 0
+
+
 async def _inject_episodic(
     client: QdrantClient,
     embedder: FakeEmbedder,
@@ -202,6 +212,19 @@ async def test_skips_when_fewer_than_3_new_memories(
     report = await synthesis_run(qdrant, sink, ollama, embedder, cursor, ns)
     assert report.memories_selected == 2
     assert report.clusters_formed == 0
+
+
+async def test_synthesis_worker_observes_lifecycle_job_duration(
+    qdrant: QdrantClient,
+    ns: str,
+    sink: LifecycleEventSink,
+    cursor: SynthesisCursor,
+    embedder: FakeEmbedder,
+) -> None:
+    before = _duration_count("synthesis")
+    report = await synthesis_run(qdrant, sink, FakeSynthesisOllama(), embedder, cursor, ns)
+    assert report.memories_selected == 0
+    assert _duration_count("synthesis") == before + 1
 
 
 async def test_cursor_per_namespace_tracked_separately(

--- a/tests/observability/test_observability.py
+++ b/tests/observability/test_observability.py
@@ -11,12 +11,9 @@ Closure plan:
   OTel is opt-in per the SDK spec and adding ``opentelemetry-api`` as
   a hard dep is out of scope for this slice too.
 - bullet 7 (lifecycle job start/end emitted to events table) → skipped
-  against new cross-slice ticket
-  ``slice-ops-observability-slice-lifecycle-job-emit.md``: writing
-  to the lifecycle event ledger touches ``src/musubi/lifecycle/``
-  which is forbidden_paths for this slice. The ledger surface is
-  already proven by slice-lifecycle-* tests; this slice subscribes
-  to it once the lifecycle workers emit on it.
+  in the observability slice and resolved by cross-slice ticket
+  ``slice-ops-observability-slice-lifecycle-job-emit.md``: lifecycle
+  workers now emit the shared duration + error metric families.
 - bullet 8 (dashboard JSON loads in Grafana) → declared out-of-scope
   in the slice work log; integration test needs a live Grafana.
 """
@@ -25,6 +22,7 @@ from __future__ import annotations
 
 import json
 import logging
+from importlib import import_module
 from pathlib import Path
 from typing import Any
 
@@ -36,6 +34,7 @@ from musubi.observability import (
     Registry,
     StructuredJsonFormatter,
     check_component_health,
+    default_registry,
     install_metrics_middleware,
     redact_token_filter,
     render_text_format,
@@ -216,11 +215,22 @@ def test_otel_span_covers_retrieve_orchestration() -> None:
     """Bullet 6 — placeholder."""
 
 
-@pytest.mark.skip(
-    reason="deferred to slice-ops-observability-slice-lifecycle-job-emit: lifecycle ledger is forbidden_paths for this slice; cross-slice ticket tracks the worker-side emit"
-)
 def test_lifecycle_job_start_end_emitted_to_events_table() -> None:
-    """Bullet 7 — placeholder."""
+    """Bullet 7 — lifecycle workers register job duration + error metrics."""
+    # Importing the worker modules registers the shared metric families.
+    for module in (
+        "musubi.lifecycle.maturation",
+        "musubi.lifecycle.promotion",
+        "musubi.lifecycle.reflection",
+        "musubi.lifecycle.synthesis",
+    ):
+        import_module(module)
+
+    text = render_text_format(default_registry())
+    assert "# HELP musubi_lifecycle_job_duration_seconds lifecycle worker tick duration" in text
+    assert "# TYPE musubi_lifecycle_job_duration_seconds histogram" in text
+    assert "# HELP musubi_lifecycle_job_errors_total lifecycle worker tick errors" in text
+    assert "# TYPE musubi_lifecycle_job_errors_total counter" in text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Cross-slice: docs/architecture/_inbox/cross-slice/slice-ops-observability-slice-lifecycle-job-emit.md

## Summary
- Wraps maturation, synthesis, promotion, and reflection worker ticks with lifecycle duration/error metrics.
- Adds one registry-observation assertion per worker family.
- Unskips observability Test Contract bullet 7 and resolves the cross-slice ticket.

## Verification
- uv run pytest tests/lifecycle/test_maturation.py::test_maturation_worker_observes_lifecycle_job_duration tests/lifecycle/test_synthesis.py::test_synthesis_worker_observes_lifecycle_job_duration tests/lifecycle/test_promotion.py::test_promotion_worker_observes_lifecycle_job_duration tests/lifecycle/test_reflection.py::test_reflection_worker_observes_lifecycle_job_duration tests/observability/test_observability.py::test_lifecycle_job_start_end_emitted_to_events_table -q
- uv run pytest tests/lifecycle/test_maturation.py tests/lifecycle/test_synthesis.py tests/lifecycle/test_promotion.py tests/lifecycle/test_reflection.py tests/observability/test_observability.py -q
- make check
- make agent-check 2>&1 | grep "^  ✗"