### PR TITLE
feat(ops): musubi-core Dockerfile + compose/env fixes → stack fully deployed

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,46 @@
+# Version control
+.git
+.gitignore
+.gitattributes
+
+# Python dev caches
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.hypothesis
+.coverage
+htmlcov
+
+# Virtualenv + uv runtime caches (rebuilt inside the image)
+.venv
+.uv-cache
+
+# IDE / editor state
+.vscode
+.idea
+*.swp
+*.swo
+.DS_Store
+
+# Test + dev-only directories not needed in the runtime image
+tests
+docs
+deploy
+.github
+.claude
+.agents
+.cursor
+.operator
+.agent-context.local.md
+.agent-context.local/
+.agent-brief*.local.md
+.env.example
+
+# Files that would bloat the build context
+*.log
+*.md
+!README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+# syntax=docker/dockerfile:1.9
+#
+# Musubi Core image.
+#
+# Multi-stage: `builder` installs deps via uv into a .venv; `runtime` copies
+# the built venv + source into a slim base. No compilers or build tooling in
+# the final image.
+
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_CACHE_DIR=/uv-cache \
+    UV_PYTHON_DOWNLOADS=never
+
+WORKDIR /app
+
+# Install production deps first so the layer caches when only source changes.
+COPY pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/uv-cache \
+    uv sync --frozen --no-install-project --no-dev
+
+# Now install the project itself.
+COPY src/ ./src/
+COPY README.md ./
+RUN --mount=type=cache,target=/uv-cache \
+    uv sync --frozen --no-dev
+
+
+FROM python:3.12-slim-bookworm AS runtime
+
+# Non-root user to run the service.
+#
+# UID/GID match the `musubi` system user that Ansible's `bootstrap.yml` creates
+# on the target host (uid=999 gid=985). Keeping the in-container IDs aligned
+# lets bind-mounts from the host data dirs (`/var/lib/musubi/*`, `/var/log/musubi`,
+# 0750 perms owned by host `musubi`) be read and written without privilege
+# escalation or chown gymnastics.
+RUN groupadd --system --gid 985 musubi \
+ && useradd  --system --uid 999 --gid 985 --home-dir /app --no-create-home musubi \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder --chown=musubi:musubi /app /app
+
+ENV PATH="/app/.venv/bin:${PATH}" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    MUSUBI_BIND_HOST=0.0.0.0 \
+    MUSUBI_PORT=8100
+
+USER musubi
+
+EXPOSE 8100
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=5 \
+  CMD curl -fsS http://localhost:8100/v1/ops/health || exit 1
+
+CMD ["uvicorn", "--factory", "musubi.api.app:create_app", \
+     "--host", "0.0.0.0", "--port", "8100", \
+     "--proxy-headers", "--forwarded-allow-ips=*"]

--- a/deploy/ansible/deploy.yml
+++ b/deploy/ansible/deploy.yml
@@ -16,7 +16,31 @@
         project_src: "{{ musubi_config_dir }}"
         policy: missing
 
-    - name: Start Musubi stack without moving digest pins
+    - name: Start inference + storage services (everything except core) and wait for healthy
+      community.docker.docker_compose_v2:
+        project_src: "{{ musubi_config_dir }}"
+        state: present
+        pull: missing
+        remove_orphans: true
+        wait: true
+        wait_timeout: 300
+        services:
+          - qdrant
+          - tei-dense
+          - tei-sparse
+          - tei-reranker
+          - ollama
+
+    - name: Ensure the LLM model is pulled into Ollama
+      # Idempotent: `ollama pull` no-ops if the model is already present.
+      # Runs after inference services are up (compose healthchecks guarantee
+      # ollama HTTP is responsive) but before Core starts.
+      ansible.builtin.command:
+        cmd: docker compose -f {{ musubi_config_dir }}/docker-compose.yml exec -T ollama ollama pull {{ musubi_ollama_model }}
+      register: ollama_pull
+      changed_when: "'pulling' in (ollama_pull.stdout | default(''))"
+
+    - name: Start Musubi Core now that inference is up
       community.docker.docker_compose_v2:
         project_src: "{{ musubi_config_dir }}"
         state: present
