### PR TITLE
fix(ci): security-events:write + Trivy table output

### DIFF
--- a/.github/workflows/publish-core-image.yml
+++ b/.github/workflows/publish-core-image.yml
@@ -44,11 +44,13 @@ jobs:
     permissions:
       # GITHUB_TOKEN needs `packages: write` to push to the repo's GHCR
       # namespace. `id-token: write` is required for cosign keyless
-      # signing via GitHub's OIDC provider. `contents: read` is the
-      # default but stated explicitly.
+      # signing via GitHub's OIDC provider. `security-events: write`
+      # is required by `github/codeql-action/upload-sarif@v3` to post
+      # Trivy findings to the Security → Code scanning tab.
       contents: read
       packages: write
       id-token: write
+      security-events: write
     outputs:
       image: ${{ steps.meta.outputs.tags }}
       digest: ${{ steps.build.outputs.digest }}
@@ -151,7 +153,20 @@ jobs:
             --type cyclonedx \
             "ghcr.io/ericmey/musubi-core@${{ steps.build.outputs.digest }}"
 
-      - name: Trivy vulnerability scan (fail on CRITICAL)
+      - name: Trivy vulnerability scan (table — always visible in logs)
+        # Human-readable pass first so operators can see what CRITICAL
+        # / HIGH findings exist without downloading the SARIF artefact.
+        # `exit-code: 0` → this step never fails; gating is below.
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: "ghcr.io/ericmey/musubi-core@${{ steps.build.outputs.digest }}"
+          format: table
+          severity: CRITICAL,HIGH
+          exit-code: "0"
+          ignore-unfixed: true
+          scanners: vuln
+
+      - name: Trivy vulnerability scan (SARIF — CRITICAL gate)
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: "ghcr.io/ericmey/musubi-core@${{ steps.build.outputs.digest }}"
@@ -159,12 +174,13 @@ jobs:
           output: trivy-results.sarif
           severity: CRITICAL
           # Exit 1 if any CRITICAL vulnerability is found. HIGH is
-          # surfaced as SARIF but not gated — a homelab service
-          # can't afford to chase every `libssl` HIGH on upstream
-          # images. Tune with an allowlist later if we hit false
-          # positives too often.
+          # surfaced in the prior table step for visibility but NOT
+          # gated — a homelab service can't afford to chase every
+          # libssl HIGH on upstream images. Tune via `.trivyignore`
+          # if we hit false positives too often.
           exit-code: "1"
           ignore-unfixed: true
+          scanners: vuln
 
       - name: Upload Trivy SARIF to GitHub Security tab
         # Runs even if Trivy failed so the findings are visible in

--- a/tests/ops/test_image_publish.py
+++ b/tests/ops/test_image_publish.py
@@ -151,18 +151,35 @@ def test_workflow_attaches_sbom_as_cosign_attestation() -> None:
 
 
 def test_workflow_trivy_scans_for_critical_cves_and_fails_on_finding() -> None:
+    """At least one Trivy step must fail the build on CRITICAL findings.
+    Workflow may have a table-format pre-scan for log visibility (exit-code
+    0) AND the SARIF gate (exit-code 1); only the gate matters here."""
     steps = _job_steps()
-    trivy = [s for s in steps if "aquasecurity/trivy-action" in str(s.get("uses", ""))]
-    assert trivy, "missing aquasecurity/trivy-action step"
-    w = trivy[0].get("with") or {}
-    # Must scan the published digest, not a mutable tag.
-    assert "@${{ steps.build.outputs.digest }}" in str(w.get("image-ref", "")), (
-        "Trivy must scan the image by digest"
+    trivy_steps = [s for s in steps if "aquasecurity/trivy-action" in str(s.get("uses", ""))]
+    assert trivy_steps, "missing aquasecurity/trivy-action step"
+
+    gate = None
+    for s in trivy_steps:
+        w = s.get("with") or {}
+        if str(w.get("exit-code")) == "1":
+            gate = w
+            break
+    assert gate is not None, (
+        "no Trivy step with exit-code: 1 — at least one step must gate the build"
     )
-    # Must fail the job on findings.
-    assert str(w.get("exit-code")) == "1", "Trivy exit-code must be 1 to gate the build"
-    severity = str(w.get("severity", "")).upper()
-    assert "CRITICAL" in severity, "Trivy severity must include CRITICAL"
+    assert "@${{ steps.build.outputs.digest }}" in str(gate.get("image-ref", "")), (
+        "Trivy gate must scan the image by digest"
+    )
+    severity = str(gate.get("severity", "")).upper()
+    assert "CRITICAL" in severity, "Trivy gate severity must include CRITICAL"
+
+
+def test_workflow_grants_security_events_write_for_sarif_upload() -> None:
+    """`upload-sarif@v3` requires security-events:write on the job token."""
+    perms = _job().get("permissions") or {}
+    assert perms.get("security-events") == "write", (
+        "missing security-events:write — upload-sarif fails without it"
+    )
 
 
 def test_workflow_uploads_trivy_sarif_to_code_scanning() -> None:


### PR DESCRIPTION
Follow-up to #159. Two real bugs found by the post-merge publish run:

1. `upload-sarif@v3` returned `Resource not accessible` because `security-events: write` wasn't granted. Findings never reached the Security tab.
2. The SARIF-only gate hides findings from the workflow logs, so operators couldn't see what the CRITICAL was without downloading the dockerbuild artefact.

This PR:
- Adds `security-events: write` to the job permissions.
- Adds a table-format Trivy pre-scan step (exit-code 0) that prints findings in logs.
- Keeps the SARIF gate step (exit-code 1) for the CRITICAL fail-on-finding behaviour.
- Pins `scanners: vuln` on both so we don't muddy the signal with license/config scans.

After merge, the next v2-push publish workflow run will surface any actual findings in a readable table, AND the SARIF upload will succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)