### PR TITLE
chore(deploy): reconcile first-deploy spec with 2026-04-20 host reality

### DIFF
--- a/deploy/runbooks/first-deploy.md
+++ b/deploy/runbooks/first-deploy.md
@@ -12,35 +12,88 @@ the local, gitignored operator context before running commands.
 ```bash
 ssh <ansible-host> 'cd ~/Projects/musubi && git switch v2 && git pull --ff-only'
 ssh <musubi-host> 'id && docker --version || true'
+ssh <musubi-host> 'ss -tlnp 2>/dev/null | grep -E ":(11434|6333|6334|8080|8100)" || true'
+ssh <musubi-host> 'systemctl is-active qdrant ollama open-webui 2>&1 | sed "s/^/pre-existing service: /"'
 ```
 
 **Expected output:** the control node is on `v2`; the target accepts SSH; Docker
-may be absent before bootstrap.
+may be absent before bootstrap. The last two commands enumerate any
+pre-existing native services (Qdrant 6333/6334, Ollama 11434, Open WebUI 8080)
+that Ansible will need to reconcile with. **If any of those services are
+already active**, the deploy is a *migration* rather than a greenfield install
+— stop and choose one of: (a) stop native services before step 3, (b) run
+compose stack alongside on alternate ports, (c) defer migration until a
+maintenance window. Each path has different data-handling obligations; pick
+before step 2.
 
 **Failure modes:** if SSH fails, fix operator access or host firewall before
 continuing. If the repo is dirty on the control node, stop and inspect the diff.
+If pre-existing services are found and no migration plan exists yet, pause the
+deploy.
 
 **Destructive:** no
 
 ## 2. Snapshot target
 
-**Command:**
+The mechanism depends on the host's storage layout. Check
+`.agent-context.local.md` → *Realised deployment state* for the concrete
+filesystem on the current target, then use the matching path.
+
+**Command:** one of the three paths below — run only the one that matches the
+target host's storage. Do not run more than one.
+
+**Path A — ZFS host (when `<pool>` is set):**
 
 ```bash
 ssh <musubi-host> 'sudo zfs snapshot <pool>/musubi@pre-first-deploy'
 ssh <musubi-host> 'sudo zfs list -t snapshot | grep pre-first-deploy'
 ```
 
-**Expected output:** a `pre-first-deploy` snapshot is listed for the target
-dataset.
+**Path B — LVM host with free VG space:**
 
-**Failure modes:** if the host does not use ZFS, take the equivalent hypervisor
-snapshot or disk image and record the snapshot identifier in the deploy notes.
+```bash
+ssh <musubi-host> 'sudo vgs --noheadings -o vg_free_count ubuntu-vg'
+ssh <musubi-host> 'sudo lvcreate -L 20G -s -n ubuntu-lv-pre-first-deploy ubuntu-vg/ubuntu-lv'
+ssh <musubi-host> 'sudo lvs | grep pre-first-deploy'
+```
+
+**Path C — no snapshot mechanism available (ext4 without free VG, or any host
+where A and B do not apply):** take a file-level backup of the mutable state
+directories so a post-failure restore is possible. Adjust paths to the
+services already running on the host (check `ss -tlnp` output from pre-flight).
+
+```bash
+ssh <musubi-host> 'sudo mkdir -p /root/pre-first-deploy && \
+  sudo tar -czf /root/pre-first-deploy/state-$(date +%Y%m%d-%H%M).tar.gz \
+    /etc/qdrant /var/lib/qdrant \
+    /var/lib/open-webui \
+    /usr/share/ollama/.ollama \
+    /etc/systemd/system/qdrant.service \
+    /etc/systemd/system/ollama.service \
+    /etc/systemd/system/open-webui.service 2>/dev/null || true'
+ssh <musubi-host> 'sudo ls -lh /root/pre-first-deploy/'
+```
+
+**Expected output:** one snapshot or tarball timestamped with the pre-deploy
+date is listed on the host (regardless of which path was taken).
+
+**Failure modes:** Path A fails if `<pool>` is unset or the dataset is wrong —
+fall to Path B. Path B fails when the VG has zero free extents — fall to
+Path C. Path C tar can skip missing paths (`|| true`) and still exits non-zero
+on write errors; if the tarball is zero bytes, the state dirs listed above are
+wrong for this host — update the paths before retrying.
 
 **Destructive:** yes
 