@@ -33,4 +57,8 @@
       ansible.builtin.uri:
         url: "{{ musubi_health_urls.core }}"
         status_code: 200
+      retries: 12
+      delay: 5
+      register: core_health
+      until: core_health.status == 200
       changed_when: false

--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -16,12 +16,21 @@ musubi_data_dirs:
   - /var/lib/musubi/qdrant-storage
   - /var/lib/musubi/tei-models
   - /var/lib/musubi/ollama-models
+  - /var/lib/musubi/lifecycle
 
 musubi_core_port: 8100
-musubi_core_image: "ghcr.io/example/musubi-core@sha256:<core-digest>"
-musubi_qdrant_image: "qdrant/qdrant@sha256:<qdrant-digest>"
-musubi_tei_image: "ghcr.io/huggingface/text-embeddings-inference@sha256:<tei-digest>"
-musubi_ollama_image: "ollama/ollama@sha256:<ollama-digest>"
+# Musubi Core image. For now this is built locally (see repo `Dockerfile`) and
+# transferred to the target via `docker save | ssh | docker load`. When a
+# GHCR publish workflow lands, flip this to `ghcr.io/ericmey/musubi-core:<tag>`
+# and pin by digest.
+musubi_core_image: "musubi-core:dev"
+musubi_qdrant_image: "qdrant/qdrant:v1.17.1"
+# TEI image tag = <compute-capability>-<version>. RTX 3080 is Ampere,
+# compute 8.6 → `86-*`. Other GPUs: `turing-*` (RTX 20xx), `89-*` (RTX 40xx),
+# `hopper-*` (H100/H200), `cpu-*` (no GPU). See
+# https://github.com/huggingface/text-embeddings-inference for the full list.
+musubi_tei_image: "ghcr.io/huggingface/text-embeddings-inference:86-1.2.0"
+musubi_ollama_image: "ollama/ollama:latest"
 musubi_ollama_model: "qwen3:4b"
 
 musubi_required_packages:

--- a/deploy/ansible/templates/docker-compose.yml.j2
+++ b/deploy/ansible/templates/docker-compose.yml.j2
@@ -1,3 +1,5 @@
+# Managed by deploy/ansible/ — do not edit on the host.
+# Rendered by `deploy/ansible/bootstrap.yml` (and refreshed by `deploy.yml`).
 services:
   core:
     image: {{ musubi_core_image }}
@@ -8,6 +10,8 @@ services:
     volumes:
       - /var/lib/musubi/vault:/var/lib/musubi/vault
       - /var/lib/musubi/artifact-blobs:/var/lib/musubi/artifact-blobs
+      - /var/lib/musubi/lifecycle:/var/lib/musubi/lifecycle
+      - /var/log/musubi:/var/log/musubi
     depends_on:
       qdrant:
         condition: service_healthy
@@ -17,16 +21,24 @@ services:
         condition: service_healthy
       ollama:
         condition: service_healthy
+    restart: unless-stopped
 
   qdrant:
     image: {{ musubi_qdrant_image }}
+    environment:
+      # Qdrant reads its API key from config OR env. Env wins. Keeps the
+      # value out of the mounted config and in the ansible-vault instead.
+      QDRANT__SERVICE__API_KEY: "{{ vault_qdrant_api_key }}"
     volumes:
       - /var/lib/musubi/qdrant-storage:/qdrant/storage
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:6333/health"]
-      interval: 30s
+      # Qdrant image has no curl/wget. Use bash /dev/tcp for liveness.
+      test: ["CMD", "bash", "-c", "exec 6<>/dev/tcp/localhost/6333"]
+      interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 10s
+    restart: unless-stopped
 
   tei-dense:
     image: {{ musubi_tei_image }}
@@ -39,10 +51,15 @@ services:
           devices:
             - capabilities: [gpu]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:80/health"]
