### PR TITLE
chore(vault): mark synthesis-builder slice done

### DIFF
--- a/docs/Musubi/_slices/slice-lifecycle-synthesis-builder.md
+++ b/docs/Musubi/_slices/slice-lifecycle-synthesis-builder.md
@@ -3,10 +3,10 @@ title: "Slice: Wire real synthesis jobs into the lifecycle runner"
 slice_id: slice-lifecycle-synthesis-builder
 section: _slices
 type: slice
-status: in-review
+status: done
 owner: claude-code-opus-4-7
 phase: "6 Lifecycle"
-tags: [section/slices, status/in-review, type/slice, lifecycle, synthesis, runner]
+tags: [section/slices, status/done, type/slice, lifecycle, synthesis, runner]
 updated: 2026-04-21
 reviewed: false
 depends-on: ["[[_slices/slice-lifecycle-synthesis]]"]


### PR DESCRIPTION
No tracking Issue: post-merge cleanup for #165 / #158.

Flips `docs/Musubi/_slices/slice-lifecycle-synthesis-builder.md` from `status: in-review` to `status: done` now that PR #165 is merged. Identical to what #168 did for demotion-builder.