### PR TITLE
fix(ci): make Trivy SARIF upload optional on private repos

### DIFF
--- a/.github/workflows/publish-core-image.yml
+++ b/.github/workflows/publish-core-image.yml
@@ -194,9 +194,16 @@ jobs:
           scanners: vuln
 
       - name: Upload Trivy SARIF to GitHub Security tab
-        # Runs even if Trivy failed so the findings are visible in
-        # the repo's Security → Code scanning view.
+        # Runs even if Trivy failed so the findings are visible in the
+        # repo's Security → Code scanning view when available.
+        #
+        # `continue-on-error: true` tolerates the "Code scanning is not
+        # enabled" failure on private repos without a GitHub Advanced
+        # Security subscription. The CRITICAL gate in the prior step
+        # still blocks bad images from shipping; this upload is a
+        # visibility nice-to-have, not a security gate.
         if: always()
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-results.sarif


### PR DESCRIPTION
No tracking Issue: third and (hopefully) final Trivy CI hotfix.

## Summary
Adds `continue-on-error: true` to the `github/codeql-action/upload-sarif` step. Private repos without GHAS can't enable code-scanning, so the upload is guaranteed to fail on this repo. The failure was skipping the tail of the publish job (`Summarise digest` + `Attach digest as release asset`).

The CRITICAL gate in the prior Trivy step still fails the job on real CRITICAL findings — security posture unchanged. This is about the last step being visibility-only, not a gate.

## Test plan
- [ ] Merge → next publish workflow run completes end-to-end.
- [ ] SARIF gate still exits 1 on a planted CRITICAL (unchanged).
- [ ] Summarise-digest + release-asset-attach steps run instead of being skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)