-      interval: 30s
+      # TEI image is minimal (no curl/wget/nc). Use bash's /dev/tcp pseudo-
+      # device to verify port 80 is accepting connections. Liveness-only;
+      # model-load errors show up in docker logs if they happen.
+      test: ["CMD", "bash", "-c", "exec 6<>/dev/tcp/localhost/80"]
+      interval: 15s
       timeout: 5s
-      retries: 5
+      retries: 10
+      start_period: 60s
+    restart: unless-stopped
 
   tei-sparse:
     image: {{ musubi_tei_image }}
@@ -55,14 +72,22 @@ services:
           devices:
             - capabilities: [gpu]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:80/health"]
-      interval: 30s
+      # TEI image is minimal (no curl/wget/nc). Use bash's /dev/tcp pseudo-
+      # device to verify port 80 is accepting connections. Liveness-only;
+      # model-load errors show up in docker logs if they happen.
+      test: ["CMD", "bash", "-c", "exec 6<>/dev/tcp/localhost/80"]
+      interval: 15s
       timeout: 5s
-      retries: 5
+      retries: 10
+      start_period: 60s
+    restart: unless-stopped
 
   tei-reranker:
     image: {{ musubi_tei_image }}
-    command: --model-id BAAI/bge-reranker-v2-m3 --pooling rerank
+    # Reranker models are cross-encoders; TEI auto-detects from the model
+    # config and runs them as rerankers. No `--pooling` flag — the value
+    # `rerank` doesn't exist in TEI 1.x (only cls / mean / splade).
+    command: --model-id BAAI/bge-reranker-v2-m3
     volumes:
       - tei-models:/data
     deploy:
@@ -71,10 +96,15 @@ services:
           devices:
             - capabilities: [gpu]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:80/health"]
-      interval: 30s
+      # TEI image is minimal (no curl/wget/nc). Use bash's /dev/tcp pseudo-
+      # device to verify port 80 is accepting connections. Liveness-only;
+      # model-load errors show up in docker logs if they happen.
+      test: ["CMD", "bash", "-c", "exec 6<>/dev/tcp/localhost/80"]
+      interval: 15s
       timeout: 5s
-      retries: 5
+      retries: 10
+      start_period: 60s
+    restart: unless-stopped
 
   ollama:
     image: {{ musubi_ollama_image }}
@@ -89,11 +119,20 @@ services:
         reservations:
           devices:
             - capabilities: [gpu]
+    # `ollama` CLI talks to the local daemon over HTTP — same effect as
+    # `curl /api/tags` but works without curl (the official image is minimal).
+    # Model presence is orthogonal — `deploy.yml` runs `ollama pull` as a
+    # separate idempotent step after this service is healthy. Coupling model-
+    # pull state into the healthcheck would deadlock the pull (which needs
+    # HTTP up) against `core`'s `depends_on: service_healthy` (which needs
+    # the model present). Keep them independent.
     healthcheck:
-      test: ["CMD-SHELL", "ollama list | grep {{ musubi_ollama_model }}"]
-      interval: 30s
-      timeout: 10s
-      retries: 10
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    restart: unless-stopped
 
 volumes:
   tei-models:

--- a/deploy/ansible/templates/env.production.j2
+++ b/deploy/ansible/templates/env.production.j2
@@ -1,10 +1,50 @@
-MUSUBI_ENV=production
-MUSUBI_BIND_HOST=0.0.0.0
-MUSUBI_PORT={{ musubi_core_port }}
-MUSUBI_JWT_SIGNING_KEY={{ vault_musubi_jwt_signing_key }}
-QDRANT_URL=http://qdrant:6333
+# Managed by deploy/ansible/ — do not edit on the host.
+#
+# Fields map 1:1 to `src/musubi/settings.py` (pydantic-settings, case-insensitive,
+# no prefix). Ordered alphabetically by field so diffs stay sane.
+
+# --- core --------------------------------------------------------------------
+BRAIN_PORT={{ musubi_core_port }}
+JWT_SIGNING_KEY={{ vault_musubi_jwt_signing_key }}
+LOG_DIR=/var/log/musubi
+
+# --- state paths (bind-mounted into the container by docker-compose) ---------
+ARTIFACT_BLOB_PATH=/var/lib/musubi/artifact-blobs
+LIFECYCLE_SQLITE_PATH=/var/lib/musubi/lifecycle/work.sqlite
+VAULT_PATH=/var/lib/musubi/vault
+
+# --- inference backends (compose-network DNS) --------------------------------
+OLLAMA_URL=http://ollama:11434
 TEI_DENSE_URL=http://tei-dense:80
 TEI_SPARSE_URL=http://tei-sparse:80
 TEI_RERANKER_URL=http://tei-reranker:80
