### PR TITLE
docs(vault): capture the 2026-04-20 first-deploy milestone

### DIFF
--- a/docs/Musubi/00-index/work-log.md
+++ b/docs/Musubi/00-index/work-log.md
@@ -4,7 +4,7 @@ section: 00-index
 type: index
 status: living-document
 tags: [section/index, status/living-document, type/index]
-updated: 2026-04-18
+updated: 2026-04-20
 up: "[[00-index/index]]"
 reviewed: true
 ---
@@ -26,6 +26,89 @@ What it is **not:** a commit log. Code commits live in git. This log is for
 *vault-visible* events.
 
 ## Entries
+
+### 2026-04-20 — Musubi stack live on `musubi.mey.house` (first real deploy)
+
+The six-container Musubi compose stack came up end-to-end against the real
+target host for the first time. All services report `healthy`:
+
+```
+musubi-core-1           healthy   /v1/ops/health → {"status":"ok","version":"v0"}
+musubi-ollama-1         healthy   qwen3:4b loaded (per [[13-decisions/0019-qwen-on-musubi-gpu-phase-1]])
+musubi-qdrant-1         healthy   v1.17.1, api-key-auth on
+musubi-tei-dense-1      healthy   BGE-M3
+musubi-tei-reranker-1   healthy   BGE-reranker-v2-m3
+musubi-tei-sparse-1     healthy   SPLADE v3
+```
+
+GPU: 3.3 / 10 GiB VRAM used; room for query-time batching.
+
+### Getting there surfaced a chain of real bugs in the playbooks
+
+Every one of these was a spec-vs-reality gap that `slice-ops-first-deploy`
+could not have caught because it shipped without ever running against a real
+host. Each fix landed via PR tonight:
+
+- **#146** `chore(ansible): parametrise inventory + yua control-host workflow` —
+  replaced `<placeholder>` literals in `deploy/ansible/inventory.yml` with
+  `{{ jinja_vars }}`, added `deploy/ansible/setup-control-host.sh` to seed
+  `~/.musubi-secrets/` on yua. Musubi playbooks are now run from yua alongside
+  the homelab fleet ansible; vault password is shared (`~/ansible/.vault_pass`).
+- **#147** `chore(ansible): bootstrap.yml adds Docker + NVIDIA apt repos` —
+  `bootstrap.yml` was missing the Docker-CE and NVIDIA container-toolkit apt
+  repo setup; first `apt install` failed immediately. Driver install pattern
+  changed from the rotted `nvidia-driver-560-server` pin to
+  `ubuntu-drivers autoinstall` guarded by an `nvidia-smi` probe (so the
+  pre-staged 580.126.20 isn't downgraded).
+- **#148** `feat(ops): musubi-core Dockerfile + compose/env template fixes` —
+  wrote the missing Musubi Core `Dockerfile` (was only referenced as
+  `ghcr.io/example/musubi-core:<digest>` — no such image existed). Rewrote
+  the `.env.production.j2` template against the real `settings.py` field
+  set (it was ~half-missing). Corrected TEI image tag from `1.5-cuda`
+  (doesn't exist on GHCR) to `86-1.2.0` (Ampere compute-8.6 variant). Dropped
+  `--pooling rerank` from the reranker service (rerankers are auto-detected
+  in TEI 1.x; only `cls / mean / splade` are valid pooling values). Decoupled
+  the Ollama healthcheck from model-pull state (the old check deadlocked
+  against `core.depends_on`). Moved every healthcheck off `curl` (not
+  installed in the minimal Qdrant / Ollama / TEI images) to either `bash
+  /dev/tcp` or the service's own CLI. Set `MUSUBI_ALLOW_PLAINTEXT=true` so
+  Core talks HTTP to in-bridge Qdrant (TLS inside the compose network is
+  orthogonal; Kong-deferred per ADR 0024 means Core isn't externally
+  exposed either).
+
+### One-time operator steps that happened outside the playbooks
+
+- `ericmey`'s Mac pubkey added to `yua`'s `authorized_keys` (via Proxmox
+  console — the prior laptop's key didn't follow).
+- `yua`'s `id_ed25519_yua` registered as a read-only GitHub deploy key on
+  `ericmey/musubi` so yua can `git clone` the repo.
+- Native `qdrant.service` / `ollama.service` / `open-webui.service` stopped,
+  disabled, and purged (binaries, data dirs, service users). Design call per
+  discussion: `bootstrap.yml` assumes a greenfield host going forward; the
+  native services were pre-staging artefacts only.
+- HF cache at `/home/ericmey/musubi-hf-cache/hub/` rsynced into
+  `/var/lib/musubi/tei-models/` so SPLADE v3 loads from cache (it's gated on
+  HuggingFace; download would 401). Automating this is a follow-up (the
+  current `bootstrap.yml` doesn't do it).
+
+### Vault changes
+
+- [[08-deployment/host-profile|host-profile.md]] § *Actually deployed state*
+  updated from pre-Compose snapshot (2026-04-18) to post-Compose reality.
+- [[_slices/slice-ops-first-deploy|slice-ops-first-deploy.md]] work-log
+  appended with the execution record and the bugs-found ledger.
+- [[12-roadmap/status|status.md]] v1 progress table updated; Phase 8 Ops
+  rolls over to *first deploy complete*.
+
+### Downstream unblocked
+
+- **First capture → retrieve round-trip** is now testable end-to-end
+  (`deploy/smoke/verify.sh` against `http://10.0.20.45:8100`). Queued for
+  the next session.
+- **POC → v1 data migration** (`slice-poc-data-migration`) now has a live
+  target Musubi it can push into.
+- **OpenClaw / LiveKit / MCP adapters** have a real endpoint to integration-
+  test against.
 
 ### 2026-04-20 — slice-poc-data-migration completed via SDK
 

--- a/docs/Musubi/08-deployment/host-profile.md
+++ b/docs/Musubi/08-deployment/host-profile.md
@@ -6,7 +6,7 @@ type: spec
 status: complete
 deployment_status: provisioned
 provisioned_at: 2026-04-17
-updated: 2026-04-18
+updated: 2026-04-20
 up: "[[08-deployment/index]]"
 reviewed: true
 implements: "docs/Musubi/08-deployment/"
@@ -164,9 +164,35 @@ Monitored continuously; alerts at 75% on any dimension. See [[09-operations/aler
 
 ## Actual deployed state
 
-The point-in-time snapshot of what's actually running on the reference host — services, ports, model weights cached, config knobs applied, and which gap-list items are partially done — is maintained in `.agent-context.local.md` at the repo root under § *Realised deployment state (2026-04-18)*. That file is gitignored because it names concrete internal IPs / hostnames.
+The point-in-time snapshot of what's actually running on the reference host — services, ports, model weights cached, config knobs applied — is maintained in `.agent-context.local.md` at the repo root under § *Realised deployment state*. That file is gitignored because it names concrete internal IPs / hostnames.
 
-Public-safe summary: Qdrant + Ollama + Open WebUI are running natively on the host (pre-Compose, pre-Ansible for Musubi); LLM + embedding weights are pre-staged in the user's home directory for the eventual `tei-models` Docker volume; Musubi Core itself is not yet built. See the gap list below for the checklist.
+**Public-safe summary (as of 2026-04-20, first real deploy):** the full Musubi
+compose stack is running. Six services healthy:
+
+| Container              | Image                                              | Role                       |
+|------------------------|----------------------------------------------------|----------------------------|
+| `musubi-core-1`        | `musubi-core:dev` (locally built — see repo `Dockerfile`) | FastAPI API + lifecycle orchestration |
+| `musubi-qdrant-1`      | `qdrant/qdrant:v1.17.1`                            | Vector DB, api-key-auth on |
+| `musubi-tei-dense-1`   | `ghcr.io/huggingface/text-embeddings-inference:86-1.2.0` | BGE-M3 dense embeddings |
+| `musubi-tei-sparse-1`  | same                                               | SPLADE v3 sparse embeddings |
+| `musubi-tei-reranker-1`| same                                               | BGE-reranker-v2-m3 cross-encoder |
+| `musubi-ollama-1`      | `ollama/ollama:latest`                             | Qwen 3 4B LLM              |
+
+Health: `curl http://<musubi-ip>:8100/v1/ops/health → {"status":"ok","version":"v0"}`.
+GPU usage at rest: ~3.3 GiB of 10 GiB VRAM.
+
+The native Qdrant / Ollama / Open WebUI installs that occupied the host before
+the first compose deploy were stopped, disabled, and purged (binaries,
+`/etc/qdrant/`, `/var/lib/{qdrant,open-webui}`, `/usr/share/ollama/`, service
+users). The `bootstrap.yml` playbook assumes a greenfield host; pre-existing
+services are a one-time artefact of this specific migration and not a pattern
+to codify.
+
+The HF cache under `/home/ericmey/musubi-hf-cache/hub/` (BGE-M3, SPLADE v3,
+BGE-reranker-v2-m3) was rsynced into `/var/lib/musubi/tei-models/` before the
+compose stack came up. That preserved ~6.9 GB of downloads (SPLADE v3 is
+gated on HuggingFace and would 401 otherwise). Automating this rsync in
+`bootstrap.yml` is a tracked follow-up (see [[00-index/work-log]] 2026-04-20).
 
 ## Known deployment gotchas
 
@@ -181,14 +207,28 @@ Captured from operational work on 2026-04-18. The future Ansible role that event
 
 ## Gap list before this spec is "realized"
 
-- [ ] Add 16 GB RAM (currently 15 GB of 32 GB target).
+- [ ] Add 16 GB RAM (currently 15 GB of 32 GB target; compose stack runs
+      comfortably within this for now but the 32 GB spec target stands).
 - [ ] Add 4 TB SATA SSD for snapshots + artifact-blob mount.
 - [ ] Replace ad-hoc Samba share with Syncthing for the vault.
-- [ ] Lift native Qdrant / Ollama installs into the Ansible-managed Docker Compose layout (per [[08-deployment/compose-stack]]).
-- [ ] Create Musubi system user `musubi` with the ownership model described above.
-- [ ] Decide on Kong route(s) under `<homelab-domain>` (internal) or `<external-domain>` (external) for Musubi Core, Ollama, and Open WebUI.
-- [ ] Wire up the TEI model cache: either bind-mount the operator's local HF cache dir into the `tei-models` Docker volume, or rsync its contents in when the volume is first created. (Weights are already on disk — see `.agent-context.local.md` — just not yet attached to the not-yet-existing `tei-dense` / `tei-sparse` / `tei-reranker` containers.)
-- [x] Pull the LLM and embedding model weights used by Musubi (Qwen2.5-7B Q4 into Ollama; BGE-M3 + SPLADE-v3 + BGE-reranker-v2-m3 into local HF cache) — done 2026-04-18.
+- [x] Lift native Qdrant / Ollama installs into the Ansible-managed Docker
+      Compose layout (per [[08-deployment/compose-stack]]) — done 2026-04-20.
+      Native services purged; compose stack is the only inference path.
+- [x] Create Musubi system user `musubi` with the ownership model described
+      above — done 2026-04-20 via `bootstrap.yml` (uid 999, gid 985).
+- [ ] Decide on Kong route(s) under `<homelab-domain>` (internal) or
+      `<external-domain>` (external) for Musubi Core. **Deferred** per
+      [[13-decisions/0024-kong-deferred-for-musubi-v1]]; Musubi is
+      VLAN-internal only today.
+- [x] Wire up the TEI model cache — done 2026-04-20. One-time rsync from
+      `~ericmey/musubi-hf-cache/hub/` into `/var/lib/musubi/tei-models/`.
+      Automating this in `bootstrap.yml` is a follow-up.
+- [x] Pull the LLM and embedding model weights used by Musubi — done
+      2026-04-18 for BGE-M3 / SPLADE v3 / BGE-reranker-v2-m3; done 2026-04-20
+      for Qwen 3 4B (auto-pulled by `deploy.yml`'s `ollama pull` step).
+      The pre-staged Qwen 2.5 7B was discarded when the native Ollama was
+      purged — the spec and deploy now agree on Qwen 3 4B per
+      [[13-decisions/0019-qwen-on-musubi-gpu-phase-1]].
 
 Each of these is a candidate for future `_slices/slice-ops-*` or `slice-musubi-*` work.
 

--- a/docs/Musubi/12-roadmap/status.md
+++ b/docs/Musubi/12-roadmap/status.md
@@ -4,13 +4,13 @@ section: 12-roadmap
 tags: [progress, roadmap, section/roadmap, status, status/complete, type/roadmap]
 type: roadmap
 status: complete
-updated: 2026-04-17
+updated: 2026-04-20
 up: "[[12-roadmap/index]]"
 reviewed: false
 ---
 # Status
 
-Snapshot as of **April 2026**. Updated as reality evolves.
+Snapshot as of **2026-04-20**. Updated as reality evolves.
 
 ## Boards
 
@@ -20,18 +20,26 @@ Snapshot as of **April 2026**. Updated as reality evolves.
 
 ## v1 progress
 
+Slice-level status drives these phase rollups (see [[_slices/completed-work]]
+for the live per-slice view). As of 2026-04-20, 42 of 48 slices are `done`,
+1 `blocked-on-demand` (`slice-ops-workspace-packaging`, deferred until an
+external consumer needs thin wheels), 1 retired.
+
 | Phase | Status | Notes |
 |---|---|---|
-| 1. Schema | in progress | Pydantic models partially migrated; some dict-passthrough remains. |
-| 2. Hybrid search | not started | TEI containers not yet deployed. |
-| 3. Reranker | not started | — |
-| 4. Planes | not started | Still single-collection POC. |
-| 5. Vault | not started | Obsidian vault exists locally; no watcher yet. |
-| 6. Lifecycle | not started | No scheduler or events. |
-| 7. Adapters | not started | MCP runs in-process with core. |
-| 8. Ops | partial | Docker-compose exists; no Ansible, no observability. |
+| 1. Schema | **done** | Pydantic models via `slice-types` and followups. |
+| 2. Hybrid search | **done** | TEI dense + sparse running live on the host per [[08-deployment/host-profile]]. |
+| 3. Reranker | **done** | BGE-reranker-v2-m3 live; scoring wired via `slice-retrieval-rerank`. |
+| 4. Planes | **done** | All five planes (episodic, artifact, curated, concept, thoughts) shipped. |
+| 5. Vault | **done** | Watcher + vault-sync shipped via `slice-vault-sync`. |
+| 6. Lifecycle | **done** | Engine, maturation, synthesis, promotion, reflection all shipped. |
+| 7. Adapters | **done** | MCP adapter shipped; LiveKit + OpenClaw (OpenClaw retired) landed. |
+| 8. Ops | **done (first deploy)** | Ansible + Compose + observability + backup + hardening + first-deploy runbook shipped AND executed: Musubi is live on `musubi.mey.house` as of 2026-04-20. See [[00-index/work-log]]. |
 
-We're at the beginning of the v1 plan. This architecture vault is the blueprint.
+Phase 8's "first deploy" doesn't mean Ops is perfect forever — it means the
+stack was brought up end-to-end on the reference host, the health endpoint
+returns 200, and the playbooks handle a greenfield host. Hardening, image-
+digest pinning, GHCR publish, and smoke-test automation are named follow-ups.
 
 ## What exists today (POC)
 
@@ -43,19 +51,36 @@ We're at the beginning of the v1 plan. This architecture vault is the blueprint.
 
 See [[02-current-state/index]] for detail.
 
-## What's in flight (April 2026)
+## What's in flight (2026-04-20)
 
-- Schema tightening (phase 1).
-- Evaluating TEI setup for dense + sparse (pre-phase 2).
-- Deciding on Qwen2.5 vs alternatives for local LLM.
+- First end-to-end smoke test against the live deploy
+  (`deploy/smoke/verify.sh` → capture → retrieve round-trip). Queued.
+- POC → v1 data migration execution (`slice-poc-data-migration`) against
+  the now-live target.
+- Harden / automate the operator-only steps that happened manually during
+  tonight's first deploy (see [[_slices/slice-ops-first-deploy|first-deploy
+  slice]]'s post-mortem section for the list).
 
 ## Next up
 
-Finish phase 1 schema work. Then start phase 2 (TEI dense deployment, create `musubi_episodic_v2`, dual-write).
+1. Smoke-test the live deploy, wire failures (if any) as ordinary slices.
+2. Publish Musubi Core to GHCR + pin external image digests, replacing the
+   `docker save | ssh | docker load` transfer the first deploy used.
+3. Automate the HF-cache rsync step in `bootstrap.yml` so a fresh host
+   matches the current one without manual intervention.
+4. Resolve the `[R]` findings in [[_inbox/operator-notes]] (Ollama model
+   drift — closed in tonight's deploy; health-URL contradiction — still
+   open, `health.yml` probes Qdrant/Ollama on localhost but compose makes
+   them bridge-only).
 
 ## Recently completed
 
-- (none in the v1 plan yet — architecture doc itself is the recent milestone)
+- **2026-04-20** — First real deploy of Musubi stack on `musubi.mey.house`.
+  All six services healthy. See [[00-index/work-log]] for the full entry.
+- **2026-04-20** — ADR 0023 (Qdrant 1.15 → 1.17 pin bump) + ADR 0024 (Kong
+  deferred for v1) + runbook reconciliation.
+- **2026-04-20** — `docs/architecture/` → `docs/Musubi/` vault rename
+  landed atomically with history preserved.
 
 ## Blockers
 

--- a/docs/Musubi/_slices/slice-ops-first-deploy.md
+++ b/docs/Musubi/_slices/slice-ops-first-deploy.md
@@ -219,6 +219,59 @@ Those are operator actions with the runbook open.
 
 - _(none yet; may open one to slice-api-rate-limits for Kong rate-limit plugin config if the in-app enforcement shape demands it)_
 
+### 2026-04-20 — operator + aoi — first real deploy executed
+
+The playbooks shipped in PR #121 were not executed end-to-end against a real
+host at merge time. Tonight's deploy session did that; several real bugs
+surfaced and were fixed in follow-up PRs. All fixes are on `v2`.
+
+**Outcome:** full Musubi compose stack is live on `musubi.mey.house`. All six
+services healthy. `curl http://10.0.20.45:8100/v1/ops/health →
+{"status":"ok","version":"v0"}`. See [[00-index/work-log]] 2026-04-20 entry
+for the full ledger.
+
+**Bugs surfaced + fixed (not originally in this slice's Test Contract because
+no end-to-end run had ever happened):**
+
+1. [PR #146] Inventory hard-coded `<placeholder>` literals; replaced with
+   `{{ jinja_vars }}` + added `setup-control-host.sh` for yua.
+2. [PR #147] `bootstrap.yml` couldn't install `docker-ce` without first
+   adding Docker's apt repo. Same for `nvidia-container-toolkit`. The pinned
+   `nvidia-driver-560-server` would have downgraded the 580.126.20 on the
+   target host. Added pre-tasks for both repos + an idempotent driver probe.
+3. [PR #148] Musubi Core had no `Dockerfile` in the repo (compose referenced
+   `ghcr.io/example/musubi-core@sha256:<core-digest>` — no such image). Wrote
+   the Dockerfile. Rewrote `.env.production.j2` to match `settings.py` (was
+   ~half missing + wrong field names). TEI image tag `1.5-cuda` doesn't
+   exist on GHCR → correct form is `86-1.2.0` (Ampere compute-8.6). TEI
+   `--pooling rerank` not a valid value; rerankers auto-detect. All health-
+   checks moved off `curl` to `bash /dev/tcp` / `ollama list` (minimal
+   images have no curl). Ollama healthcheck decoupled from model-pull state
+   (would deadlock otherwise). `MUSUBI_ALLOW_PLAINTEXT=true` set so Core
+   can talk plain HTTP to in-bridge Qdrant.
+
+**Operator-only one-time steps** (outside the playbooks; captured in
+`.agent-context.local.md` so they reproduce):
+
+- Native Qdrant / Ollama / Open WebUI purged before first run.
+- HF cache rsynced into `/var/lib/musubi/tei-models/` so SPLADE v3 loads
+  from local cache (HF-gated; would 401).
+- yua's deploy key added to `ericmey/musubi` on GitHub.
+
+**What the slice's Test Contract did NOT catch** (follow-up for the
+post-incident review):
+
+- Structural tests of the runbook/systemd/smoke/Kong files passed in CI
+  but no test actually ran `ansible-playbook` against a real (or
+  containerised-real) target. That's why the repo-missing, env-template-
+  wrong, TEI-tag-invalid, curl-missing problems all landed as production
+  bugs instead of CI failures. A `tests/ops/test_compose_boots.py` that
+  stands the stack up in a nested VM or on a self-hosted runner would have
+  caught most of these.
+
 ## PR links
 
-- [PR #121](https://github.com/ericmey/musubi/pull/121)
+- [PR #121](https://github.com/ericmey/musubi/pull/121) — original slice.
+- [PR #146](https://github.com/ericmey/musubi/pull/146) — inventory parametrisation + control-host setup.
+- [PR #147](https://github.com/ericmey/musubi/pull/147) — bootstrap apt repo fixes.
+- [PR #148](https://github.com/ericmey/musubi/pull/148) — musubi-core Dockerfile + compose/env fixes (the deploy-unblocker).


### PR DESCRIPTION
No tracking Issue: documentation-only catchup following tonight's first deploy; no slice applies.

## Summary

Four vault files now reflect post-deploy reality instead of pre-deploy assumptions:

| File | Change |
|---|---|
| `00-index/work-log.md` | new 2026-04-20 entry for "Musubi stack live" with the PR-by-PR bug ledger + one-time operator steps |
| `08-deployment/host-profile.md` | § *Actually deployed state* rewritten from pre-Compose snapshot to post-Compose reality; 4 gap-list items flipped `[x]` |
| `_slices/slice-ops-first-deploy.md` | work-log appended with execution record + bugs-surfaced-at-runtime + PR links |
| `12-roadmap/status.md` | phase table caught up from stale "not started" values to actual slice-registry state; Phase 8 Ops marked "done (first deploy)"; narrative + frontmatter dates bumped |

## Test plan

- [x] `python3 docs/Musubi/_tools/check.py all` → clean (warnings only).
- [x] `make check` → 1013 passed / 231 skipped / 0 failed.
- [x] All wikilinks resolve.
- [ ] Remote CI.

## Follow-ups (intentional, not in this PR)

- Smoke-test the live deploy (`deploy/smoke/verify.sh` against `http://10.0.20.45:8100`) — queued for next.
- Convert the one-time operator steps (native-purge, HF-cache rsync) into ansible tasks so the playbooks are truly idempotent against a fresh host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)