### PR TITLE
fix(artifact): tokenizer wiring for chunkers (rescue finish for Codex)

### DIFF
--- a/docs/architecture/_inbox/cross-slice/slice-plane-artifact-tokenizer.md
+++ b/docs/architecture/_inbox/cross-slice/slice-plane-artifact-tokenizer.md
@@ -2,10 +2,37 @@
 title: "Cross-slice: Tokenizer wiring for artifact chunkers"
 section: _inbox/cross-slice
 type: cross-slice
-status: open
-tags: [section/inbox-cross-slice, type/cross-slice, status/open]
-updated: 2026-04-19
+status: resolved
+tags: [section/inbox-cross-slice, type/cross-slice, status/resolved]
+updated: 2026-04-20
 ---
+
+## Resolution
+
+Resolved by the PR closing this branch (chore/artifact-tokenizer) —
+`src/musubi/planes/artifact/chunking.py` now uses the BGE-M3 tokenizer
+via the minimal `tokenizers` HF dependency (not the full `transformers`
+package). `TokenSlidingChunker` windows at exactly 512 tokens with
+128-token overlap; `MarkdownHeadingChunker` delegates oversize sections
+to the token splitter, preserving heading-path metadata and marking
+split chunks with `split_from_oversize_section=True`. Small sections
+stay single-chunk without paying tokenizer-load cost (lazy-load gated
+on `_likely_within_window` heuristic + injection in tests).
+
+Codex drove the bulk of the implementation (~268 lines in
+`chunking.py`, new `tokenizers` dep in `pyproject.toml` + `uv.lock`)
+before his credits ran out mid-session. Operator picked up and
+finished: 8 new tokenizer tests in `tests/planes/test_artifact.py`
+covering exact window + overlap math, oversize markdown splits,
+heading-path preservation, sentence-boundary preference, empty text,
+invalid-overlap validation; fixed ruff `RUF001` on CJK sentence-end
+regex (noqa + inline comment); added `tokenizers.*` to mypy
+ignore-missing-imports override.
+
+Original ticket preserved below for audit.
+
+---
+
 # Tokenizer wiring for artifact chunkers
 
 **From:** `slice-plane-artifact`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ explicit_package_bases = true
 mypy_path = "src"
 
 [[tool.mypy.overrides]]
-module = ["ksuid.*", "svix_ksuid.*", "ksuid", "qdrant_client.*"]
+module = ["ksuid.*", "svix_ksuid.*", "ksuid", "qdrant_client.*", "tokenizers", "tokenizers.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     # Multipart parsing for POST /v1/artifacts file uploads
     # (slice-api-v0-write).
     "python-multipart>=0.0.9",
+    "tokenizers>=0.20",
 ]
 
 [project.optional-dependencies]

--- a/src/musubi/planes/artifact/chunking.py
+++ b/src/musubi/planes/artifact/chunking.py
@@ -1,6 +1,17 @@
+from __future__ import annotations
+
 import re
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Protocol
+from functools import lru_cache
+from typing import Any, Protocol, runtime_checkable
+
+from tokenizers import Tokenizer
+
+_BGE_M3_TOKENIZER = "BAAI/bge-m3"
+_DEFAULT_WINDOW_TOKENS = 512
+_DEFAULT_OVERLAP_TOKENS = 128
+_SENTENCE_END_RE = re.compile(r"[.!?。？！][\"')\]]*$")
 
 
 @dataclass
@@ -16,44 +27,165 @@ class ChunkerProtocol(Protocol):
     def chunk(self, text: str) -> list[RawChunk]: ...
 
 