-OLLAMA_URL=http://ollama:11434
-OLLAMA_MODEL={{ musubi_ollama_model }}
+
+# --- model ids ---------------------------------------------------------------
+EMBEDDING_MODEL=BAAI/bge-m3
+LLM_MODEL={{ musubi_ollama_model }}
+RERANKER_MODEL=BAAI/bge-reranker-v2-m3
+SPARSE_MODEL=naver/splade-v3
+
+# --- Qdrant ------------------------------------------------------------------
+QDRANT_API_KEY={{ vault_qdrant_api_key }}
+QDRANT_HOST=qdrant
+QDRANT_PORT=6333
+
+# --- feature flags ------------------------------------------------------------
+# Qdrant inside the compose bridge network is plain HTTP (no TLS on the
+# intra-stack links). Core defaults to `https=True` when talking to Qdrant;
+# `MUSUBI_ALLOW_PLAINTEXT=true` flips that to plain HTTP so the TCP
+# handshake doesn't fail with SSL version errors. Safe because:
+#   - Qdrant is bridge-only (no LAN port published; Kong fronts the edge).
+#   - Musubi Core's own HTTP listener remains the only public surface.
+# When we eventually enable TLS on Qdrant's side, flip this to false.
+MUSUBI_ALLOW_PLAINTEXT=true
+
+# --- OAuth -------------------------------------------------------------------
+# Kong + OAuth flow is deferred for Musubi v1 (see
+# docs/Musubi/13-decisions/0024-kong-deferred-for-musubi-v1.md). Settings still
+# requires an AnyHttpUrl shape. Any future Core code path that actually calls
+# this URL must be guarded by a feature check; until then the reserved
+# `.invalid` TLD (RFC 6761) keeps parsing happy while guaranteeing the URL
+# never resolves.
+OAUTH_AUTHORITY=https://oauth.deferred.invalid/


### PR DESCRIPTION
No tracking Issue: deploy readiness; no slice applies.

## Summary

Adds the previously-missing Musubi Core container image + reconciles the env + compose + playbook templates against what `src/musubi/settings.py` actually requires. **The full stack is running on `musubi.mey.house` as of this commit.**

## Live state (verified on `musubi.mey.house` tonight)

```
NAME                    SERVICE        STATUS
musubi-core-1           core           Up  healthy
musubi-ollama-1         ollama         Up  healthy
musubi-qdrant-1         qdrant         Up  healthy
musubi-tei-dense-1      tei-dense      Up  healthy
musubi-tei-reranker-1   tei-reranker   Up  healthy
musubi-tei-sparse-1     tei-sparse     Up  healthy
```

- `curl http://127.0.0.1:8100/v1/ops/health` → `{"status":"ok","version":"v0"}`
- GPU VRAM: 3.3 GiB / 10 GiB (all four inference models loaded, room for query batching)
- Qwen 3 4B pulled on first deploy ✓

## What this PR contains

### Dockerfile + .dockerignore (new)
Multi-stage `uv` build for Musubi Core. Non-root user uid=999 gid=985 matching the Ansible-created host user so bind-mounts work without chown. Entry: `uvicorn --factory musubi.api.app:create_app`. Verified boots with full env file, health returns 200.

