### PR TITLE
fix(ci): grant actions:read so upload-sarif can post to Security tab

### DIFF
--- a/.github/workflows/publish-core-image.yml
+++ b/.github/workflows/publish-core-image.yml
@@ -46,11 +46,15 @@ jobs:
       # namespace. `id-token: write` is required for cosign keyless
       # signing via GitHub's OIDC provider. `security-events: write`
       # is required by `github/codeql-action/upload-sarif@v3` to post
-      # Trivy findings to the Security → Code scanning tab.
+      # Trivy findings to the Security → Code scanning tab. `actions:
+      # read` lets upload-sarif hit the workflow-runs API for
+      # fingerprinting — without it the step fails with "Resource not
+      # accessible by integration" even when SARIF itself is valid.
       contents: read
       packages: write
       id-token: write
       security-events: write
+      actions: read
     outputs:
       image: ${{ steps.meta.outputs.tags }}
       digest: ${{ steps.build.outputs.digest }}


### PR DESCRIPTION
No tracking Issue: chore/CI hotfix — unblocks the publish workflow's post-scan tail.

## Summary
Adds \`actions: read\` to the publish-core-image job permissions block.

The Trivy CRITICAL gate fix in #166 unmasked a separate pre-existing issue: \`github/codeql-action/upload-sarif@v3\` was failing with \"Resource not accessible by integration\" when calling the workflow-runs API. That short-circuited the job, causing the Summarise-digest and release-asset steps to be skipped.

With \`actions: read\` the upload-sarif step completes, findings reach the Security → Code scanning tab, and the digest tail steps run.

## Test plan
- [ ] Merge → publish workflow triggers.
- [ ] Upload Trivy SARIF step exits 0.
- [ ] Summarise digest + Attach digest as release asset steps run (currently skipped).
- [ ] Security → Code scanning tab shows Trivy findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)