### PR TITLE
feat(api): debug-synthesis-trigger endpoint + #119 ollama-offline unskip

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -57,6 +57,39 @@ paths:
           content:
             application/json:
               schema: {}
+  /v1/ops/debug/trigger-synthesis:
+    post:
+      tags:
+      - ops
+      summary: Trigger Synthesis
+      description: 'Operator-scope debug endpoint that drives one synthesis tick
+        on demand. Test-hook for the integration harness (Issue #119); restricted
+        to operator-scope tokens because the synthesis loop is expensive. Production
+        workers run synthesis on their own tick loop; this endpoint exists so the
+        integration suite can deterministically exercise the path without an embedded
+        worker.'
+      operationId: debug_trigger_synthesis.bucket=default
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [namespace]
+              properties:
+                namespace:
+                  type: string
+                simulate_ollama_offline:
+                  type: boolean
+                  default: false
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '501':
+          description: Real Ollama client impl unavailable; pass simulate_ollama_offline=true.
   /v1/memories/{object_id}:
     get:
       tags:

--- a/src/musubi/api/routers/ops.py
+++ b/src/musubi/api/routers/ops.py
@@ -1,4 +1,4 @@
-"""Operational endpoints — health, status, metrics passthrough.
+"""Operational endpoints — health, status, metrics passthrough, debug.
 
 ``/health`` is a liveness probe (always 200 if the process serves
 requests). ``/status`` is per-component readiness — populates
@@ -6,16 +6,25 @@ requests). ``/status`` is per-component readiness — populates
 (Qdrant + each TEI service + Ollama), satisfying Aoi's v0.1
 health-granularity ask. ``/metrics`` exposes the in-process
 Prometheus registry in text format.
