### PR TITLE
ci(ops): Tier 1 supply-chain — cosign + SBOM + Trivy

### DIFF
--- a/.github/workflows/publish-core-image.yml
+++ b/.github/workflows/publish-core-image.yml
@@ -43,9 +43,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       # GITHUB_TOKEN needs `packages: write` to push to the repo's GHCR
-      # namespace. `contents: read` is the default but stated explicitly.
+      # namespace. `id-token: write` is required for cosign keyless
+      # signing via GitHub's OIDC provider. `contents: read` is the
+      # default but stated explicitly.
       contents: read
       packages: write
+      id-token: write
     outputs:
       image: ${{ steps.meta.outputs.tags }}
       digest: ${{ steps.build.outputs.digest }}
@@ -100,6 +103,77 @@ jobs:
           # pushing cache layers into GHCR itself.
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # Embed provenance + SBOM attestations in the manifest. This
+          # is the default on build-push-action v6 but declaring
+          # explicitly documents the supply-chain commitment.
+          provenance: true
+          sbom: true
+
+      # ------------------------------------------------------------------
+      # Supply-chain hardening. Each step is allowed to fail the job —
+      # a signed, scanned image is the contract this workflow sells.
+      # ------------------------------------------------------------------
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: "v2.4.1"
+
+      - name: Sign the published image (keyless, via GitHub OIDC)
+        # Signs by digest — tags are mutable, digests aren't. Anyone
+        # can verify later with `cosign verify --certificate-identity-
+        # regexp 'https://github.com/ericmey/musubi/.*' --certificate-
+        # oidc-issuer https://token.actions.githubusercontent.com
+        # ghcr.io/ericmey/musubi-core@<digest>`. Verification on the
+        # deploy side is future-enabled by ADR (not required today).
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+        run: |
+          set -euo pipefail
+          cosign sign --yes \
+            "ghcr.io/ericmey/musubi-core@${{ steps.build.outputs.digest }}"
+
+      - name: Generate SBOM (CycloneDX)
+        uses: anchore/sbom-action@v0
+        with:
+          image: "ghcr.io/ericmey/musubi-core@${{ steps.build.outputs.digest }}"
+          format: cyclonedx-json
+          output-file: sbom.cdx.json
+          upload-artifact: true
+
+      - name: Attach SBOM as cosign attestation
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+        run: |
+          set -euo pipefail
+          cosign attest --yes \
+            --predicate sbom.cdx.json \
+            --type cyclonedx \
+            "ghcr.io/ericmey/musubi-core@${{ steps.build.outputs.digest }}"
+
+      - name: Trivy vulnerability scan (fail on CRITICAL)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: "ghcr.io/ericmey/musubi-core@${{ steps.build.outputs.digest }}"
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL
+          # Exit 1 if any CRITICAL vulnerability is found. HIGH is
+          # surfaced as SARIF but not gated — a homelab service
+          # can't afford to chase every `libssl` HIGH on upstream
+          # images. Tune with an allowlist later if we hit false
+          # positives too often.
+          exit-code: "1"
+          ignore-unfixed: true
+
+      - name: Upload Trivy SARIF to GitHub Security tab
+        # Runs even if Trivy failed so the findings are visible in
+        # the repo's Security → Code scanning view.
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy
 
       - name: Summarise digest
         # Surface the digest at the top of the workflow run page so an

--- a/tests/ops/test_image_publish.py
+++ b/tests/ops/test_image_publish.py
@@ -95,6 +95,84 @@ def test_workflow_requests_packages_write_permission() -> None:
     perms = _job().get("permissions") or {}
     assert perms.get("packages") == "write", "missing packages:write permission"
     assert perms.get("contents") in ("read", "write"), "missing contents permission"
