### PR TITLE
fix(ci): trivy-action v0.28.0 doesn't exist, use v0.35.0

### DIFF
--- a/.github/workflows/publish-core-image.yml
+++ b/.github/workflows/publish-core-image.yml
@@ -152,7 +152,7 @@ jobs:
             "ghcr.io/ericmey/musubi-core@${{ steps.build.outputs.digest }}"
 
       - name: Trivy vulnerability scan (fail on CRITICAL)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: "ghcr.io/ericmey/musubi-core@${{ steps.build.outputs.digest }}"
           format: sarif


### PR DESCRIPTION
Hotfix for PR #159. The pinned trivy-action version failed workflow resolution:

```
##[error]Unable to resolve action aquasecurity/trivy-action@0.28.0, unable to find version 0.28.0
```

The aquasecurity/trivy-action release series skipped from 0.27.x → 0.32.x; verified latest via API: **v0.35.0**.

No tracking Issue: hotfix for the merged #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)