### deploy/ansible/templates/env.production.j2 — rewritten
Previous template was missing half the fields `settings.py` requires and used wrong field names. Now maps 1:1 against the Settings model. Sets `MUSUBI_ALLOW_PLAINTEXT=true` (plain HTTP inside the compose bridge is intentional; Qdrant's TLS story is orthogonal), `OAUTH_AUTHORITY=https://oauth.deferred.invalid/` (OAuth deferred per ADR 0024).

### deploy/ansible/templates/docker-compose.yml.j2 — several fixes

- **Core:** adds `lifecycle` + `log` volume mounts.
- **Qdrant:** passes `QDRANT__SERVICE__API_KEY` so containerised Qdrant carries forward the API key. Healthcheck uses `bash /dev/tcp` (image has no curl).
- **Ollama:** healthcheck uses `ollama list` (image has no curl). Decoupled from model-pull (otherwise deadlock with Core's `depends_on: service_healthy`).
- **tei-reranker:** `--pooling rerank` dropped (not a valid value in TEI 1.x; rerankers are auto-detected).
- **TEI services:** healthcheck uses `bash /dev/tcp` (image has no curl); `start_period: 60s` to absorb model-load time.
- `restart: unless-stopped` on all services.

### deploy/ansible/deploy.yml — three-phase bring-up

1. Start inference+storage services with `wait: true`.
2. `docker compose exec ollama ollama pull` (idempotent).
3. Start Core, poll health up to 60s.

### deploy/ansible/group_vars/all.yml

- `musubi_core_image: "musubi-core:dev"` (locally built, `docker save | ssh | docker load` transfer for now).
- `musubi_qdrant_image: "qdrant/qdrant:v1.17.1"` (per ADR 0023).
- `musubi_tei_image: "ghcr.io/huggingface/text-embeddings-inference:86-1.2.0"` — architecture-specific tag for RTX 3080 (Ampere, compute 8.6); `1.5-cuda` as was pinned doesn't exist.
- `musubi_ollama_image: "ollama/ollama:latest"`.
- `nvidia-driver-560-server` dropped from required packages (handled separately in bootstrap.yml).
- `musubi_data_dirs` adds `/var/lib/musubi/lifecycle`.

## What took the most iterations tonight

1. **TEI tag naming.** The `1.5-cuda` in the spec doesn't exist on GHCR. Real tag format is `<compute-capability>-<version>`, e.g. `86-1.2.0` for Ampere.
2. **`--pooling rerank` doesn't exist.** Rerankers are auto-detected from model config in TEI 1.x.
3. **SPLADE v3 is gated on HF.** Works because we pre-staged the weights at `/home/ericmey/musubi-hf-cache/` and rsynced into `/var/lib/musubi/tei-models/` before first deploy.
4. **Ollama/Qdrant/TEI images have no curl.** All healthchecks moved to `bash /dev/tcp` or `ollama list`.
5. **Core → Qdrant plaintext.** Core defaults to HTTPS for Qdrant; compose-bridge Qdrant is HTTP. `MUSUBI_ALLOW_PLAINTEXT=true` flips the flag.

## Test plan

- [x] Docker image builds locally (`docker buildx build --platform linux/amd64 -t musubi-core:dev .`).
- [x] Container boots under synthetic env; `/v1/ops/health` returns 200.
- [x] `ansible-playbook bootstrap.yml` against real host → no failures.
- [x] `ansible-playbook deploy.yml` → all 6 services healthy.
- [x] `make check` → 1013 passed / 231 skipped / 0 failed.
- [ ] Remote CI.

## Follow-ups (not in this PR)

- Publish Musubi Core to GHCR (`ghcr.io/ericmey/musubi-core:<tag>`) and pin by digest; drop the `docker save | load` transfer.
- Automate the pre-deploy HF-cache rsync into `tei-models/` (currently a one-time manual step).
- Pin external image digests (tags for now; lock in once stable).
- Resolve the remaining `[R]` operator-note about health.yml's localhost probes for Qdrant/Ollama (those ports are bridge-only so health.yml won't work as-written).

🤖 Generated with [Claude Code](https://claude.com/claude-code)