### PR TITLE
test(integration): unskip #118 batch-perf + #120 SSE live delivery

### DIFF
--- a/tests/ingestion/test_capture.py
+++ b/tests/ingestion/test_capture.py
@@ -19,7 +19,8 @@ Closure plan:
 - bullets 20-21 (single TEI / single Qdrant batch instrumentation) →
   skipped, cross-slice ticket to slice-plane-episodic to add a
   ``batch_create`` method
-- bullet 22 (100-item batch under 1s benchmark) → out-of-scope
+- bullet 22 (100-item batch under 1s benchmark) → moved to integration
+  suite (tests/integration/test_capture_perf.py) per Issue #118
 """
 
 from __future__ import annotations
@@ -499,12 +500,15 @@ def test_batch_capture_single_qdrant_upsert() -> None:
 
 
 @pytest.mark.skip(
-    reason="declared out-of-scope in slice work log: 100-item benchmark "
-    "needs a real warmed-up Qdrant + TEI; deferred to a follow-up perf "
-    "suite (slice-perf-bench)."
+    reason=(
+        "moved to integration suite: see tests/integration/test_capture_perf.py "
+        "(unskipped via #118 against the live docker-compose stack from "
+        "slice-ops-integration-harness PR #114). This unit-suite placeholder "
+        "is retained as a pointer."
+    )
 )
 def test_batch_capture_100_items_under_1s() -> None:
-    """Bullet 22 — placeholder."""
+    """Bullet 22 — moved to tests/integration/test_capture_perf.py."""
 
 
 @pytest.mark.skip(

--- a/tests/integration/test_capture_perf.py
+++ b/tests/integration/test_capture_perf.py
@@ -1,0 +1,82 @@
+"""Test contract — slice-ingestion-capture bullet 22 (100-item batch
+capture under 1s end-to-end against the live stack).
+
+Closes Issue #118 (followup to slice-ops-integration-harness PR #114).
+
+The original placeholder lived in ``tests/ingestion/test_capture.py``
+as ``test_batch_capture_100_items_under_1s`` skipped with
+"deferred to a follow-up perf suite." The harness landed in PR #114
+and the production bootstrap landed in PR #126; this is the
+consumer-side unskip per the canonical pattern.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def _strict_perf_budgets() -> bool:
+    """Same env-var gate as ``tests/integration/test_smoke.py`` —
+    on the CPU-only test stack, 100-item batch under 1s is
+    unrealistic; gate the strict assertion on operator's nightly
+    GPU host where the spec budget actually holds."""
+    return os.environ.get("MUSUBI_TEST_PERF_BUDGETS", "").lower() == "strict"
+
+
+@pytest.mark.skipif(
+    not _strict_perf_budgets(),
+    reason=(
+        "perf budget is CPU-stack-unrealistic; set "
+        "MUSUBI_TEST_PERF_BUDGETS=strict on a GPU reference host "
+        "(operator's nightly runner) to enforce. CPU-stack runs still "
+        "exercise the path; only the wall-clock assertion is gated."
+    ),
+)
+async def test_batch_capture_100_items_under_1s(api_client: Any) -> None:
+    """Bullet 22 — single-batch capture of 100 items completes
+    end-to-end (one TEI batch embed + one Qdrant upsert + the API
+    routing overhead) under the spec's 1s budget."""
+    namespace = "eric/integration-test/episodic"
+    items = [
+        f"batch-perf-{uuid.uuid4().hex[:6]}-{i}-payload-some-distinct-content" for i in range(100)
+    ]
+
+    start = time.monotonic()
+    async with api_client.memories.batch(namespace=namespace) as batch:
+        for content in items:
+            batch.capture(content=content, importance=4)
+    elapsed = time.monotonic() - start
+
+    assert batch.results is not None, "batch context did not flush"
+    assert elapsed < 1.0, f"100-item batch capture took {elapsed * 1000:.0f}ms (budget 1000ms)"
+
+
+async def test_batch_capture_100_items_completes_without_strict_budget(
+    api_client: Any,
+) -> None:
+    """Surface-form companion that runs on the CPU stack too — verifies
+    the path executes correctly + the batch flushes its single POST,
+    without asserting the spec's 1s wall-clock. Strict budget lives in
+    the test above."""
+    namespace = "eric/integration-test/episodic"
+    items = [f"batch-surface-{uuid.uuid4().hex[:6]}-{i}-payload" for i in range(100)]
+
+    async with api_client.memories.batch(namespace=namespace) as batch:
+        for content in items:
+            batch.capture(content=content, importance=4)
+
+    assert batch.results is not None
+    # Batch endpoint returns either {"items": [...]} or {"object_ids": [...]}
+    # depending on the API version; tolerate either shape.
+    flushed = batch.results
+    if "items" in flushed:
+        assert len(flushed["items"]) == 100
+    elif "object_ids" in flushed:
+        assert len(flushed["object_ids"]) == 100

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -107,11 +107,70 @@ async def test_thought_send_check_read_history(api_client: Any) -> None:
 # --------------------------------------------------------------------------
 
 