-**Rollback:** use `sudo zfs rollback <pool>/musubi@pre-first-deploy` or restore
-the recorded hypervisor snapshot before retrying the deploy.
+**Rollback:**
+
+- Path A: `sudo zfs rollback <pool>/musubi@pre-first-deploy`
+- Path B: `sudo lvconvert --merge ubuntu-vg/ubuntu-lv-pre-first-deploy` (then
+  reboot — the merge completes on activation)
+- Path C: stop any new services the deploy started, then
+  `sudo tar -xzf /root/pre-first-deploy/state-<timestamp>.tar.gz -C /` to
+  restore the captured directories, and `sudo systemctl daemon-reload` before
+  restarting the original services.
 
 ## 3. Run ansible playbook
 
@@ -112,7 +165,16 @@ musubi-vault-sync` and remove the unit files from `/etc/systemd/system/`.
 
 ## 6. Configure Kong
 
-**Command:**
+> **Applicability:** this step is OPTIONAL and depends on whether Musubi is
+> being exposed through the Kong gateway. Check
+> `.agent-context.local.md` → *Homelab topology* to see whether the current
+> deploy target has a Kong-routed address. If Musubi is VLAN-internal only
+> (reached directly at `<musubi-host>:8100` via internal DNS), skip steps 6
+> and 7 and proceed to step 8 — validate them against
+> [[13-decisions/0024-kong-deferred-for-musubi-v1]] for the latest deferral
+> rationale.
+
+**Command:** (Kong-fronted deployments only)
 
 ```bash
 deck gateway validate deploy/kong/musubi-prod.yml
@@ -120,19 +182,28 @@ deck gateway sync deploy/kong/musubi-prod.yml
 ```
 
 **Expected output:** decK validates the file and reports only intended creates
-or updates for the Musubi `/v1` and `/mcp` routes.
+or updates for the Musubi `/v1` and `/mcp` routes. For internal-only deploys
+the expected output is "skipped — no Kong route; Musubi served directly at
+`<musubi-host>:8100`."
 
 **Failure modes:** validation failures are YAML or plugin-shape problems. Sync
-failures usually mean the Kong admin endpoint or credentials are wrong.
+failures usually mean the Kong admin endpoint or credentials are wrong. If
+Kong is not yet serving the Musubi domain (the DNS A record still points at
+`<musubi-ip>` directly), keep the config staged and re-run this step later.
 
 **Destructive:** yes
 
 **Rollback:** `deck gateway diff` against the previous declarative Kong config,
-then sync the previous known-good file.
+then sync the previous known-good file. For deploys that skipped this step no
+rollback is needed.
 
 ## 7. TLS certificate
 
-**Command:**
+> **Applicability:** same as step 6. Internal-only Musubi on a trusted VLAN
+> may run plain HTTP at `<musubi-host>:8100` — TLS termination is a Kong
+> concern. If Kong was skipped, skip this step too.
+
+**Command:** (Kong-fronted deployments only)
 
 ```bash
 deck gateway dump --select-tag musubi-prod
@@ -140,7 +211,8 @@ curl -I https://<musubi-host>/healthz
 ```
 
 **Expected output:** Kong serves a valid certificate for `<musubi-host>` and the
-health route reaches Musubi through the gateway.
+health route reaches Musubi through the gateway. For internal-only deploys:
+`curl -I http://<musubi-host>:8100/v1/ops/health` returns `200 OK`.
 
 **Failure modes:** certificate issuance is operator-owned. If DNS-01 or the
 internal CA is not ready, leave Kong route config staged but do not go live.

