### PR TITLE
fix(ci): scope Trivy SARIF gate to CRITICAL-only

### DIFF
--- a/.github/workflows/publish-core-image.yml
+++ b/.github/workflows/publish-core-image.yml
@@ -173,6 +173,13 @@ jobs:
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL
+          # `limit-severities-for-sarif` forces trivy-action to apply
+          # the `severity:` filter when emitting SARIF. Without it the
+          # action generates a SARIF report containing findings of ALL
+          # severities, and `exit-code: 1` then fires on any non-empty
+          # report — turning a CRITICAL-only gate into a de-facto
+          # HIGH+CRITICAL gate.
+          limit-severities-for-sarif: "true"
           # Exit 1 if any CRITICAL vulnerability is found. HIGH is
           # surfaced in the prior table step for visibility but NOT
           # gated — a homelab service can't afford to chase every


### PR DESCRIPTION
No tracking Issue: chore/CI hotfix — the publish workflow's CRITICAL gate was mis-scoped and blocking merges on HIGH findings.

## Summary
Adds `limit-severities-for-sarif: \"true\"` to the SARIF-gated Trivy step in \`publish-core-image.yml\`.

Without this flag, trivy-action emits SARIF containing ALL severities regardless of \`severity:\` — and then \`exit-code: 1\` fires on any finding, not just CRITICAL. The previous run showed 0 CRITICAL + 2 HIGH (\`CVE-2026-28390\` on libssl3/openssl), correctly, in the table step — but the SARIF step failed on those HIGHs. This restores the intent: CRITICAL fails the build, HIGH is visible but not gated.

## Test plan
- [ ] Merge → next v2 push triggers publish workflow.
- [ ] SARIF stage exits 0 (no CRITICAL findings).
- [ ] Table stage still shows the HIGH findings (no regression in visibility).
- [ ] Security tab still receives the SARIF upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)