-@pytest.mark.skip(
-    reason="SSE thought-stream subscription surface lands in slice-api-thoughts-stream PR #103 followup; harness primitives ready, consumer slice owns the unskip per slice-ops-integration-harness §Implementation notes"
-)
-def test_thought_stream_delivers_live() -> None:
-    """Bullet 8 — placeholder; consumer slice owns the unskip."""
+async def test_thought_stream_delivers_live(api_client: Any, live_stack: StackHandle) -> None:
+    """Bullet 8 — SSE subscriber sees a live-published thought within
+    ~200ms. Closes Issue #120 (followup to slice-ops-integration-harness
+    PR #114; consumer-side unskip per the canonical pattern).
+
+    Shape: open the SSE stream in a background task, give it a beat to
+    establish the broker subscription, post a thought via the SDK, then
+    pull the next event from the stream. Assert object_id matches the
+    posted thought's ack."""
+    namespace = "eric/integration-test/thought"
+    presence = "integration-test/sse-subscriber"
+
+    received: dict[str, Any] = {}
+
+    async def _consume() -> None:
+        async with (
+            httpx.AsyncClient(
+                base_url=live_stack.api_url,
+                headers={"Authorization": f"Bearer {live_stack.operator_token}"},
+                timeout=10.0,
+            ) as client,
+            client.stream(
+                "GET",
+                "/thoughts/stream",
+                params={"namespace": namespace, "include": f"{presence},all"},
+            ) as resp,
+        ):
+            resp.raise_for_status()
+            async for line in resp.aiter_lines():
+                if line.startswith("data: "):
+                    payload = line.removeprefix("data: ").strip()
+                    if payload and payload != "{}":
+                        import json
+
+                        received.update(json.loads(payload))
+                        return
+
+    consumer = asyncio.create_task(_consume())
+    # Give the SSE handshake a beat to register the broker subscription
+    # before we publish; otherwise the published thought lands before
+    # the subscriber is registered and the test races.
+    await asyncio.sleep(0.5)
+
+    ack = await api_client.thoughts.send(
+        namespace=namespace,
+        from_presence="integration-test/sse-publisher",
+        to_presence=presence,
+        content=f"sse-live-{uuid.uuid4().hex[:6]}",
+        channel="default",
+        importance=5,
+    )
+
+    try:
+        await asyncio.wait_for(consumer, timeout=5.0)
+    except TimeoutError:
+        consumer.cancel()
+        pytest.fail(
+            f"SSE subscriber didn't receive the published thought within 5s; "
+            f"received so far: {received}"
+        )
+
+    assert received.get("object_id") == ack["object_id"], (
+        f"SSE subscriber received {received!r}; expected ack {ack['object_id']!r}"
+    )
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Closes #118.
Closes #120.

Two of three consumer-unskip followups against the integration harness from PR #114, in one PR per the operator's grouped-CI preference.

## What lands

**#118 — batch-capture <1s perf** ([tests/integration/test_capture_perf.py](tests/integration/test_capture_perf.py)):
- New file with two tests against the live stack: a strict-mode wall-clock assertion (gated on `MUSUBI_TEST_PERF_BUDGETS=strict`) and a surface-form companion that runs unconditionally on the CPU stack.
- Uses the SDK's `client.memories.batch(namespace=...)` async context manager — one `POST /v1/memories/batch` on exit per the spec.
- Pointer-skip retained in [tests/ingestion/test_capture.py](tests/ingestion/test_capture.py) with reason updated.

**#120 — SSE live delivery** ([tests/integration/test_smoke.py](tests/integration/test_smoke.py)):
- Replaced the placeholder `test_thought_stream_delivers_live` with a real SSE consumer.
- Opens `GET /v1/thoughts/stream` in a background `asyncio` task, gives the broker subscription 0.5s to register, posts a thought via SDK, asserts the SSE consumer receives the matching `object_id` within 5s.

## #119 deferred to separate PR (Refs #119)

The ollama-offline scenario needs either:
1. A new admin/debug endpoint to trigger one synthesis tick from a test, OR
2. Direct lifecycle worker access (in `src/musubi/lifecycle/`, which is `forbidden_paths` for test-only PRs).

Per the operator's grace note ("If any of the three surface as deeper than expected, pull that one into its own PR + ship the other two"), splitting #119 out so this PR isn't blocked on a non-trivial scope question. Will comment on #119 with the analysis.

## CI

PR-trigger path-filter on `.github/workflows/integration.yml` already fires on `tests/integration/**` changes (per PR #114 wiring) → one Integration job validates both unskips end-to-end against the live stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)