+    # id-token:write is required for cosign keyless signing via GitHub
+    # OIDC. Without it, the sign step silently tries to open a browser
+    # for oauth — which of course fails in CI.
+    assert perms.get("id-token") == "write", (
+        "missing id-token:write — cosign keyless signing needs GitHub OIDC"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Supply-chain hardening (Tier 1)
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_signs_image_via_cosign_keyless() -> None:
+    """Every published digest MUST be cosign-signed so pullers can later
+    verify against this repo's workflow identity."""
+    steps = _job_steps()
+    installer = [s for s in steps if "sigstore/cosign-installer" in str(s.get("uses", ""))]
+    assert installer, "missing sigstore/cosign-installer step"
+
+    # The sign step either uses an action or `run:`s cosign directly.
+    sign_step = None
+    for s in steps:
+        run = str(s.get("run", ""))
+        if "cosign sign" in run and "--yes" in run:
+            sign_step = s
+            break
+    assert sign_step, "no cosign sign step found"
+    # Must sign by digest, not by tag (tags are mutable).
+    assert "@${{ steps.build.outputs.digest }}" in str(sign_step.get("run", "")), (
+        "cosign sign must target the image by digest, not tag"
+    )
+
+
+def test_workflow_generates_sbom() -> None:
+    steps = _job_steps()
+    sbom = [s for s in steps if "anchore/sbom-action" in str(s.get("uses", ""))]
+    assert sbom, "missing anchore/sbom-action step (SBOM generation)"
+    with_block = sbom[0].get("with") or {}
+    assert "cyclonedx" in str(with_block.get("format", "")).lower(), (
+        "SBOM format should be CycloneDX (the cross-tool standard)"
+    )
+
+
+def test_workflow_attaches_sbom_as_cosign_attestation() -> None:
+    steps = _job_steps()
+    for s in steps:
+        run = str(s.get("run", ""))
+        if "cosign attest" in run and "cyclonedx" in run:
+            # Also must target by digest.
+            assert "@${{ steps.build.outputs.digest }}" in run
+            return
+    raise AssertionError("no cosign attest step for the CycloneDX SBOM")
+
+
+def test_workflow_trivy_scans_for_critical_cves_and_fails_on_finding() -> None:
+    steps = _job_steps()
+    trivy = [s for s in steps if "aquasecurity/trivy-action" in str(s.get("uses", ""))]
+    assert trivy, "missing aquasecurity/trivy-action step"
+    w = trivy[0].get("with") or {}
+    # Must scan the published digest, not a mutable tag.
+    assert "@${{ steps.build.outputs.digest }}" in str(w.get("image-ref", "")), (
+        "Trivy must scan the image by digest"
+    )
+    # Must fail the job on findings.
+    assert str(w.get("exit-code")) == "1", "Trivy exit-code must be 1 to gate the build"
+    severity = str(w.get("severity", "")).upper()
+    assert "CRITICAL" in severity, "Trivy severity must include CRITICAL"
+
+
+def test_workflow_uploads_trivy_sarif_to_code_scanning() -> None:
+    """Findings must reach the Security tab even when the scan failed,
+    otherwise operators can't see what broke."""
+    steps = _job_steps()
+    upload = [s for s in steps if "github/codeql-action/upload-sarif" in str(s.get("uses", ""))]
+    assert upload, "missing upload-sarif step"
+    # Must run even on prior-step failure.
+    assert str(upload[0].get("if", "")).strip() == "always()"
 
 
 def test_workflow_logs_into_ghcr() -> None:


### PR DESCRIPTION
## Summary

Hardens the GHCR publish workflow with the three supply-chain guarantees every published image should carry.

- **Cosign keyless signing** via GitHub OIDC. Signs by digest.
- **CycloneDX SBOM** via anchore/sbom-action, attached as cosign attestation.
- **Trivy CVE scan** (CRITICAL, fail-on-finding). SARIF uploaded to Security tab on `always()`.

Required permission bump: `id-token: write` for cosign OIDC.

## Why this and not something heavier

Trivy can trip on HIGH findings in the upstream `python:3.12-slim-bookworm` base image routinely — we don't want to be chasing every libssl HIGH at homelab scale. Gating at CRITICAL keeps the signal high. Tune via `.trivyignore` or `ignore-unfixed: true` if false positives surface.

Signing does NOT enforce verification on the deploy side yet. That's a Tier 2/3 concern (deploy-side cosign verify + admission policy). Landing the signature now means we can enforce any time without rotating trust.

## Test plan

- [x] `make check` green (1103 tests)
- [x] 5 new structural tests assert every new step
- [ ] End-to-end smoke: merging this to v2 triggers the workflow on the branch push event. That run publishes `:v2` with the hardened steps — first real end-to-end run of the flow.

## Follow-up

After this merges:
- Cut `v0.2.1-test` tag → first versioned-tag publish with the full chain.
- Capture the digest, open a pin-bump PR per `deploy/runbooks/upgrade-image.md`, and flip `group_vars/all.yml` from `musubi-core:dev` → `ghcr.io/ericmey/musubi-core@sha256:<...>`.

No tracking Issue: CI hardening carved from the "Tier 1" discussion in PR #154's follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)