### PR TITLE
chore(ansible): bootstrap.yml adds Docker + NVIDIA apt repos; idempotent driver install

### DIFF
--- a/deploy/ansible/bootstrap.yml
+++ b/deploy/ansible/bootstrap.yml
@@ -3,11 +3,81 @@
   hosts: musubi
   become: true
   pre_tasks:
+    # ---- Prereqs for adding third-party apt sources ---------------------
+    - name: Install prerequisites for adding third-party apt repos
+      ansible.builtin.apt:
+        name:
+          - ca-certificates
+          - curl
+          - gnupg
+        state: present
+        update_cache: true
+
+    - name: Create apt keyrings directory
+      ansible.builtin.file:
+        path: /etc/apt/keyrings
+        state: directory
+        mode: "0755"
+
+    # ---- Docker CE apt repo ---------------------------------------------
+    - name: Install Docker's official GPG key
+      ansible.builtin.get_url:
+        url: https://download.docker.com/linux/ubuntu/gpg
+        dest: /etc/apt/keyrings/docker.asc
+        mode: "0644"
+        force: false
+
+    - name: Add Docker apt repository
+      ansible.builtin.apt_repository:
+        repo: "deb [arch={{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+        state: present
+        filename: docker
+        update_cache: false
+
+    # ---- NVIDIA Container Toolkit apt repo ------------------------------
+    - name: Install NVIDIA container toolkit GPG key
+      ansible.builtin.get_url:
+        url: https://nvidia.github.io/libnvidia-container/gpgkey
+        dest: /etc/apt/keyrings/nvidia-container-toolkit.asc
+        mode: "0644"
+        force: false
+
+    - name: Add NVIDIA container toolkit apt source
+      ansible.builtin.copy:
+        dest: /etc/apt/sources.list.d/nvidia-container-toolkit.list
+        content: |
+          deb [signed-by=/etc/apt/keyrings/nvidia-container-toolkit.asc] https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH) /
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Refresh apt cache after adding third-party repos
+      ansible.builtin.apt:
+        update_cache: true
+
+    # ---- NVIDIA driver (skip if one is already present) ----------------
+    # Pre-staged hosts may already have a GPU driver. Don't downgrade or
+    # double-install — check first, and only let ubuntu-drivers autoinstall
+    # take over on a genuinely bare host.
+    - name: Probe for an existing NVIDIA driver
+      ansible.builtin.command: nvidia-smi --query-gpu=driver_version --format=csv,noheader
+      register: nvidia_driver_probe
+      changed_when: false
+      failed_when: false
+      check_mode: false  # read-only probe; must run even in --check mode
+
+    - name: Install NVIDIA driver via ubuntu-drivers (bare hosts only)
+      ansible.builtin.command: ubuntu-drivers autoinstall
+      when: nvidia_driver_probe.rc != 0 or nvidia_driver_probe.stdout | trim == ''
+      register: ubuntu_drivers_result
+      changed_when: "'already installed' not in (ubuntu_drivers_result.stdout | default(''))"
+
+    # ---- Main package install (Docker, NVIDIA toolkit, etc.) -----------
     - name: Install required apt packages
       ansible.builtin.apt:
         name: "{{ musubi_required_packages }}"
         state: present
-        update_cache: true
+        update_cache: false
 
     - name: Ensure Docker service is enabled
       ansible.builtin.systemd_service:
@@ -77,6 +147,16 @@
         proto: tcp
         from_ip: "{{ musubi_kong_ip }}"
         comment: "Kong upstream only"
+      when: musubi_kong_ip | default('') | length > 0
+
+    - name: Allow Musubi Core from the musubi VLAN (when Kong is not yet the gateway)
+      community.general.ufw:
+        rule: allow
+        port: "{{ musubi_core_port }}"
+        proto: tcp
+        from_ip: "{{ musubi_vlan_cidr | default('10.0.20.0/24') }}"
+        comment: "VLAN-internal access — remove when Kong fronts Musubi (ADR 0024)"
+      when: musubi_kong_ip | default('') | length == 0
 
     - name: Enable UFW
       community.general.ufw:

--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -34,8 +34,11 @@ musubi_required_packages:
   - gnupg
   - logrotate
   - nvidia-container-toolkit
-  - nvidia-driver-560-server
   - unattended-upgrades
+# NVIDIA GPU driver is NOT pinned here — a specific `nvidia-driver-NNN-server`
+# package name rots quickly (and will downgrade a pre-staged newer driver).
+# bootstrap.yml instead probes for an existing driver via `nvidia-smi`, and
+# runs `ubuntu-drivers autoinstall` only on hosts that don't have one yet.
 
 musubi_health_urls:
   core: "http://127.0.0.1:8100/v1/ops/health"

--- a/tests/ops/test_ansible.py
+++ b/tests/ops/test_ansible.py
@@ -102,6 +102,7 @@ def test_playbook_syntax() -> None:
 def test_playbook_idempotent_on_clean_vm() -> None:
     idempotent_modules = {
         "ansible.builtin.apt",
+        "ansible.builtin.apt_repository",
         "ansible.builtin.copy",
         "ansible.builtin.file",
         "ansible.builtin.get_url",


### PR DESCRIPTION
No tracking Issue: bug fixes surfaced during first ever end-to-end dry-run of `slice-ops-first-deploy`.

## What happened

First real dry-run of `bootstrap.yml` against `musubi.mey.house` (from yua, with the new parametrised inventory workflow from PR #146) failed on the very first task:

```
TASK [Install required apt packages] ***
fatal: [musubi-workload]: FAILED! => {"msg": "No package matching 'docker-ce' is available"}
```

`slice-ops-first-deploy` had shipped without ever being run end-to-end. Three bugs surfaced.

## Three bugs, one PR

1. **No Docker apt repo setup.** `docker-ce` + `docker-compose-plugin` require Docker's official repo. Ubuntu's default sources don't carry them.
2. **No NVIDIA apt repo setup.** `nvidia-container-toolkit` requires NVIDIA's apt repo.
3. **Hardcoded `nvidia-driver-560-server`** in `musubi_required_packages`. Version rots quickly and would downgrade the already-installed `580.126.20` on the current host.

## The fixes

- New pre-tasks in `bootstrap.yml`: install prereqs → create `/etc/apt/keyrings` → fetch Docker GPG key → add Docker apt repo → fetch NVIDIA GPG key → write NVIDIA apt source → refresh cache.
- Driver install reworked: probe via `nvidia-smi` (with `check_mode: false` so it runs even in dry-run), then `ubuntu-drivers autoinstall` only when the probe fails. Works for pre-staged and bare hosts.
- UFW Kong rule guarded: when `musubi_kong_ip` is empty (ADR 0024 state), allow the Musubi Core port from the VLAN CIDR instead (default `10.0.20.0/24`, overridable). Original Kong-only rule still applies when Kong is re-enabled.
- `nvidia-driver-560-server` dropped from `musubi_required_packages` with a comment explaining why.

## Verified

- `ansible-playbook --syntax-check` all four playbooks.
- `ansible-playbook --check --diff bootstrap.yml` from yua against musubi.mey.house runs through all the repo setup tasks, driver probe (detects existing 580.126.20, skips autoinstall), reaches main `apt install`. Remaining check-mode failure is inherent to `apt_repository` not writing files in check mode.

## Intentionally not in this PR

- Running `bootstrap.yml` for real (operator approval needed).
- Resolving the two `[R]` findings in `docs/Musubi/_inbox/operator-notes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)