+@runtime_checkable
+class TokenizerProtocol(Protocol):
+    def encode(self, sequence: str) -> Any: ...
+
+
+@dataclass(frozen=True)
+class _TokenizedText:
+    ids: list[int]
+    offsets: list[tuple[int, int]]
+
+
+@lru_cache(maxsize=1)
+def _load_bge_m3_tokenizer() -> Tokenizer:
+    """Load and cache the BGE-M3 tokenizer.
+
+    `tokenizers` handles the HuggingFace cache on disk; this process-level
+    cache keeps repeated chunking calls from paying construction cost.
+    """
+    return Tokenizer.from_pretrained(_BGE_M3_TOKENIZER)
+
+
+def _tokenize(text: str, tokenizer: TokenizerProtocol | None = None) -> _TokenizedText:
+    tok = tokenizer or _load_bge_m3_tokenizer()
+    encoded = tok.encode(text)
+    ids = list(encoded.ids)
+    offsets = [tuple(offset) for offset in encoded.offsets]
+
+    # Drop special tokens with empty offsets. Chunk sizes are measured over
+    # text-bearing tokens only, and offsets then map directly back to content.
+    filtered_ids: list[int] = []
+    filtered_offsets: list[tuple[int, int]] = []
+    for token_id, (start, end) in zip(ids, offsets, strict=True):
+        if end <= start:
+            continue
+        filtered_ids.append(int(token_id))
+        filtered_offsets.append((int(start), int(end)))
+    return _TokenizedText(ids=filtered_ids, offsets=filtered_offsets)
+
+
+def _trim_span(text: str, start: int, end: int) -> tuple[int, int]:
+    while start < end and text[start].isspace():
+        start += 1
+    while end > start and text[end - 1].isspace():
+        end -= 1
+    return start, end
+
+
+def _likely_within_window(text: str, window_tokens: int) -> bool:
+    # BGE-M3 may split punctuation/subwords, so this is intentionally
+    # conservative. It only avoids tokenizer loading for clearly small
+    # markdown sections.
+    return len(text.split()) <= window_tokens // 2 and len(text) <= window_tokens * 4
+
+
+def _sentence_boundary_token_index(
+    text: str,
+    offsets: Sequence[tuple[int, int]],
+    *,
+    max_end_token: int,
+    min_end_token: int,
+) -> int | None:
+    for token_index in range(max_end_token - 1, min_end_token - 1, -1):
+        _, char_end = offsets[token_index]
+        if _SENTENCE_END_RE.search(text[:char_end].rstrip()):
+            return token_index + 1
+    return None
+
+
 class MarkdownHeadingChunker:
-    """Split on H2/H3."""
+    """Split on H2/H3, token-splitting oversize sections."""
+
+    def __init__(
+        self,
+        *,
+        tokenizer: TokenizerProtocol | None = None,
+        window_tokens: int = _DEFAULT_WINDOW_TOKENS,
+        overlap_tokens: int = _DEFAULT_OVERLAP_TOKENS,
+    ) -> None:
+        self._tokenizer = tokenizer
+        self._window_tokens = window_tokens
+        self._overlap_tokens = overlap_tokens
 
     def chunk(self, text: str) -> list[RawChunk]:
-        # Naive implementation for test contract
-        chunks = []
-        # Split on \n## or \n###
-        pattern = re.compile(r"(?=\n##\s|\n###\s)")
-        parts = pattern.split(text)
-        offset = 0
-        for i, part in enumerate(parts):
-            if not part:
-                continue
-            path = "unknown"
-            match = re.match(r"^\n?(#{2,3})\s+(.*)$", part, re.M)
-            if match:
-                path = match.group(2).strip()
-            # If the part is somehow larger than a threshold, we'd token-slide it.
-            # But naive works for test.
-            end = offset + len(part)
-            chunks.append(
-                RawChunk(
-                    index=i,
-                    content=part.strip(),
-                    start_offset=offset,
-                    end_offset=end,
-                    metadata={"heading_path": path},
+        chunks: list[RawChunk] = []
+
+        for section_start, section_end, heading_path in _markdown_sections(text):
+            section_text = text[section_start:section_end]
+            tokenizer = self._tokenizer
+            token_count: int | None = None
+            if tokenizer is not None:
+                token_count = len(_tokenize(section_text, tokenizer).ids)
+
+            if (
+                token_count is not None and token_count <= self._window_tokens
+            ) or (
+                token_count is None and _likely_within_window(section_text, self._window_tokens)
+            ):
+                start, end = _trim_span(text, section_start, section_end)
+                if start == end:
+                    continue
+                chunks.append(
+                    RawChunk(
+                        index=len(chunks),
+                        content=text[start:end],
+                        start_offset=start,
+                        end_offset=end,
+                        metadata={
+                            "heading_path": heading_path,
+                            "token_count": token_count,
+                        },
+                    )
                 )
+                continue
+
+            tokenizer = tokenizer or _load_bge_m3_tokenizer()
+            splitter = TokenSlidingChunker(
+                tokenizer=tokenizer,
+                window_tokens=self._window_tokens,
+                overlap_tokens=self._overlap_tokens,
+                prefer_sentence_boundary=True,
             )
-            offset = end
+            for subchunk in splitter.chunk(section_text):
+                chunks.append(
+                    RawChunk(
+                        index=len(chunks),
+                        content=subchunk.content,
+                        start_offset=section_start + subchunk.start_offset,
+                        end_offset=section_start + subchunk.end_offset,
+                        metadata={
+                            **subchunk.metadata,
+                            "heading_path": heading_path,
+                            "split_from_oversize_section": True,
+                        },
+                    )
+                )
         return chunks
+
+
+def _markdown_sections(text: str) -> list[tuple[int, int, str]]:
+    headings = list(re.finditer(r"(?m)^#{2,3}\s+(.+)$", text))
+    sections: list[tuple[int, int, str]] = []
+
+    if not headings:
+        return [(0, len(text), "unknown")] if text else []
+
+    first = headings[0]
+    if text[: first.start()].strip():
+        sections.append((0, first.start(), "unknown"))
+
+    for idx, heading in enumerate(headings):
+        end = headings[idx + 1].start() if idx + 1 < len(headings) else len(text)
+        sections.append((heading.start(), end, heading.group(1).strip()))
+    return sections
 
 
 class VTTTurnsChunker:
     """Group 3-5 speaker turns."""
 
     def chunk(self, text: str) -> list[RawChunk]:
-        # Naive turn grouping
         chunks = []
         turns = text.split("\n\n")
         offset = 0
@@ -75,32 +207,76 @@ class VTTTurnsChunker:
 
 
 class TokenSlidingChunker:
-    """512-token window, 128-token overlap. (Naively implemented with words)"""
+    """BGE-M3 token windows with a 512-token window and 128-token overlap."""
+
+    def __init__(
+        self,
+        *,
+        tokenizer: TokenizerProtocol | None = None,
+        window_tokens: int = _DEFAULT_WINDOW_TOKENS,
+        overlap_tokens: int = _DEFAULT_OVERLAP_TOKENS,
+        prefer_sentence_boundary: bool = False,
+    ) -> None:
+        if window_tokens <= 0:
+            raise ValueError("window_tokens must be positive")
+        if overlap_tokens < 0 or overlap_tokens >= window_tokens:
+            raise ValueError("overlap_tokens must be >= 0 and less than window_tokens")
+        self._tokenizer = tokenizer
+        self._window_tokens = window_tokens
+        self._overlap_tokens = overlap_tokens
+        self._prefer_sentence_boundary = prefer_sentence_boundary
 
     def chunk(self, text: str) -> list[RawChunk]:
-        words = text.split()
-        chunks = []
-        window = 512
-        overlap = 128
-        step = window - overlap
+        if not text:
+            return []
 
-        idx = 0
-        word_offset = 0
-        while word_offset < max(1, len(words)):
-            chunk_words = words[word_offset : word_offset + window]
-            content = " ".join(chunk_words)
-            # We don't have true char offsets for sliding words easily, just approximate
-            start = text.find(content[:10]) if content else 0
-            end = start + len(content)
+        tokenized = _tokenize(text, self._tokenizer)
+        if not tokenized.ids:
+            start, end = _trim_span(text, 0, len(text))
+            return [
+                RawChunk(
+                    index=0,
+                    content=text[start:end],
+                    start_offset=start,
+                    end_offset=end,
+                    metadata={"token_count": 0, "token_start": 0, "token_end": 0},
+                )
+            ]
+
+        chunks: list[RawChunk] = []
+        token_start = 0
+        while token_start < len(tokenized.ids):
+            token_end = min(token_start + self._window_tokens, len(tokenized.ids))
+            if self._prefer_sentence_boundary and token_end < len(tokenized.ids):
+                boundary = _sentence_boundary_token_index(
+                    text,
+                    tokenized.offsets,
+                    max_end_token=token_end,
+                    min_end_token=min(token_start + self._overlap_tokens + 1, token_end),
+                )
+                if boundary is not None:
+                    token_end = boundary
+
+            char_start = tokenized.offsets[token_start][0]
+            char_end = tokenized.offsets[token_end - 1][1]
+            char_start, char_end = _trim_span(text, char_start, char_end)
             chunks.append(
                 RawChunk(
-                    index=idx, content=content, start_offset=start, end_offset=end, metadata={}
+                    index=len(chunks),
+                    content=text[char_start:char_end],
+                    start_offset=char_start,
+                    end_offset=char_end,
+                    metadata={
+                        "token_start": token_start,
+                        "token_end": token_end,
+                        "token_count": token_end - token_start,
+                    },
                 )
             )
-            idx += 1
-            word_offset += step
-            if word_offset >= len(words):
+
+            if token_end >= len(tokenized.ids):
                 break
+            token_start = max(token_end - self._overlap_tokens, token_start + 1)
         return chunks
 
 

--- a/src/musubi/planes/artifact/chunking.py
+++ b/src/musubi/planes/artifact/chunking.py
@@ -11,7 +11,10 @@ from tokenizers import Tokenizer
 _BGE_M3_TOKENIZER = "BAAI/bge-m3"
 _DEFAULT_WINDOW_TOKENS = 512
 _DEFAULT_OVERLAP_TOKENS = 128
-_SENTENCE_END_RE = re.compile(r"[.!?。？！][\"')\]]*$")
+# Sentence-end markers cover ASCII + CJK. noqa: RUF001 — the fullwidth
+# variants are real punctuation in CJK text that the tokenizer may emit;
+# matching them by literal codepoint is intentional.
+_SENTENCE_END_RE = re.compile(r"[.!?。？！][\"')\]]*$")  # noqa: RUF001
 
 
 @dataclass
@@ -119,9 +122,7 @@ class MarkdownHeadingChunker:
             if tokenizer is not None:
                 token_count = len(_tokenize(section_text, tokenizer).ids)
 
-            if (
-                token_count is not None and token_count <= self._window_tokens
-            ) or (
+            if (token_count is not None and token_count <= self._window_tokens) or (
                 token_count is None and _likely_within_window(section_text, self._window_tokens)
             ):
                 start, end = _trim_span(text, section_start, section_end)

--- a/tests/planes/test_artifact.py
+++ b/tests/planes/test_artifact.py
@@ -367,3 +367,168 @@ def test_get_chunker_returns_json_for_json_v1() -> None:
 def test_get_chunker_returns_token_sliding_for_unknown() -> None:
     chunker = get_chunker("unknown-chunker")
     assert isinstance(chunker, TokenSlidingChunker)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Tokenizer-aware chunking — cross-slice slice-plane-artifact-tokenizer
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class _FakeTokenizer:
+    """Deterministic stub tokenizer.
+
+    Each whitespace-delimited word becomes one token; offsets map back to
+    the original character span. Lets us exercise window + overlap +
+    sentence-boundary logic without pulling down BGE-M3 in CI.
+    """
+
+    def encode(self, text: str) -> Any:
+        import re as _re
+
+        token_spans = [(m.start(), m.end()) for m in _re.finditer(r"\S+", text)]
+
+        class _Encoding:
+            def __init__(self, spans: list[tuple[int, int]]) -> None:
+                self.ids = list(range(len(spans)))
+                self.offsets = spans
+
+        return _Encoding(token_spans)
+
+
+def test_token_sliding_chunker_uses_exact_window_and_overlap() -> None:
+    """A 900-token document splits into windows of exactly 512 with 128-token overlap."""
+    from musubi.planes.artifact.chunking import TokenSlidingChunker
+
+    words = [f"w{i}" for i in range(900)]
+    text = " ".join(words)
+    chunker = TokenSlidingChunker(tokenizer=_FakeTokenizer(), window_tokens=512, overlap_tokens=128)
+    chunks = chunker.chunk(text)
+
+    # First chunk covers tokens 0-511 (512 tokens).
+    assert chunks[0].metadata["token_count"] == 512
+    assert chunks[0].metadata["token_start"] == 0
+    assert chunks[0].metadata["token_end"] == 512
+
+    # Second chunk starts at 512 - 128 = 384 (overlap of 128).
+    assert chunks[1].metadata["token_start"] == 384
+    # Covers remaining 900 - 384 = 516, capped at 512 → ends at 896.
+    assert chunks[1].metadata["token_end"] == 896
+
+    # Third chunk covers the tail (896 - 128 overlap = 768 start → 900 end).
+    assert chunks[2].metadata["token_start"] == 768
+    assert chunks[2].metadata["token_end"] == 900
+    assert chunks[2].metadata["token_count"] == 132
+
+    # Coverage: every content character appears at least once across chunks.
+    covered: set[int] = set()
+    for c in chunks:
+        covered.update(range(c.start_offset, c.end_offset))
+    assert len(covered) >= len(text) - 10  # account for trimmed whitespace
+
+
+def test_token_sliding_chunker_empty_text() -> None:
+    from musubi.planes.artifact.chunking import TokenSlidingChunker
+
+    chunker = TokenSlidingChunker(tokenizer=_FakeTokenizer())
+    assert chunker.chunk("") == []
+
+
+def test_token_sliding_chunker_smaller_than_window_emits_single_chunk() -> None:
+    from musubi.planes.artifact.chunking import TokenSlidingChunker
+
+    chunker = TokenSlidingChunker(tokenizer=_FakeTokenizer(), window_tokens=100, overlap_tokens=20)
+    text = " ".join(f"w{i}" for i in range(50))
+    chunks = chunker.chunk(text)
+    assert len(chunks) == 1
+    assert chunks[0].metadata["token_count"] == 50
+
+
+def test_token_sliding_chunker_invalid_overlap_raises() -> None:
+    from musubi.planes.artifact.chunking import TokenSlidingChunker
+
+    with pytest.raises(ValueError):
+        TokenSlidingChunker(window_tokens=100, overlap_tokens=100)
+    with pytest.raises(ValueError):
+        TokenSlidingChunker(window_tokens=0, overlap_tokens=0)
+    with pytest.raises(ValueError):
+        TokenSlidingChunker(window_tokens=100, overlap_tokens=-1)
+
+
+def test_markdown_heading_chunker_splits_oversize_sections() -> None:
+    """An H2 section with 800 tokens gets split into 512 + overlap windows;
+    normal H3 sections stay single-chunk."""
+    from musubi.planes.artifact.chunking import MarkdownHeadingChunker
+
+    big_body = " ".join(f"big{i}" for i in range(800))
+    small_body = "short section body"
+    text = f"## Big Section\n\n{big_body}\n\n### Small Section\n\n{small_body}\n"
+
+    chunker = MarkdownHeadingChunker(
+        tokenizer=_FakeTokenizer(), window_tokens=512, overlap_tokens=128
+    )
+    chunks = chunker.chunk(text)
+
+    big_chunks = [c for c in chunks if c.metadata.get("heading_path") == "Big Section"]
+    small_chunks = [c for c in chunks if c.metadata.get("heading_path") == "Small Section"]
+
+    # Big section split into multiple token-window chunks.
+    assert len(big_chunks) >= 2
+    assert all(c.metadata.get("split_from_oversize_section") for c in big_chunks)
+
+    # Small section stays a single chunk.
+    assert len(small_chunks) == 1
+    assert not small_chunks[0].metadata.get("split_from_oversize_section")
+
+
+def test_markdown_heading_chunker_preserves_heading_path_across_splits() -> None:
+    from musubi.planes.artifact.chunking import MarkdownHeadingChunker
+
+    big_body = " ".join(f"w{i}" for i in range(700))
+    text = f"## Research Notes\n\n{big_body}\n"
+
+    chunker = MarkdownHeadingChunker(
+        tokenizer=_FakeTokenizer(), window_tokens=512, overlap_tokens=128
+    )
+    chunks = chunker.chunk(text)
+
+    assert len(chunks) >= 2
+    for c in chunks:
+        assert c.metadata["heading_path"] == "Research Notes"
+
+
+def test_markdown_heading_chunker_no_headings_treats_whole_text_as_one_section() -> None:
+    from musubi.planes.artifact.chunking import MarkdownHeadingChunker
+
+    text = "plain text with no headings at all"
+    chunker = MarkdownHeadingChunker(tokenizer=_FakeTokenizer(), window_tokens=512)
+    chunks = chunker.chunk(text)
+
+    assert len(chunks) == 1
+    assert chunks[0].metadata["heading_path"] == "unknown"
+
+
+def test_token_sliding_chunker_prefers_sentence_boundary_when_enabled() -> None:
+    """Sentence boundary preference snaps window-end to the nearest
+    sentence-end punctuation within the overlap range."""
+    from musubi.planes.artifact.chunking import TokenSlidingChunker
+
+    # 20 sentences of 30 tokens each; window=100, overlap=20 means the
+    # boundary-snap should land on sentence-end punctuation.
+    sentences = [" ".join([f"s{s}w{w}" for w in range(30)]) + "." for s in range(20)]
+    text = " ".join(sentences)
+
+    chunker = TokenSlidingChunker(
+        tokenizer=_FakeTokenizer(),
+        window_tokens=100,
+        overlap_tokens=20,
+        prefer_sentence_boundary=True,
+    )
+    chunks = chunker.chunk(text)
+
+    # Every chunk except possibly the last should end at a sentence boundary
+    # (the mocked tokenizer treats "." as a word — so we verify the chunk
+    # content ends with "." rather than mid-sentence).
+    for c in chunks[:-1]:
+        assert c.content.rstrip().endswith("."), (
+            f"chunk {c.index} should end at sentence boundary, got: ...{c.content[-30:]}"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -288,6 +288,24 @@ wheels = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/cf/b50ddf667c15276a9ab15a70ef5f257564de271957933ffea49d2cdbcdfb/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41", size = 313547, upload-time = "2026-03-27T19:11:14.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4", size = 202595, upload-time = "2026-03-27T19:11:13.595Z" },
+]
+
+[[package]]
 name = "grpcio"
 version = "1.80.0"
 source = { registry = "https://pypi.org/simple" }
@@ -351,6 +369,38 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/92/ec9ad04d0b5728dca387a45af7bc98fbb0d73b2118759f5f6038b61a57e8/hf_xet-1.4.3.tar.gz", hash = "sha256:8ddedb73c8c08928c793df2f3401ec26f95be7f7e516a7bee2fbb546f6676113", size = 670477, upload-time = "2026-03-31T22:40:07.874Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/43/724d307b34e353da0abd476e02f72f735cdd2bc86082dee1b32ea0bfee1d/hf_xet-1.4.3-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7551659ba4f1e1074e9623996f28c3873682530aee0a846b7f2f066239228144", size = 3800935, upload-time = "2026-03-31T22:39:49.618Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d2/8bee5996b699262edb87dbb54118d287c0e1b2fc78af7cdc41857ba5e3c4/hf_xet-1.4.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:bee693ada985e7045997f05f081d0e12c4c08bd7626dc397f8a7c487e6c04f7f", size = 3558942, upload-time = "2026-03-31T22:39:47.938Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/a1/e993d09cbe251196fb60812b09a58901c468127b7259d2bf0f68bf6088eb/hf_xet-1.4.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:21644b404bb0100fe3857892f752c4d09642586fd988e61501c95bbf44b393a3", size = 4207657, upload-time = "2026-03-31T22:39:39.69Z" },
+    { url = "https://files.pythonhosted.org/packages/64/44/9eb6d21e5c34c63e5e399803a6932fa983cabdf47c0ecbcfe7ea97684b8c/hf_xet-1.4.3-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:987f09cfe418237812896a6736b81b1af02a3a6dcb4b4944425c4c4fca7a7cf8", size = 3986765, upload-time = "2026-03-31T22:39:37.936Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7b/8ad6f16fdb82f5f7284a34b5ec48645bd575bdcd2f6f0d1644775909c486/hf_xet-1.4.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:60cf7fc43a99da0a853345cf86d23738c03983ee5249613a6305d3e57a5dca74", size = 4188162, upload-time = "2026-03-31T22:39:58.382Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c4/39d6e136cbeea9ca5a23aad4b33024319222adbdc059ebcda5fc7d9d5ff4/hf_xet-1.4.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2815a49a7a59f3e2edf0cf113ae88e8cb2ca2a221bf353fb60c609584f4884d4", size = 4424525, upload-time = "2026-03-31T22:40:00.225Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f2/adc32dae6bdbc367853118b9878139ac869419a4ae7ba07185dc31251b76/hf_xet-1.4.3-cp313-cp313t-win_amd64.whl", hash = "sha256:42ee323265f1e6a81b0e11094564fb7f7e0ec75b5105ffd91ae63f403a11931b", size = 3671610, upload-time = "2026-03-31T22:40:10.42Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/19/25d897dcc3f81953e0c2cde9ec186c7a0fee413eb0c9a7a9130d87d94d3a/hf_xet-1.4.3-cp313-cp313t-win_arm64.whl", hash = "sha256:27c976ba60079fb8217f485b9c5c7fcd21c90b0367753805f87cb9f3cdc4418a", size = 3528529, upload-time = "2026-03-31T22:40:09.106Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/36/3e8f85ca9fe09b8de2b2e10c63b3b3353d7dda88a0b3d426dffbe7b8313b/hf_xet-1.4.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:5251d5ece3a81815bae9abab41cf7ddb7bcb8f56411bce0827f4a3071c92fdc6", size = 3801019, upload-time = "2026-03-31T22:39:56.651Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9c/defb6cb1de28bccb7bd8d95f6e60f72a3d3fa4cb3d0329c26fb9a488bfe7/hf_xet-1.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1feb0f3abeacee143367c326a128a2e2b60868ec12a36c225afb1d6c5a05e6d2", size = 3558746, upload-time = "2026-03-31T22:39:54.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/bd/8d001191893178ff8e826e46ad5299446e62b93cd164e17b0ffea08832ec/hf_xet-1.4.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8b301fc150290ca90b4fccd079829b84bb4786747584ae08b94b4577d82fb791", size = 4207692, upload-time = "2026-03-31T22:39:46.246Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/6790b402803250e9936435613d3a78b9aaeee7973439f0918848dde58309/hf_xet-1.4.3-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d972fbe95ddc0d3c0fc49b31a8a69f47db35c1e3699bf316421705741aab6653", size = 3986281, upload-time = "2026-03-31T22:39:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/51/56/ea62552fe53db652a9099eda600b032d75554d0e86c12a73824bfedef88b/hf_xet-1.4.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c5b48db1ee344a805a1b9bd2cda9b6b65fe77ed3787bd6e87ad5521141d317cd", size = 4187414, upload-time = "2026-03-31T22:40:04.951Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f5/bc1456d4638061bea997e6d2db60a1a613d7b200e0755965ec312dc1ef79/hf_xet-1.4.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:22bdc1f5fb8b15bf2831440b91d1c9bbceeb7e10c81a12e8d75889996a5c9da8", size = 4424368, upload-time = "2026-03-31T22:40:06.347Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/76/ab597bae87e1f06d18d3ecb8ed7f0d3c9a37037fc32ce76233d369273c64/hf_xet-1.4.3-cp314-cp314t-win_amd64.whl", hash = "sha256:0392c79b7cf48418cd61478c1a925246cf10639f4cd9d94368d8ca1e8df9ea07", size = 3672280, upload-time = "2026-03-31T22:40:16.401Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/2e462d34e23a09a74d73785dbed71cc5dbad82a72eee2ad60a72a554155d/hf_xet-1.4.3-cp314-cp314t-win_arm64.whl", hash = "sha256:681c92a07796325778a79d76c67011764ecc9042a8c3579332b61b63ae512075", size = 3528945, upload-time = "2026-03-31T22:40:14.995Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/9f/9c23e4a447b8f83120798f9279d0297a4d1360bdbf59ef49ebec78fe2545/hf_xet-1.4.3-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d0da85329eaf196e03e90b84c2d0aca53bd4573d097a75f99609e80775f98025", size = 3805048, upload-time = "2026-03-31T22:39:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/f8/7aacb8e5f4a7899d39c787b5984e912e6c18b11be136ef13947d7a66d265/hf_xet-1.4.3-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e23717ce4186b265f69afa66e6f0069fe7efbf331546f5c313d00e123dc84583", size = 3562178, upload-time = "2026-03-31T22:39:51.295Z" },
+    { url = "https://files.pythonhosted.org/packages/df/9a/a24b26dc8a65f0ecc0fe5be981a19e61e7ca963b85e062c083f3a9100529/hf_xet-1.4.3-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc360b70c815bf340ed56c7b8c63aacf11762a4b099b2fe2c9bd6d6068668c08", size = 4212320, upload-time = "2026-03-31T22:39:42.922Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/46d493db155d2ee2801b71fb1b0fd67696359047fdd8caee2c914cc50c79/hf_xet-1.4.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:39f2d2e9654cd9b4319885733993807aab6de9dfbd34c42f0b78338d6617421f", size = 3991546, upload-time = "2026-03-31T22:39:41.335Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f5/067363e1c96c6b17256910830d1b54099d06287e10f4ec6ec4e7e08371fc/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:49ad8a8cead2b56051aa84d7fce3e1335efe68df3cf6c058f22a65513885baac", size = 4193200, upload-time = "2026-03-31T22:40:01.936Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4b/53951592882d9c23080c7644542fda34a3813104e9e11fa1a7d82d419cb8/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba", size = 4429392, upload-time = "2026-03-31T22:40:03.492Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/21/75a6c175b4e79662ad8e62f46a40ce341d8d6b206b06b4320d07d55b188c/hf_xet-1.4.3-cp37-abi3-win_amd64.whl", hash = "sha256:6b591fcad34e272a5b02607485e4f2a1334aebf1bc6d16ce8eb1eb8978ac2021", size = 3677359, upload-time = "2026-03-31T22:40:13.619Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/7c/44314ecd0e89f8b2b51c9d9e5e7a60a9c1c82024ac471d415860557d3cd8/hf_xet-1.4.3-cp37-abi3-win_arm64.whl", hash = "sha256:7c2c7e20bcfcc946dc67187c203463f5e932e395845d098cc2a93f5b67ca0b47", size = 3533664, upload-time = "2026-03-31T22:40:12.152Z" },
+]
+
+[[package]]
 name = "hpack"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -399,6 +449,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/89/e7aa12d8a6b9259bed10671abb25ae6fa437c0f88a86ecbf59617bae7759/huggingface_hub-1.11.0.tar.gz", hash = "sha256:15fb3713c7f9cdff7b808a94fd91664f661ab142796bb48c9cd9493e8d166278", size = 761749, upload-time = "2026-04-16T13:07:39.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/02/4f3f8997d1ea7fe0146b343e5e14bd065fa87af790d07e5576d31b31cc18/huggingface_hub-1.11.0-py3-none-any.whl", hash = "sha256:42a6de0afbfeb5e022222d36398f029679db4eb4778801aafda32257ae9131ab", size = 645499, upload-time = "2026-04-16T13:07:37.716Z" },
 ]
 
 [[package]]
@@ -540,6 +610,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -628,6 +710,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "musubi"
 version = "0.2.0"
 source = { editable = "." }
@@ -642,6 +733,7 @@ dependencies = [
     { name = "qdrant-client" },
     { name = "ruamel-yaml" },
     { name = "svix-ksuid" },
+    { name = "tokenizers" },
     { name = "watchdog" },
 ]
 
@@ -685,6 +777,7 @@ requires-dist = [
     { name = "ruamel-yaml", specifier = ">=0.18" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "svix-ksuid", specifier = ">=0.6" },
+    { name = "tokenizers", specifier = ">=0.20" },
     { name = "types-pyyaml", marker = "extra == 'dev'" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6" },
     { name = "watchdog", specifier = ">=4.0" },
@@ -1184,6 +1277,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1299,6 +1405,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1343,6 +1458,59 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ef/f0/b534cc208ee8ea010254208345324d2e3d3c5d13a210d2249f9f11840f2f/svix_ksuid-0.7.0.tar.gz", hash = "sha256:e6b824437b5bb76d75163b928cbf9ae6c871d3e713e5de75cde89bae6a19bfe8", size = 5810, upload-time = "2026-03-14T02:44:51.944Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/74/51/922e6ad4da6b3f4863ea059db2391259c9247b9fe4f0c08da50eff4e1312/svix_ksuid-0.7.0-py3-none-any.whl", hash = "sha256:6bceae49f85e026c77a13e6de81bf4536c15039ecb160415e954403618c2a06f", size = 5607, upload-time = "2026-03-14T02:44:50.822Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Codex ran out of credits mid-implementation. Operator rescue picks up + finishes.

## What lands

Codex delivered the core (~268 lines in chunking.py):
- BGE-M3 tokenizer via minimal `tokenizers` dep (not transformers)
- `TokenSlidingChunker` with exact 512-token window / 128-token overlap
- `MarkdownHeadingChunker` that keeps small sections intact + delegates oversize to token splitter
- Lazy tokenizer load for markdown, preserves `heading_path` metadata across splits

Rescue adds:
- 8 new Test Contract tests (27 total artifact tests, up from 19) using a `_FakeTokenizer` for CI — no HF download required
- ruff RUF001 fix on CJK sentence-end regex (noqa + explanatory comment)
- mypy override: `tokenizers.*` in ignore-missing-imports

## Verification

- `make check`: 982 passed, 228 skipped, all checks passed
- Cross-slice ticket `slice-plane-artifact-tokenizer.md` → `status: resolved` with Resolution block

## Test plan

- [x] `make check` green
- [x] `make agent-check` clean
- [x] 8 new tests cover exact math + oversize splits + sentence-boundary + validation + empty text

Cites: `docs/architecture/_inbox/cross-slice/slice-plane-artifact-tokenizer.md`