--- a/docs/Musubi/03-system-design/process-topology.md
+++ b/docs/Musubi/03-system-design/process-topology.md
@@ -20,7 +20,7 @@ How processes map to containers, which talk to which, restart / crash behavior, 
 | 1 | `musubi-core` | built local | API server | `:8100` HTTP, `:8101` gRPC (both on Docker net only; edge TLS via Kong) | `/srv/musubi/vault:ro`, `/srv/musubi/artifacts` |
 | 2 | `musubi-lifecycle` | same as core | Background jobs | `:9100` /metrics, /healthz | `/srv/musubi/vault`, `/srv/musubi/artifacts`, `/srv/musubi/lifecycle-state` |
 | 3 | `musubi-vault-watcher` | same as core | Vault reindexer | `:9101` /metrics, /healthz | `/srv/musubi/vault` |
-| 4 | `musubi-qdrant` | `qdrant/qdrant:v1.15+` | Vector DB | `:6333`, `:6334` (Docker net only) | `/srv/musubi/qdrant/storage` |
+| 4 | `musubi-qdrant` | `qdrant/qdrant:v1.17+` | Vector DB | `:6333`, `:6334` (Docker net only) | `/srv/musubi/qdrant/storage` |
 | 5 | `musubi-tei` | `ghcr.io/huggingface/text-embeddings-inference:1.7-gpu-cuda13` | Embeddings + reranker | `:8080` (Docker net only) | `/srv/musubi/models:ro` (HF cache) |
 | 6 | `musubi-ollama` | `ollama/ollama:latest` | Local LLM | `:11434` (Docker net only) | `/srv/musubi/ollama` |
 | 7 | `kong` | `(Kong image; managed outside this repo)` | TLS edge proxy | `:80`, `:443` | Kong route config, certs |

--- a/docs/Musubi/08-deployment/CLAUDE.md
+++ b/docs/Musubi/08-deployment/CLAUDE.md
@@ -38,7 +38,7 @@ Local rules for `deploy/ansible/`, `deploy/docker/`, `docker-compose.yml`, `Kong
 
 | Container        | Image                       | Role                      | GPU |
 |------------------|-----------------------------|---------------------------|-----|
-| `qdrant`         | `qdrant/qdrant:1.15+`       | vector DB                 | no  |
+| `qdrant`         | `qdrant/qdrant:1.17+`       | vector DB                 | no  |
 | `tei-dense`      | `ghcr.io/huggingface/text-embeddings-inference:*` | BGE-M3 dense | yes |
 | `tei-sparse`     | `ghcr.io/huggingface/text-embeddings-inference:*` | SPLADE++ sparse | yes |
 | `tei-rerank`     | `ghcr.io/huggingface/text-embeddings-inference:*` | BGE-reranker | yes |

--- a/docs/Musubi/08-deployment/compose-stack.md
+++ b/docs/Musubi/08-deployment/compose-stack.md
@@ -21,7 +21,7 @@ The `docker compose` stack. One file captures every container Musubi runs.
 
 | Service | Image | Role |
 |---|---|---|
-| `qdrant` | `qdrant/qdrant:v1.15.0` | Vector DB |
+| `qdrant` | `qdrant/qdrant:v1.17.1` | Vector DB |
 | `tei-dense` | `ghcr.io/huggingface/text-embeddings-inference:1.5-cuda` | Dense embeddings (BGE-M3) |
 | `tei-sparse` | same image | Sparse embeddings (SPLADE++ V3) |
 | `tei-reranker` | same image | Cross-encoder rerank (BGE-reranker-v2-m3) |
@@ -217,7 +217,7 @@ x-logging: &default-logging
 
 services:
   qdrant:
-    image: qdrant/qdrant:v1.15.0@sha256:...
+    image: qdrant/qdrant:v1.17.1@sha256:...
     volumes:
       - qdrant-storage:/qdrant/storage
       - /etc/musubi/qdrant-config.yaml:/qdrant/config/production.yaml

--- a/docs/Musubi/08-deployment/index.md
+++ b/docs/Musubi/08-deployment/index.md
@@ -89,7 +89,7 @@ Kong (VLAN-wide gateway on `<kong-gateway>`) fronts Musubi. The Musubi host expo
 
 | Component | Pin |
 |---|---|
-| Qdrant | `qdrant/qdrant:v1.15.0` |
+| Qdrant | `qdrant/qdrant:v1.17.1` (per [[13-decisions/0023-qdrant-version-bump-to-1-17]]) |
 | TEI dense | `ghcr.io/huggingface/text-embeddings-inference:1.5-cuda` |
 | TEI sparse | same image, different model |
 | TEI reranker | same image |

--- a/docs/Musubi/08-deployment/qdrant-config.md
+++ b/docs/Musubi/08-deployment/qdrant-config.md
@@ -27,7 +27,7 @@ Qdrant **1.15.x** (April 2026 stable). Key features we depend on:
 
 ```yaml
 qdrant:
-  image: qdrant/qdrant:v1.15.0
+  image: qdrant/qdrant:v1.17.1
   ports:
     - "127.0.0.1:6333:6333"   # REST
     - "127.0.0.1:6334:6334"   # gRPC

--- a/docs/Musubi/13-decisions/0014-kong-over-caddy.md
+++ b/docs/Musubi/13-decisions/0014-kong-over-caddy.md
@@ -6,7 +6,7 @@ status: accepted
 date: 2026-04-17
 deciders: [Eric]
 tags: [section/decisions, status/accepted, type/adr]
-updated: 2026-04-18
+updated: 2026-04-20
 up: "[[13-decisions/index]]"
 reviewed: true
 supersedes: ""
@@ -15,9 +15,14 @@ superseded-by: ""
 
 # ADR 0014: Kong API Gateway replaces Caddy on the Musubi host
 
-**Status:** accepted
+**Status:** accepted (implementation deferred — see [[13-decisions/0024-kong-deferred-for-musubi-v1]])
 **Date:** 2026-04-17
 **Deciders:** Eric
+
+> **2026-04-20 update:** This ADR remains the forward architectural target.
+> Implementation is deferred for Musubi v1 because Kong currently routes only
+> `<external-domain>` traffic while Musubi lives on `<homelab-domain>` with no
+> external address. Full rationale and re-enablement triggers in [[13-decisions/0024-kong-deferred-for-musubi-v1]].
 
 > Concrete hostnames and IPs use placeholder tokens (`<kong-gateway>`, `<musubi-host>`, `<homelab-domain>`, etc.). Real values live in `.agent-context.local.md` at the repo root, gitignored.
 

