### PR TITLE
fix(api): ops/status probes ollama at /api/tags, not /health

### DIFF
--- a/src/musubi/api/routers/ops.py
+++ b/src/musubi/api/routers/ops.py
@@ -71,15 +71,18 @@ async def status(
         overall = "degraded"
         return StatusResponse(status=overall, components=components)
 
-    for name, base_url in (
-        ("tei-dense", str(settings.tei_dense_url)),
-        ("tei-sparse", str(settings.tei_sparse_url)),
-        ("tei-reranker", str(settings.tei_reranker_url)),
-        ("ollama", str(settings.ollama_url)),
+    # Per-service liveness paths. TEI exposes `/health`; Ollama doesn't —
+    # it returns 404 on `/health` and 200 on `/api/tags` (empty model list
+    # when no model is loaded, which still proves the daemon is up).
+    for name, base_url, probe_path in (
+        ("tei-dense", str(settings.tei_dense_url), "/health"),
+        ("tei-sparse", str(settings.tei_sparse_url), "/health"),
+        ("tei-reranker", str(settings.tei_reranker_url), "/health"),
+        ("ollama", str(settings.ollama_url), "/api/tags"),
     ):
         components[name] = check_component_health(
             name=name,
-            url=base_url.rstrip("/") + "/health",
+            url=base_url.rstrip("/") + probe_path,
         )
 
     overall = "ok" if all(c.healthy for c in components.values()) else "degraded"


### PR DESCRIPTION
No tracking Issue: surfaced by tonight's smoke test against the live deploy.

## Summary

\`/v1/ops/status\` aggregates component health by probing \`<base_url>/health\` on each dependency. TEI exposes \`/health\`; Ollama doesn't (returns 404). So with the first deploy live, \`/v1/ops/status → "degraded"\` with \`ollama.healthy: false\` even though Ollama is fine.

Per-service probe path fix: \`/health\` for the three TEI services, \`/api/tags\` for Ollama (200 OK even with no model loaded, still proves daemon liveness).

## Verified

- \`make check\` → 1013 passed / 231 skipped / 0 failed.
- After rebuilding + redeploying the image tonight (manual), \`/v1/ops/status\` on the live deploy reports \`status: ok\` with all six components healthy.

## Follow-up

Once \`slice-ops-core-image-publish\` (#150) lands, this fix gets to the running host via the normal update workflow. In the meantime the local-build image running on \`musubi.mey.house\` tonight already has it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)