### PR TITLE
slices(ops): carve core-image-publish + update-workflow

### DIFF
--- a/docs/Musubi/_slices/slice-ops-core-image-publish.md
+++ b/docs/Musubi/_slices/slice-ops-core-image-publish.md
@@ -1,0 +1,260 @@
+---
+title: "Slice: Publish musubi-core to GHCR via CI"
+slice_id: slice-ops-core-image-publish
+section: _slices
+type: slice
+status: ready
+owner: unassigned
+phase: "8 Ops"
+tags: [section/slices, status/ready, type/slice, ops, ci, image, ghcr]
+updated: 2026-04-20
+reviewed: false
+depends-on: ["[[_slices/slice-ops-first-deploy]]"]
+blocks: ["[[_slices/slice-ops-update-workflow]]"]
+---
+
+# Slice: Publish musubi-core to GHCR via CI
+
+> Replace the one-time `docker save | ssh | docker load` transfer that
+> brought Musubi Core onto `musubi.mey.house` with a GitHub Actions
+> workflow that builds and publishes `ghcr.io/ericmey/musubi-core` on
+> every tag (and optionally on every merge to `v2`), so any host can
+> `docker pull` the image by digest.
+
+**Phase:** 8 Ops · **Status:** `ready` · **Owner:** `unassigned`
+
+## Why this slice exists
+
+The first deploy on 2026-04-20 built the Musubi Core image locally on
+Eric's Mac (`docker buildx build --platform linux/amd64`), then
+transferred it to `musubi.mey.house` via a `docker save | ssh | docker
+load` pipe. That worked for the single-host first-deploy but creates three
+problems as soon as we leave that narrow path:
+
+1. **A fresh host cannot deploy itself.** `deploy/ansible/deploy.yml`'s
+   `community.docker.docker_compose_v2_pull` step can't pull an image
+   that only exists locally on one Mac. The first deploy worked only
+   because the image was on the target before Ansible tried to pull.
+2. **No reproducibility across machines.** The build on Eric's ARM Mac
+   depends on whatever Docker buildx context happens to be active. A
+   different operator on a different machine gets a different image
+   from the same commit.
+3. **No digest pinning.** `group_vars/all.yml` currently has
+   `musubi_core_image: "musubi-core:dev"` — a floating tag. When the
+   image is rebuilt, the tag points at new bytes with no audit trail
+   and no rollback target. The companion `slice-ops-update-workflow`
+   can't safely upgrade without a pinned source.
+
+The repo has a working `Dockerfile` at the root (shipped in PR #148) and
+the build is mechanically straightforward — this slice wires that into
+CI + pins the digest.
+
+## Specs to implement
+
+- [[08-deployment/compose-stack]] — the `musubi_core_image` reference
+  that this slice replaces.
+- [[08-deployment/index]] §Pinning versions — the pinning policy that
+  expects digest-pinned images.
+- [[13-decisions/0015-monorepo-supersedes-multi-repo]] — confirms that
+  publishing from this monorepo to a single namespace is the intended
+  pattern.
+
+## Owned paths (you MAY write here)
+
+- `.github/workflows/publish-core-image.yml` (new — the GitHub Actions
+  workflow).
+- `deploy/ansible/group_vars/all.yml` (edit — flip
+  `musubi_core_image` from `musubi-core:dev` to
+  `ghcr.io/ericmey/musubi-core@sha256:<digest>`).
+- `docs/Musubi/08-deployment/compose-stack.md` (edit — update the
+  pinning docs to reflect the real GHCR path).
+- `docs/Musubi/08-deployment/index.md` (edit — same).
+<!-- Intentionally NOT listing `deploy/runbooks/first-deploy.md` under
+owns_paths — it's owned by `slice-ops-first-deploy`. The small edit to
+retire the `docker save | ssh | docker load` step belongs in the same
+PR as this slice via a cross-slice ticket + `spec-update:` commit
+trailer (see Cross-slice tickets below). -->
+- `deploy/runbooks/upgrade-image.md` (new — per-image-bump procedure
+  that replaces the ad-hoc `docker save | ssh | docker load`).
+- `tests/ops/test_image_publish.py` (new — structural tests on the
+  workflow YAML and the ansible variable).
+
+## Forbidden paths (you MUST NOT write here — open a cross-slice ticket if needed)
+
+- `Dockerfile`, `.dockerignore` — shipped in PR #148, not this slice's
+  concern. If the Dockerfile needs a change for publish, open a
+  cross-slice ticket.
+- `src/musubi/` — this is ops, not Core code.
+- `docs/Musubi/07-interfaces/`, `openapi.yaml`, `proto/` — API contract,
+  frozen.
+- `deploy/ansible/bootstrap.yml`, `config.yml`, `deploy.yml`,
+  `health.yml` — playbook logic is `slice-ops-update-workflow`'s
+  territory if you need to change how images get pulled.
+
+## Depends on
+
+- [[_slices/slice-ops-first-deploy]] (done — `Dockerfile` exists, first
+  deploy succeeded, `musubi_core_image` reference exists in
+  `group_vars/all.yml`).
+
+## Unblocks
+
+- [[_slices/slice-ops-update-workflow]] — needs a real registry source
+  to pull from; it can't upgrade an image that only lives on one Mac.
+- **Fresh-host provisioning.** Once the image is on GHCR, a new
+  `musubi.mey.house` replacement host can run `bootstrap.yml` +
+  `deploy.yml` end-to-end without any manual image transfer.
+- **Rollback on-deploy.** A digest pin means the runbook's "rollback"
+  step can be "pin the prior digest and re-run deploy.yml" — currently
+  there's no previous-image reference to roll back to.
+
+## What lands in this slice
+
+### 1. `.github/workflows/publish-core-image.yml`
+
+Triggers:
+
+- `push` to tag `v*` — builds and publishes with both `:v<version>` and
+  `@sha256:<digest>`. The authoritative release path.
+- `push` to branch `v2` — builds and publishes with tag `:v2` (floating)
+  + captures the digest as a build artefact. Lets operators run the
+  bleeding edge without cutting a tag.
+- `workflow_dispatch` — manual run for one-off images.
+
+Steps:
+
+1. Checkout.
+2. Set up `docker/setup-qemu-action` + `docker/setup-buildx-action` (for
+   reliable linux/amd64 cross-build).
+3. Log in to GHCR using `GITHUB_TOKEN` (has `packages:write` on the
+   repo's container namespace by default).
+4. `docker/build-push-action` with:
+   - `platforms: linux/amd64`
+   - `tags`: `ghcr.io/ericmey/musubi-core:v<version>` and
+     `ghcr.io/ericmey/musubi-core:v2` as appropriate.
+   - `labels`: OCI image-source labels pointing at the commit.
+   - `cache-from` / `cache-to` via GHA cache so subsequent builds reuse
+     layers.
+5. Capture the resulting digest; surface as a workflow output + a
+   GitHub release asset on tag-triggered runs.
+
+The workflow NEVER writes to `group_vars/all.yml` — the digest bump is
+a separate PR that an operator (or a future bot) opens after reviewing
+the new image. Don't couple the "publish" step with the "deploy" step;
+they're different decisions.
+
+### 2. `deploy/ansible/group_vars/all.yml` flip
+
+Replace:
+
+```yaml
+musubi_core_image: "musubi-core:dev"
+```
+
+with the first-published GHCR digest, e.g.:
+
+```yaml
+musubi_core_image: "ghcr.io/ericmey/musubi-core@sha256:<digest-from-workflow-run>"
+```
+
+Document the bump procedure in the companion `slice-ops-update-workflow`
+so operators know how to advance the pin safely.
+
+### 3. `deploy/runbooks/first-deploy.md` § 4 edits
+
+Retire the implicit `docker save | ssh | docker load` that tonight's
+first deploy relied on. Replace with:
+
+> **Before running `deploy.yml`:** confirm that the digest in
+> `group_vars/all.yml → musubi_core_image` corresponds to a
+> successfully-published workflow run on GHCR
+> (https://github.com/ericmey/musubi/pkgs/container/musubi-core). If
+> the image isn't published yet, trigger
+> `.github/workflows/publish-core-image.yml` via `workflow_dispatch`
+> and wait for the digest before proceeding.
+
+### 4. Tests: `tests/ops/test_image_publish.py`
+
+Structural — no live registry calls. Assertions:
+
+- The workflow YAML parses; has exactly one `publish-core-image` job.
+- Triggers include `push.tags: ['v*']`, `push.branches: ['v2']`,
+  `workflow_dispatch`.
+- The job uses `docker/build-push-action` with `push: true` and a tag
+  list that includes both a `:v<version>` tag and a GHCR path.
+- The job has a step that logs in to `ghcr.io`.
+- `group_vars/all.yml`'s `musubi_core_image` value is either `"musubi-
+  core:dev"` (pre-slice state, caught as failing until the digest bump
+  lands) or matches `ghcr.io/ericmey/musubi-core@sha256:[0-9a-f]{64}`.
+
+## Definition of Done
+
+![[00-index/definition-of-done]]
+
+Plus slice-specific:
+
+- [ ] `publish-core-image.yml` exists and runs green on a test tag (cut
+      a `v0.2.1-test` or similar scratch tag; delete after).
+- [ ] The workflow's published image is visible at
+      `ghcr.io/ericmey/musubi-core` with the expected tag + digest.
+- [ ] `group_vars/all.yml` flipped from the local-build tag to a
+      digest-pinned GHCR reference.
+- [ ] `ansible-playbook deploy.yml` run against `musubi.mey.house`
+      pulls from GHCR successfully (no `docker save | ssh` needed).
+      Recorded in `[[00-index/work-log]]`.
+- [ ] Runbook updated to reflect the new pre-deploy image-publish
+      check.
+- [ ] `tests/ops/test_image_publish.py` passes; coverage ≥ 80 % on
+      its module.
+- [ ] `spec-update:` commit trailer used for any changes to
+      `docs/Musubi/08-deployment/*.md`.
+
+**Explicitly NOT in scope:**
+
+- Automating the `group_vars` digest bump (a Dependabot-style or
+  Renovate-style workflow). Keep the bump a human-reviewed PR for now.
+- Signing the image (cosign, sigstore). Separate concern; open a
+  follow-up slice if signing becomes a requirement.
+- Building for `linux/arm64` in addition to `amd64`. RTX-3080 hosts are
+  x86_64; arm64 builds are speculation until a real consumer surfaces.
+
+## Test Contract
+
+**Workflow YAML structural:**
+
+1. `test_workflow_file_parses`
+2. `test_workflow_has_publish_core_image_job`
+3. `test_workflow_triggers_include_tags_v2_and_dispatch`
+4. `test_workflow_uses_build_push_action_with_push_true`
+5. `test_workflow_logs_into_ghcr`
+6. `test_workflow_builds_for_linux_amd64`
+7. `test_workflow_tags_include_ghcr_namespace`
+
+**Ansible integration:**
+
+8. `test_group_vars_musubi_core_image_is_ghcr_digest_pinned`
+9. `test_group_vars_musubi_core_image_parses_as_oci_reference`
+
+**Runbook integration:**
+
+10. `test_first_deploy_runbook_no_longer_mentions_docker_save_pipe`
+11. `test_first_deploy_runbook_mentions_workflow_dispatch_as_recovery`
+
+## Cross-slice tickets opened by this slice
+
+- **To `slice-ops-first-deploy`** — small edit to
+  `deploy/runbooks/first-deploy.md` to retire the `docker save | ssh |
+  docker load` transfer step and replace it with "confirm the GHCR
+  digest is published before running deploy.yml". File is owned by
+  slice-ops-first-deploy; this slice's PR touches it with a
+  `spec-update: deploy/runbooks/first-deploy.md` commit trailer.
+- _(open another if the `Dockerfile` needs changes for publish, e.g.
+  multi-arch builds.)_
+
+## Work log
+
+_(empty — awaiting claim)_
+
+## PR links
+
+_(empty)_

--- a/docs/Musubi/_slices/slice-ops-first-deploy.md
+++ b/docs/Musubi/_slices/slice-ops-first-deploy.md
@@ -10,7 +10,7 @@ tags: [section/slices, status/done, type/slice, ops, deploy, phase-2]
 updated: 2026-04-20
 reviewed: true
 depends-on: ["[[_slices/slice-ops-ansible]]", "[[_slices/slice-ops-compose]]", "[[_slices/slice-ops-backup]]", "[[_slices/slice-ops-observability]]"]
-blocks: []
+blocks: ["[[_slices/slice-ops-core-image-publish]]"]
 ---
 
 # Slice: First-deploy runbook + validation

--- a/docs/Musubi/_slices/slice-ops-update-workflow.md
+++ b/docs/Musubi/_slices/slice-ops-update-workflow.md
@@ -1,0 +1,303 @@
+---
+title: "Slice: update.yml — in-place upgrade for a running Musubi"
+slice_id: slice-ops-update-workflow
+section: _slices
+type: slice
+status: ready
+owner: unassigned
+phase: "8 Ops"
+tags: [section/slices, status/ready, type/slice, ops, upgrade, ansible]
+updated: 2026-04-20
+reviewed: false
+depends-on: ["[[_slices/slice-ops-core-image-publish]]"]
+blocks: []
+---
+
+# Slice: update.yml — in-place upgrade for a running Musubi
+
+> Adds a dedicated Ansible playbook for upgrading a live Musubi host
+> without a full re-bootstrap: pulls the newly-published image, recreates
+> only the changed containers, runs post-update health probes, and writes
+> a dated upgrade entry. Complements `deploy.yml` (which is
+> first-deploy-only) and `bootstrap.yml` (which is host-level-only).
+
+**Phase:** 8 Ops · **Status:** `ready` · **Owner:** `unassigned`
+
+## Why this slice exists
+
+The current `deploy/ansible/deploy.yml` pulls images with
+`policy: missing` — it only fetches images that aren't already on the
+host. Running it a second time against a running stack with a newer
+image tag is a **no-op**: the old image is still present, nothing new
+gets pulled, `docker compose up` sees no diff, no containers get
+recreated. The host keeps running the old bits forever.
+
+There's no other playbook to lean on. `bootstrap.yml` installs
+host-level packages (Docker, NVIDIA toolkit, users, UFW) — useful on a
+fresh host, overkill on every deploy, and doesn't touch container state.
+`config.yml` re-renders `.env.production` — needed when env changes, but
+doesn't restart containers unless the env actually differs. `health.yml`
+is a probe, not a mutator.
+
+So updating a running Musubi today means one of:
+
+- Operator manually runs `docker compose pull && docker compose up -d --
+  force-recreate core` on the host. No Ansible trail, no healthcheck
+  gating, no audit.
+- Operator runs `bootstrap.yml` + `deploy.yml` from scratch. Over-
+  powered: re-installs packages it doesn't need to, risks more than is
+  warranted for an image bump.
+
+`update.yml` fills the gap that sits between them: a minimal, auditable
+upgrade path with per-service recreation and explicit health gating.
+
+## Specs to implement
+
+- [[08-deployment/ansible-layout]] — the playbook roster that this slice
+  extends (adds an `update.yml` row).
+- [[09-operations/runbooks]] — gets a new `upgrade.md` as a companion
+  to `first-deploy.md`.
+- [[13-decisions/0014-kong-over-caddy]] §Consequences — the
+  "blue/green" swap story that `update.yml` is a first step toward
+  (eventually).
+
+## Owned paths (you MAY write here)
+
+- `deploy/ansible/update.yml` (new — the playbook).
+- `deploy/runbooks/upgrade.md` (new — the operator-facing runbook).
+- `tests/ops/test_update_playbook.py` (new — structural tests on the
+  playbook + runbook).
+- `deploy/ansible/README.md` (edit — add `update.yml` to the Layout
+  table and the "Per-deploy workflow" section).
+- `docs/Musubi/08-deployment/ansible-layout.md` (edit — describe
+  `update.yml`'s role in the playbook roster).
+
+## Forbidden paths (you MUST NOT write here — open a cross-slice ticket if needed)
+
+- `deploy/ansible/bootstrap.yml`, `config.yml`, `deploy.yml` — leave
+  alone. This slice adds a new playbook, it does NOT modify the
+  existing three. If behavior shared across them needs to change, open
+  a cross-slice ticket.
+- `.github/workflows/publish-core-image.yml` — owned by
+  `slice-ops-core-image-publish`. Reference its outputs (the GHCR
+  digest); don't modify its shape.
+- `src/musubi/`, `openapi.yaml`, `proto/` — Ops slice; no code.
+- `docs/Musubi/13-decisions/` — no new ADRs unless a decision is
+  forced during implementation.
+
+## Depends on
+
+- [[_slices/slice-ops-core-image-publish]] (ready — must land first so
+  `update.yml` has a pinned GHCR source to pull from. Attempting to
+  upgrade against a local `musubi-core:dev` tag is nonsense; there's
+  no "newer" to pull).
+
+## Unblocks
+
+- **Routine image bumps become safe.** Bump the digest in `group_vars`
+  + run `update.yml` → new image pulled, old container replaced, health
+  verified. No manual `docker compose` on the host.
+- **Rollback on bad deploys.** Revert the `group_vars` commit, run
+  `update.yml` again — pulls the previous digest and recreates.
+  Current state has no concept of "roll back to the previous image."
+- **Faster iteration on Core.** Publish a new image on merge to `v2`,
+  bump the group_vars, run `update.yml` — end-to-end Core upgrade in
+  one command.
+
+## What lands in this slice
+
+### 1. `deploy/ansible/update.yml`
+
+Skeleton (final shape subject to review; behaviour fixed):
+
+```yaml
+- name: Update a running Musubi stack
+  hosts: musubi
+  become: true
+  tasks:
+    - name: Re-render compose + env in case they changed
+      ansible.builtin.import_tasks: tasks/render-templates.yml
+      # Extract the template-render tasks from deploy.yml / config.yml
+      # into a shared task file so both playbooks use them.
+
+    - name: Pull any image references that changed
+      community.docker.docker_compose_v2_pull:
+        project_src: "{{ musubi_config_dir }}"
+        policy: always        # <-- the key difference from deploy.yml.
+                              # deploy.yml uses `missing` (first-deploy);
+                              # update.yml uses `always` (force-pull).
+
+    - name: Diff running containers vs desired
+      ansible.builtin.command:
+        cmd: docker compose -f {{ musubi_config_dir }}/docker-compose.yml config --format=json
+      register: compose_config
+      changed_when: false
+
+    - name: Recreate only services whose image has changed
+      # `docker_compose_v2` with `recreate: always` on a per-service
+      # list — recreating every service every time is overkill and
+      # causes unnecessary downtime on unaffected services.
+      community.docker.docker_compose_v2:
+        project_src: "{{ musubi_config_dir }}"
+        state: present
+        pull: never          # we pulled above; don't re-pull here
+        recreate: always
+        wait: true
+        wait_timeout: 300
+        services: "{{ changed_services | default(['core']) }}"
+        # The default narrow recreate targets core since that's the
+        # most common image bump. Operator can override via
+        # `-e changed_services='[core,tei-dense]'` etc.
+
+    - name: Probe core health post-update
+      ansible.builtin.uri:
+        url: "{{ musubi_health_urls.core }}"
+        status_code: 200
+      retries: 12
+      delay: 5
+      register: core_health
+      until: core_health.status == 200
+      changed_when: false
+
+    - name: Append an upgrade-record entry
+      ansible.builtin.lineinfile:
+        path: /var/log/musubi/upgrade-history.jsonl
+        create: true
+        owner: musubi
+        group: musubi
+        mode: "0640"
+        line: "{{ lookup('pipe', 'date -Iseconds') }} services={{ changed_services | default(['core']) }} image_core={{ musubi_core_image }}"
+```
+
+Key behaviours:
+
+- **`policy: always` on the pull** — distinct from `deploy.yml`. Forces
+  docker to pull the image referenced in `docker-compose.yml` even if
+  a matching local tag exists. Essential when the digest has changed
+  but the tag stayed the same (the GHCR publish workflow re-tags
+  `:v2` as the floating branch pointer).
+- **Per-service recreate via `changed_services`** — default to `[core]`
+  because Core is the most frequently-updated piece. Operator can
+  override to recreate more than one. No "recreate everything"
+  default because churning Qdrant / Ollama / TEI unnecessarily costs
+  model-load time.
+- **No `bootstrap.yml` re-run** — update assumes the host is already
+  bootstrapped. If it isn't, fail fast rather than silently re-running
+  apt + user-creation tasks.
+- **Append-only upgrade log** at `/var/log/musubi/upgrade-history.jsonl`
+  so operators can `tail -f` during a drift investigation.
+
+### 2. `deploy/runbooks/upgrade.md`
+
+Operator procedure. Structure mirrors `first-deploy.md`:
+
+1. **Pre-flight** — confirm the new image is published
+   (https://github.com/ericmey/musubi/pkgs/container/musubi-core), or
+   confirm a `qdrant`/`tei`/`ollama` version bump is in `group_vars`.
+2. **Bump the pin** — commit `musubi_core_image` (or other image) to
+   the new `@sha256:<digest>` in `group_vars/all.yml`; push; pull on
+   yua. (A future PR could automate this via Dependabot/Renovate.)
+3. **Dry-run** — `ansible-playbook update.yml --check --diff` from yua
+   against musubi. Expected output: the compose-up task shows the
+   image change + which containers will recreate.
+4. **Apply** — `ansible-playbook update.yml` without `--check`.
+5. **Verify** — `deploy/smoke/verify.sh` round-trip; `/var/log/musubi/
+   upgrade-history.jsonl` has a new entry.
+6. **Rollback** — revert the `group_vars` commit; push; pull on yua;
+   re-run `update.yml`. Operator decision: a dedicated `--rollback`
+   flag is out of scope for this slice (keep the revert-and-rerun
+   pattern until a real rollback story is needed).
+
+Every section has Command / Expected output / Destructive / Rollback,
+matching the `first-deploy.md` structure the existing smoke tests
+assert.
+
+### 3. `tests/ops/test_update_playbook.py`
+
+- The playbook parses (YAML validation).
+- The playbook's pull step uses `policy: always` (the critical
+  difference from `deploy.yml`).
+- The compose-up step uses `recreate: always`.
+- The playbook probes `/v1/ops/health` post-recreate.
+- The playbook writes to `/var/log/musubi/upgrade-history.jsonl`.
+- The upgrade runbook has all of: Pre-flight / Bump the pin / Dry-run
+  / Apply / Verify / Rollback — per the same structural-test pattern
+  that `tests/ops/test_first_deploy_smoke.py` uses against
+  `first-deploy.md`.
+
+### 4. `deploy/ansible/README.md` + `docs/Musubi/08-deployment/ansible-layout.md`
+
+Both gain an `update.yml` row in the playbook roster. Both get a
+"Per-deploy workflow" addendum noting that `update.yml` replaces the
+old "run `deploy.yml` a second time with a newer tag" pattern (which
+didn't work).
+
+## Definition of Done
+
+![[00-index/definition-of-done]]
+
+Plus slice-specific:
+
+- [ ] `ansible-playbook --syntax-check update.yml` passes.
+- [ ] `--check --diff` against the live `musubi.mey.house` (before the
+      pin bump) shows zero changes (idempotent no-op on an up-to-date
+      stack).
+- [ ] After a scratch `musubi_core_image` bump, `--check --diff` shows
+      exactly one image pull + one container recreate, no unrelated
+      churn.
+- [ ] Real apply against `musubi.mey.house` recreates Core cleanly;
+      `/v1/ops/health` returns 200 post-apply;
+      `upgrade-history.jsonl` has a new entry.
+- [ ] `deploy/runbooks/upgrade.md` reads top-to-bottom as an operator
+      procedure; every step has Command / Expected output / Rollback.
+- [ ] `tests/ops/test_update_playbook.py` passes; branch coverage
+      ≥ 80 %.
+- [ ] Work-log entry in `[[00-index/work-log]]` recording the first
+      successful upgrade via `update.yml`.
+
+**Explicitly NOT in scope:**
+
+- Blue/green deploys. This is in-place recreation with a
+  `wait: service_healthy` gate — not blue/green. Blue/green is a
+  separate, larger slice when we have spare host capacity.
+- Automated digest bumps (Dependabot/Renovate). Keep the pin bump a
+  human-reviewed PR until we've operated `update.yml` for a few cycles.
+- Rolling upgrades across multiple Musubi hosts. Single-host per ADR
+  0010; revisit when that ADR changes.
+
+## Test Contract
+
+**Playbook structural:**
+
+1. `test_update_playbook_parses`
+2. `test_update_pull_policy_is_always`
+3. `test_update_recreates_only_named_services`
+4. `test_update_does_not_invoke_bootstrap_tasks`
+5. `test_update_probes_core_health_post_apply`
+6. `test_update_writes_upgrade_history`
+
+**Runbook structural:**
+
+7. `test_upgrade_runbook_has_six_sections`
+8. `test_upgrade_runbook_every_step_has_rollback`
+9. `test_upgrade_runbook_mentions_revert_and_rerun_rollback`
+
+**Behavior (integration — runs on a scratch docker host):**
+
+10. `test_update_noop_on_unchanged_stack`
+11. `test_update_recreates_core_on_image_bump`
+12. `test_update_leaves_unchanged_services_running`
+
+## Cross-slice tickets opened by this slice
+
+- _(none expected; if `deploy.yml` needs a refactor to share template-
+  rendering logic, open one to `slice-ops-first-deploy` since it owns
+  `deploy.yml`.)_
+
+## Work log
+
+_(empty — awaiting claim)_
+
+## PR links
+
+_(empty)_

--- a/docs/Musubi/_tools/bootstrap_slice_issues.py
+++ b/docs/Musubi/_tools/bootstrap_slice_issues.py
@@ -35,7 +35,7 @@ except ImportError:
 
 
 ROOT = Path(__file__).resolve().parents[3]
-SLICE_DIR = ROOT / "docs" / "architecture" / "_slices"
+SLICE_DIR = ROOT / "docs" / "Musubi" / "_slices"
 
 # Mapping from the slice's `phase: "1 Schema"` form to the label name.
 PHASE_TO_LABEL = {


### PR DESCRIPTION
No tracking Issue for this PR itself — it carves the two slices whose GH Issues it creates.

## Summary

Two ops gaps surfaced by tonight's first deploy are now claimable slices:

- **`slice-ops-core-image-publish`** → `.github/workflows/publish-core-image.yml` that pushes \`ghcr.io/ericmey/musubi-core\` on tags + floating \`:v2\`. Retires the one-time \`docker save | ssh | docker load\` transfer that brought the image onto \`musubi.mey.house\`.
- **`slice-ops-update-workflow`** → \`deploy/ansible/update.yml\` for in-place upgrades (pull policy: always, per-service recreate, health-gated, append-only upgrade-history log). Closes the \"run deploy.yml twice doesn't pick up a new image\" gap.

Both were named as follow-ups in PR #148 and \`12-roadmap/status.md\` but weren't claimable work. They are now.

## Bonus fix

\`docs/Musubi/_tools/bootstrap_slice_issues.py\` still hard-coded \`docs/architecture/_slices/\` after the 2026-04-20 rename (PR #143). Dry-run returned 0/0/0 which is how this got caught. Fixed; \`--apply\` created GH Issues for the two new slices (visible on the slice board).

## Vault-hygiene fixes

- \`slice-ops-first-deploy.md\` gets a \`blocks: [core-image-publish]\` edge (DAG symmetry).
- New slice intentionally excludes \`deploy/runbooks/first-deploy.md\` from owned_paths (owned by first-deploy slice); the small edit lands via cross-slice ticket + \`spec-update:\` trailer when the slice is implemented.

## Test plan

- [x] \`python3 docs/Musubi/_tools/check.py all\` → clean (one pre-existing warning on reading-tour.md, unrelated).
- [x] \`make check\` → 1013 passed / 231 skipped / 0 failed.
- [x] \`bootstrap_slice_issues.py --apply\` created both Issues.
- [ ] Remote CI.

## Follow-up once merged

Either slice can be picked up in a future session via \`pick-slice\` / \`gh issue edit <n> --add-assignee @me\`. \`slice-ops-core-image-publish\` goes first (update-workflow depends on it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)