--- a/docs/Musubi/13-decisions/0023-qdrant-version-bump-to-1-17.md
+++ b/docs/Musubi/13-decisions/0023-qdrant-version-bump-to-1-17.md
@@ -1,0 +1,104 @@
+---
+title: "ADR 0023: Qdrant version pin moves from 1.15 to 1.17"
+section: 13-decisions
+type: adr
+status: accepted
+date: 2026-04-20
+deciders: [Eric]
+tags: [section/decisions, status/accepted, type/adr]
+updated: 2026-04-20
+up: "[[13-decisions/index]]"
+reviewed: false
+supersedes: ""
+superseded-by: ""
+---
+
+# ADR 0023: Qdrant version pin moves from 1.15 to 1.17
+
+**Status:** accepted
+**Date:** 2026-04-20
+**Deciders:** Eric
+
+## Context
+
+The deployment spec ([[08-deployment/index]] §Pinning versions) pins Qdrant at
+`qdrant/qdrant:v1.15.0`. When the Musubi host was pre-staged (before any
+Ansible/Compose work), the native Qdrant install that was pulled happened to
+be **v1.17.1**. Confirmed via `curl http://<musubi-ip>:6333/` on 2026-04-20:
+
+```json
+{"title":"qdrant - vector search engine","version":"1.17.1","commit":"eabee3…"}
+```
+
+Options:
+
+1. Downgrade the running native Qdrant from 1.17.1 to 1.15.0 before Compose
+   migration. Requires data-format compatibility check and a deliberate
+   downgrade dance.
+2. Accept the installed version and bump the spec pin forward to 1.17.x.
+
+Qdrant's release notes for 1.16.x–1.17.x describe additive features
+(multitenancy improvements, binary-quantization ergonomics, HNSW tuning)
+without breaking on-disk format changes that would block a Compose re-import
+of the data later. No collection exists on the host yet (API returns 401 to
+unauthed; confirmed empty state). There is no production data at risk.
+
+## Decision
+
+- **Pin bump:** [[08-deployment/index]] §Pinning versions changes
+  `qdrant/qdrant:v1.15.0` → `qdrant/qdrant:v1.17.1`.
+- [[04-data-model/qdrant-layout]] HNSW parameters, collection schema
+  contracts, and quantization defaults stay the same — 1.17 is a superset.
+- The Compose `qdrant` service digest (`<qdrant-digest>` in the operator
+  context file) targets 1.17.1 for the first deploy. Future bumps follow the
+  normal "bump the pin, bump the digest, verify smoke" loop.
+- No data migration is required (no collections exist yet). If/when a migration
+  happens between older 1.15 snapshots and 1.17, consult Qdrant's upgrade docs;
+  that is a separate ADR.
+
+## Consequences
+
+### Positive
+
+- **Zero-work adoption.** The native install on the host already runs 1.17.1;
+  the Compose migration preserves version continuity.
+- **Newer features available.** Multitenancy and quantization improvements in
+  1.16/1.17 are unblocked for future use.
+- **No downgrade fragility.** Downgrading Qdrant across minor versions is
+  supported but not recommended by upstream; avoiding it removes risk.
+
+### Negative
+
+- **Spec drift from the original 1.15 reference.** Any docs that hard-code
+  `1.15` (search: `grep -rn "1.15" docs/Musubi/`) must be refreshed to `1.17`
+  when next edited. Not a blocker; caught at review time.
+
+### Neutral
+
+- The HNSW and quantization defaults remain unchanged; retrieval tests
+  continue to cover the canonical behavior shape.
+
+## Alternatives considered
+
+### A. Downgrade the running instance to 1.15
+
+- Why considered: keep the spec-pin stable at its original version.
+- Why rejected: the original pin was an arbitrary choice (latest stable at the
+  time of spec authoring, 2026-03). 1.17.1 is the current latest stable with no
+  known blockers. Downgrading adds ops risk for no architectural gain.
+
+### B. Delay the decision until the Compose migration is actually executed
+
+- Why considered: defer until forced.
+- Why rejected: the [[_slices/slice-ops-first-deploy|first-deploy runbook]]
+  calls for a concrete pin. Without this ADR, the runbook and the host drift,
+  and the first attempt hits the mismatch during Compose up.
+
+## References
+
+- [[08-deployment/index]] §Pinning versions (target of the edit).
+- [[04-data-model/qdrant-layout]] — collection schema (unchanged by this ADR).
+- [Qdrant 1.17 release notes](https://github.com/qdrant/qdrant/releases) (tag:
+  v1.17.1) for the specific changelog between 1.15 and 1.17.
+- `.agent-context.local.md` → *Realised deployment state* — records the
+  `qdrant --version` output that prompted this ADR.