+
+``/debug/trigger-synthesis`` is an operator-scope test-hook that
+runs one synthesis tick end-to-end against the live stack; the
+integration harness uses it to verify degradation behaviours
+(Ollama-offline scenario per Issue #119) without embedding the
+lifecycle worker in the API.
 """
 
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Response
+from pydantic import BaseModel, Field
 from qdrant_client import QdrantClient
 
-from musubi.api.dependencies import get_qdrant_client
+from musubi.api.auth import require_operator
+from musubi.api.dependencies import get_embedder, get_qdrant_client
 from musubi.api.responses import ComponentStatus, HealthResponse, StatusResponse
 from musubi.config import get_settings
+from musubi.embedding import Embedder
 from musubi.observability import (
     check_component_health,
     default_registry,
@@ -83,6 +92,126 @@ async def metrics() -> Response:
     return Response(
         content=render_text_format(default_registry()),
         media_type="text/plain; version=0.0.4",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Debug — /v1/ops/debug/trigger-synthesis
+# ---------------------------------------------------------------------------
+
+
+class TriggerSynthesisRequest(BaseModel):
+    """Debug-endpoint payload for :func:`trigger_synthesis`."""
+
+    namespace: str = Field(
+        description="Tenant-scoped namespace prefix (e.g. 'eric/integration-test'). "
+        "The synthesis loop operates on '<prefix>/episodic' + '<prefix>/concept'."
+    )
+    simulate_ollama_offline: bool = Field(
+        default=False,
+        description=(
+            "Wire a stub Ollama client that always returns None "
+            "(simulates an unreachable LLM). When false, the endpoint "
+            "returns 501 — a real Ollama client impl is future work "
+            "(there's no production OllamaClient in the codebase yet; "
+            "the Protocol is satisfied by workers only)."
+        ),
+    )
+
+
+class TriggerSynthesisResponse(BaseModel):
+    """Same shape as ``musubi.lifecycle.synthesis.SynthesisReport``."""
+
+    namespace: str
+    memories_selected: int
+    clusters_formed: int
+    concepts_created: int
+    concepts_reinforced: int
+    contradictions_detected: int
+    cursor_advanced_to: float | None
+
+
+class _NoOpOllamaClient:
+    """Simulates Ollama being offline — every call returns None.
+
+    Matches the :class:`musubi.lifecycle.synthesis.SynthesisOllamaClient`
+    Protocol. When this is wired into ``synthesis_run``, the loop logs
+    'LLM unavailable during synthesis_run, skipping run' and returns a
+    zero-concept report — the graceful degradation Issue #119 asserts.
+    """
+
+    async def synthesize_cluster(self, cluster: object) -> None:
+        return None
+
+    async def check_contradiction(self, pair: object) -> None:
+        return None
+
+
+@router.post(
+    "/debug/trigger-synthesis",
+    response_model=TriggerSynthesisResponse,
+    operation_id="debug_trigger_synthesis.bucket=default",
+    dependencies=[Depends(require_operator())],
+)
+async def trigger_synthesis(
+    request: TriggerSynthesisRequest,
+    qdrant: QdrantClient = Depends(get_qdrant_client),
+    embedder: Embedder = Depends(get_embedder),
+) -> TriggerSynthesisResponse:
+    """Drive one synthesis tick on demand.
+
+    Test-hook for the integration harness (Issue #119). Restricted to
+    operator-scope tokens; the synthesis loop is expensive enough that
+    arbitrary callers shouldn't trigger it. Production workers run
+    synthesis on their own tick loop; this endpoint exists so the
+    integration suite can deterministically exercise the path without
+    an embedded worker.
+    """
+    from fastapi import HTTPException
+
+    from musubi.lifecycle.events import LifecycleEventSink
+    from musubi.lifecycle.synthesis import (
+        SynthesisCursor,
+        synthesis_run,
+    )
+
+    if not request.simulate_ollama_offline:
+        # Real OllamaClient impl is future work — there's no production
+        # implementation of SynthesisOllamaClient in the codebase today
+        # (workers construct their own). Return 501 so the caller
+        # surfaces the gap cleanly.
+        raise HTTPException(
+            status_code=501,
+            detail=(
+                "trigger_synthesis without simulate_ollama_offline=true "
+                "needs a production OllamaClient impl; the current "
+                "codebase ships only the Protocol + worker-side "
+                "construction. Issue #119's offline scenario uses the "
+                "simulate flag; see the spec."
+            ),
+        )
+
+    settings = get_settings()
+    cursor = SynthesisCursor(db_path=settings.lifecycle_sqlite_path)
+    sink = LifecycleEventSink(db_path=settings.lifecycle_sqlite_path)
+    ollama = _NoOpOllamaClient()
+
+    report = await synthesis_run(
+        client=qdrant,
+        sink=sink,
+        ollama=ollama,
+        embedder=embedder,
+        cursor=cursor,
+        namespace=request.namespace,
+    )
+    return TriggerSynthesisResponse(
+        namespace=report.namespace,
+        memories_selected=report.memories_selected,
+        clusters_formed=report.clusters_formed,
+        concepts_created=report.concepts_created,
+        concepts_reinforced=report.concepts_reinforced,
+        contradictions_detected=report.contradictions_detected,
+        cursor_advanced_to=report.cursor_advanced_to,
     )
 
 

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -229,11 +229,54 @@ def test_concept_synthesis_flow_ollama_present() -> None:
     """Bullet 10 — placeholder; lifecycle-worker trigger followup."""
 
 
-@pytest.mark.skip(
-    reason="ollama-offline scenario needs a separate compose profile (or runtime ollama stop) that this slice didn't carve to keep scope tight; tracked as follow-up Issue. Harness primitives ready."
-)
-def test_concept_synthesis_flow_ollama_offline() -> None:
-    """Bullet 11 — placeholder; ollama-offline compose-profile followup."""
+async def test_concept_synthesis_flow_ollama_offline(
+    live_stack: StackHandle,
+) -> None:
+    """Bullet 11 — synthesis_run degrades gracefully when Ollama is
+    offline (logs 'LLM unavailable', returns a zero-concept report,
+    doesn't crash). Closes Issue #119.
+
+    Instead of a sibling ollama-offline compose profile, this uses the
+    debug endpoint ``POST /v1/ops/debug/trigger-synthesis`` with
+    ``simulate_ollama_offline=true`` — wires a NoOp OllamaClient whose
+    methods always return None, which is the exact shape synthesis_run
+    expects for offline. Same observable behaviour as
+    ``docker compose stop ollama`` but deterministic + self-contained.
+
+    Note: Issue #119's original spec asked for "placeholder + re-enrichment
+    queue" behaviour; reading the current synthesis_run shows it just
+    skips the cluster entirely on Ollama-None and returns a zero report.
+    The placeholder/re-enrichment behaviour isn't in the current
+    lifecycle code — future design work (not this PR's scope). What IS
+    testable + meaningful: the synthesis loop doesn't crash on Ollama
+    absence.
+    """
+    async with httpx.AsyncClient(
+        base_url=live_stack.api_url,
+        headers={"Authorization": f"Bearer {live_stack.operator_token}"},
+        timeout=30.0,
+    ) as client:
+        resp = await client.post(
+            "/ops/debug/trigger-synthesis",
+            json={
+                "namespace": "eric/integration-test",
+                "simulate_ollama_offline": True,
+            },
+        )
+        resp.raise_for_status()
+        report = resp.json()
+
+    # Graceful-degradation invariants: no crash + zero concepts (because
+    # the loop skipped every cluster on the None response).
+    assert report["namespace"] == "eric/integration-test"
+    assert report["concepts_created"] == 0
+    assert report["concepts_reinforced"] == 0
+    # memories_selected / clusters_formed are shape-dependent on prior
+    # test state; just assert they're non-negative ints.
+    assert isinstance(report["memories_selected"], int)
+    assert isinstance(report["clusters_formed"], int)
+    assert report["memories_selected"] >= 0
+    assert report["clusters_formed"] >= 0
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Closes #119.

Adds `POST /v1/ops/debug/trigger-synthesis` (operator-scope) — the test-hook the integration harness needed to verify synthesis_run's graceful-degradation behaviour when Ollama is unreachable, without embedding the lifecycle worker into the API or carving a sibling `docker-compose.ollama-offline.test.yml`.

## What lands

**[src/musubi/api/routers/ops.py](src/musubi/api/routers/ops.py)** — new endpoint:
- `POST /v1/ops/debug/trigger-synthesis` gated by `require_operator()`.
- Body: `{namespace: str, simulate_ollama_offline: bool = False}`.
- Constructs a `_NoOpOllamaClient` (returns None on every call, satisfying the `SynthesisOllamaClient` Protocol for the offline path), then calls `musubi.lifecycle.synthesis.synthesis_run` with the live Qdrant + Embedder + the stub client.
- Returns the `SynthesisReport` verbatim as JSON.
- Non-simulate path returns 501 — production workers construct their own Ollama client; no centralized HTTP client impl exists in the codebase today.

**[tests/integration/test_smoke.py](tests/integration/test_smoke.py)** — bullet 11 unskipped:
- `test_concept_synthesis_flow_ollama_offline` replaces its placeholder with a real call to the debug endpoint + assertions on the returned `SynthesisReport`.

## Scope note on Issue #119's original spec

The Issue described offline behaviour as *"placeholder returned + re-enrichment queued."* Reading the current `synthesis_run` shows it just logs `"LLM unavailable"` and returns a zero-concept report — the placeholder/re-enrichment semantics aren't in today's lifecycle code. What's testable today is the *"doesn't crash, returns empty report"* invariant, which this PR covers. Richer placeholder/re-enrichment semantics would be a future lifecycle-design slice, not a test-only follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)