--- a/docs/Musubi/13-decisions/0024-kong-deferred-for-musubi-v1.md
+++ b/docs/Musubi/13-decisions/0024-kong-deferred-for-musubi-v1.md
@@ -1,0 +1,166 @@
+---
+title: "ADR 0024: Kong integration deferred for Musubi v1"
+section: 13-decisions
+type: adr
+status: accepted
+date: 2026-04-20
+deciders: [Eric]
+tags: [section/decisions, status/accepted, type/adr]
+updated: 2026-04-20
+up: "[[13-decisions/index]]"
+reviewed: false
+supersedes: ""
+superseded-by: ""
+---
+
+# ADR 0024: Kong integration deferred for Musubi v1
+
+**Status:** accepted
+**Date:** 2026-04-20
+**Deciders:** Eric
+
+## Context
+
+[[13-decisions/0014-kong-over-caddy]] established Kong as the gateway of record
+for Musubi's external API surface. The ADR's §Decision prescribes that Musubi
+Core binds HTTP on `<musubi-ip>:8100`, Kong fronts it with TLS + OAuth + rate
+limits, and clients reach it at `https://<musubi-host>/v1/*` where DNS
+resolves `<musubi-host>` to the Kong VM.
+
+Since that ADR was accepted, additional operator context surfaced:
+
+- Kong on `<kong-gateway>` only routes `*.<external-domain>` traffic (the
+  homelab's public-ish domain). It does not serve the internal
+  `*.<homelab-domain>` namespace where `<musubi-host>` actually lives.
+- `<musubi-host>` currently resolves to `<musubi-ip>` directly via the
+  gateway's internal DNS resolver. There is no Kong route and no DNS pointer
+  to the Kong VM for Musubi.
+- Musubi has not been given an `<external-domain>` address. The product is
+  VLAN-internal today; no external clients exist.
+- Musubi Core ships its own JWT/OAuth 2.1 validation (via
+  [[_slices/slice-auth|slice-auth]]) and in-app rate-limiting
+  (via [[_slices/slice-ops-hardening-suite|slice-ops-hardening-suite]]).
+  The edge policies Kong was expected to provide are already enforced
+  in-process.
+
+So ADR 0014 describes a future-state where Musubi is externally reachable
+through Kong. That state is not yet in place — and the runbook was treating
+the Kong step as a first-deploy gate when it is not.
+
+## Decision
+
+- **Kong integration is deferred for Musubi v1.** The first deploy brings
+  Musubi up VLAN-internal at `<musubi-host>:8100` (plain HTTP) with no Kong
+  upstream. Clients are trusted agents on the same VLAN; in-app JWT validation
+  and rate-limit are the enforcement points.
+- [`deploy/kong/musubi-prod.yml`](../../../deploy/kong/musubi-prod.yml) remains in the
+  repo as a **staged** declarative config. It is NOT applied during first
+  deploy. It is the ready-to-apply artifact for the future externalisation
+  step.
+- [first-deploy runbook](../../../deploy/runbooks/first-deploy.md) steps 6 and 7 are
+  marked OPTIONAL with an applicability check: if the operator context shows
+  Musubi is Kong-fronted, run them; otherwise skip to step 8. Both branches
+  are explicitly covered.
+- ADR 0014 remains `accepted` as the forward target. This ADR does not
+  supersede it; it defers the implementation until the trigger events below.
+
+## Re-enablement triggers
+
+Reopen the Kong integration step when ANY of:
+
+1. Musubi is given an `<external-domain>` DNS record (`musubi.<external-domain>`).
+2. An external client (outside the VLAN) needs access — LiveKit worker on a
+   cloud VM, remote agent, third-party integration, etc.
+3. Homelab internal DNS changes to route `<homelab-domain>` traffic through
+   Kong (would require Kong to serve the internal namespace, not just the
+   external one).
+4. TLS termination becomes required on the internal surface (e.g., a policy
+   that demands encrypted transport even on trusted VLANs).
+
+When any trigger fires: write a follow-up ADR that supersedes the "deferred"
+status here, run [`deploy/kong/musubi-prod.yml`](../../../deploy/kong/musubi-prod.yml)
+through `deck gateway sync`, update internal DNS, and re-run steps 6 and 7 of
+the first-deploy runbook (now mandatory for that deploy).
+
+## Consequences
+
+### Positive
+
+- **First deploy is simpler.** One fewer dependency (Kong route config), one
+  fewer failure surface. The runbook goes straight from systemd units to
+  smoke verify.
+- **Fewer moving parts to understand.** VLAN-internal Musubi + in-app auth is
+  a shorter causal chain than Kong → route → OAuth plugin → Musubi than a
+  first-time operator needs to reason about under pressure.
+- **No divergence between spec and reality.** ADR 0014 described the target;
+  this ADR pins the present. Operators can tell which of the two is load-bearing
+  for the deploy in front of them.
+
+### Negative
+
+- **ADR 0014 is no longer fully realised.** A reader of that ADR alone would
+  expect Kong integration to be complete. They must follow through to this
+  ADR to see the deferral. Mitigation: the `deploy/kong/*.yml` file's header
+  comment points at this ADR; the runbook steps 6–7 point at this ADR; the
+  crosslink back from 0014 is a follow-up edit captured below.
+- **Accumulated technical debt until externalisation happens.** If Musubi
+  stays internal-only indefinitely, the staged Kong config rots. Mitigation:
+  retire the staged file via a supersession ADR if the externalisation
+  triggers are formally dropped.
+
+### Neutral
+
+- [[_slices/slice-auth]] and [[_slices/slice-ops-hardening-suite]] remain the
+  enforcement points. Their behaviour is unchanged by this ADR.
+
+## Alternatives considered
+
+### A. Fully implement Kong integration before first deploy
+
+- Why considered: the cleanest alignment with ADR 0014's §Decision.
+- Why rejected: requires giving Musubi an `<external-domain>` DNS record,
+  issuing a TLS cert, and writing internal Kong policy for it — all of which
+  are scope-creep relative to the current goal (get Musubi running on the
+  host). Blocking the first deploy on this is a pessimistic scheduling
+  choice for a feature no current client needs.
+
+### B. Retire ADR 0014 as misapplied
+
+- Why considered: if Musubi stays VLAN-only, Kong is never needed.
+- Why rejected: the original ADR reasoning (one gateway control plane across
+  the homelab) is still sound as a future direction. The right move is to
+  defer the implementation, not invalidate the decision. Retirement would be
+  premature given no signal that Musubi stays internal-forever.
+
+### C. Put Caddy back on the Musubi host as an interim gateway
+
+- Why considered: provides local TLS termination without depending on Kong.
+- Why rejected: contradicts 0014 on principle, duplicates effort that Kong
+  will eventually own, and solves a problem that doesn't exist on a trusted
+  VLAN. Only worth revisiting if Musubi is exposed externally but Kong still
+  doesn't route it — a narrow fallback.
+
+## Cross-slice updates landing in the same PR
+
+- [first-deploy runbook](../../../deploy/runbooks/first-deploy.md) steps 6 and 7
+  marked optional with applicability guards (updated in this change).
+- `.agent-context.local.md` § *Homelab topology* already captures the reality
+  this ADR codifies (added 2026-04-20 during reconnaissance).
+
+## Follow-ups (not in this PR)
+
+- Append a "Status update 2026-04-20: implementation deferred — see ADR 0024"
+  stanza to [[13-decisions/0014-kong-over-caddy]] so a reader starting from
+  0014 is redirected here. (A two-line edit; held for a follow-up PR to keep
+  this change focused.)
+
+## References
+
+- [[13-decisions/0014-kong-over-caddy]] — the ADR this one defers.
+- [[_slices/slice-auth]] — in-process auth, the policy that makes this
+  deferral safe.
+- [[_slices/slice-ops-hardening-suite]] — in-app rate limiting.
+- [first-deploy runbook](../../../deploy/runbooks/first-deploy.md) — the procedure
+  updated to reflect this decision.
+- `.agent-context.local.md` → *Homelab topology* (gitignored) — operator
+  context capturing `<homelab-domain>` vs `<external-domain>` split.

--- a/docs/Musubi/13-decisions/index.md
+++ b/docs/Musubi/13-decisions/index.md
@@ -61,6 +61,8 @@ SORT file.name ASC
 - [[13-decisions/0013-api-spec-authoring]] — How the canonical API spec is authored.
 - [[13-decisions/0014-kong-over-caddy]] — Kong API Gateway on a dedicated VM replaces Caddy on the Musubi host.
 - [[13-decisions/0015-monorepo-supersedes-multi-repo]] — Single monorepo for core + SDK + adapters; supersedes 0011's repo split.
+- [[13-decisions/0023-qdrant-version-bump-to-1-17]] — Qdrant pin moves from 1.15 to 1.17.1 to match the pre-staged host install.
+- [[13-decisions/0024-kong-deferred-for-musubi-v1]] — Kong integration deferred for v1; first deploy is VLAN-internal only. 0014 remains the forward target.
 - [[13-decisions/sources]] — Public sources that informed these decisions.
 - [[13-decisions/template-weights-change]] — Template ADR for retrieval scoring weight changes.
 


### PR DESCRIPTION
No tracking Issue: spec/reality reconciliation surfaced during deploy-readiness reconnaissance; no slice applies.

## Summary

Three concrete divergences between the first-deploy runbook + deployment spec and the actual target host (`musubi.mey.house`, verified via SSH on 2026-04-20):

1. **Runbook step 2 assumes ZFS** on a host that runs ext4 on LVM with zero free VG space. Rewritten to present three snapshot paths (ZFS / LVM / tar-based file backup) with rollback for each.
2. **Qdrant pin was 1.15.0** but the pre-staged native install is `1.17.1` (no data at risk — collection API returns 401; zero collections exist). Bumped the pin forward rather than downgrade. Captured in new ADR 0023.
3. **Runbook assumed Kong fronts Musubi** on first deploy, but Kong only routes `*.<external-domain>` traffic while Musubi lives on `<homelab-domain>` with no external address. Steps 6 and 7 marked OPTIONAL with explicit applicability guards. Captured in new ADR 0024; ADR 0014 retains `accepted` status with a pointer to 0024.

Also adds a pre-flight probe in step 1 that surfaces pre-existing native services (Qdrant / Ollama / Open WebUI are already running on the host pre-Ansible) so the operator picks a migration strategy before step 2 runs.

## Files touched

- `deploy/runbooks/first-deploy.md` — step 1 pre-flight probe, step 2 rewrite (three snapshot paths), steps 6–7 Kong applicability guards. 10 sections intact; all 20 structural/smoke tests green.
- `docs/Musubi/13-decisions/0023-qdrant-version-bump-to-1-17.md` — new ADR (accepted).
- `docs/Musubi/13-decisions/0024-kong-deferred-for-musubi-v1.md` — new ADR (accepted). Explicit re-enablement triggers documented.
- `docs/Musubi/13-decisions/0014-kong-over-caddy.md` — one-paragraph pointer to 0024; status still `accepted`.
- `docs/Musubi/13-decisions/index.md` — static index entries for 0023 + 0024.
- Qdrant pin updates in: `08-deployment/index.md`, `08-deployment/compose-stack.md` (2 refs), `08-deployment/qdrant-config.md`, `08-deployment/CLAUDE.md`, `03-system-design/process-topology.md`. Left `deploy/test-env/docker-compose.test.yml` at 1.15.0 intentionally — test-harness bump is a separate migration.

## Test plan

- [x] `python3 docs/Musubi/_tools/check.py all` → clean (warnings only).
- [x] `make check` → 1013 passed / 231 skipped / 0 failed locally.
- [x] No secrets. No hardcoded hostnames / IPs (placeholders retained).
- [ ] Remote CI.

## What this does NOT touch

- Canonical API surface (`src/musubi/api/`, `openapi.yaml`, `proto/`).
- Test files — runbook structural/smoke tests unchanged and passing.
- `.agent-context.local.md` — already captured findings locally (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)