### PR TITLE
feat(lifecycle): promotion-builder

### DIFF
--- a/docs/Musubi/_slices/slice-lifecycle-promotion-builder.md
+++ b/docs/Musubi/_slices/slice-lifecycle-promotion-builder.md
@@ -3,10 +3,10 @@ title: "Slice: Wire real promotion jobs into the lifecycle runner"
 slice_id: slice-lifecycle-promotion-builder
 section: _slices
 type: slice
-status: ready
-owner: unassigned
+status: in-review
+owner: claude-code-opus-4-7
 phase: "6 Lifecycle"
-tags: [section/slices, status/ready, type/slice, lifecycle, promotion, runner]
+tags: [section/slices, status/in-review, type/slice, lifecycle, promotion, runner]
 updated: 2026-04-21
 reviewed: false
 depends-on: ["[[_slices/slice-lifecycle-promotion]]", "[[_slices/slice-vault-sync]]"]
@@ -20,7 +20,7 @@ blocks: []
 > that composes `run_promotion_sweep` against live `PromotionLLM`,
 > `VaultWriter`, and `ThoughtEmitter` implementations.
 
-**Phase:** 6 Lifecycle · **Status:** `ready` · **Owner:** `unassigned`
+**Phase:** 6 Lifecycle · **Status:** `in-review` · **Owner:** `claude-code-opus-4-7`
 
 ## Why this slice exists
 
@@ -84,8 +84,25 @@ Plus:
 
 ## Work log
 
-_(empty — awaiting claim)_
+### 2026-04-21 — claude-code-opus-4-7
+
+- `src/musubi/llm/prompts/promotion-render/v1.txt` + `src/musubi/llm/promotion_client.py`:
+  `HttpxPromotionClient` satisfying `PromotionLLM`. Raises on failure (no `None`-return) so the
+  sweep's existing try/except records a specific rejection reason.
+- `src/musubi/lifecycle/promotion.py`: added `build_promotion_jobs()` helper wired to
+  `run_promotion_sweep` behind `file_lock("promotion.lock")` at cron `04:00` UTC.
+- `src/musubi/lifecycle/runner.py`: `build_lifecycle_jobs()` grew a `promotion_jobs=` kwarg;
+  `_main_async()` composes the real `VaultWriter` (from `src/musubi/vault/writer.py`) + the
+  `HttpxPromotionClient` + the shared `ThoughtsPlaneEmitter` into the production
+  `PromotionDeps`.
+- `tests/llm/test_promotion_client.py` (new): 8 tests covering happy path, network / 5xx,
+  invalid envelope, and every validation branch (no H2, AI-disclaimer, body too short).
+- `tests/lifecycle/test_runner.py`: two new wiring tests
+  (`_wires_promotion_builders`, `_merges_all_four_builder_groups`).
+
+**Local verification:** `make check` → 1134 passed / 231 skipped. Commits follow
+tests-first ordering this time (per reviewer feedback on #165).
 
 ## PR links
 
-_(empty)_
+- PR — to be opened after local push.

--- a/src/musubi/lifecycle/promotion.py
+++ b/src/musubi/lifecycle/promotion.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel, Field, model_validator
 from qdrant_client import QdrantClient, models
 
 from musubi.lifecycle.events import LifecycleEventSink
+from musubi.lifecycle.scheduler import Job, file_lock
 from musubi.observability import default_registry
 from musubi.planes.concept.plane import ConceptPlane
 from musubi.planes.curated.plane import CuratedPlane
@@ -366,3 +367,65 @@ async def _promote_concept(deps: PromotionDeps, concept: SynthesizedConcept) -> 
         f"Promoted concept '{concept.title}' to {rel_path}. Please review.",
         "Concept Promoted",
     )
+
+
+# ---------------------------------------------------------------------------
+# Scheduler integration
+# ---------------------------------------------------------------------------
+
+
+def build_promotion_jobs(
+    *,
+    deps: PromotionDeps,
+    lock_dir: Path,
+    batch_size: int = 1,
+) -> list[Job]:
+    """Return the one-element Job list matching
+    :func:`musubi.lifecycle.scheduler.build_default_jobs`'s ``promotion``
+    entry (daily at 04:00 UTC).
+
+    ``lock_dir/promotion.lock`` serialises the sweep against any other
+    worker attempting the same promotion pass. ``batch_size`` defaults
+    to 1 — we'd rather promote slowly and give the human reviewer time
+    to notice than fire-hose a queue on first deploy.
+    """
+    import asyncio as _asyncio
+
+    lock_path = lock_dir / "promotion.lock"
+
+    async def _run_all() -> None:
+        try:
+            count = await run_promotion_sweep(deps, batch_size=batch_size)
+            log.info("promotion-done promoted=%d", count)
+        except Exception:
+            log.exception("promotion-failed")
+
+    def _runner() -> None:
+        with file_lock(lock_path) as acquired:
+            if not acquired:
+                log.info("lifecycle-job=promotion lock-held; skipping run")
+                return
+            _asyncio.run(_run_all())
+
+    return [
+        Job(
+            name="promotion",
+            trigger_kind="cron",
+            trigger_kwargs={"hour": 4, "minute": 0},
+            func=_runner,
+            grace_time_s=3600,
+        ),
+    ]
+
+
+__all__ = [
+    "PromotionDeps",
+    "PromotionLLM",
+    "PromotionRender",
+    "ThoughtEmitter",
+    "VaultWriter",
+    "build_promotion_jobs",
+    "compute_path",
+    "run_promotion_sweep",
+    "slugify",
+]

--- a/src/musubi/lifecycle/runner.py
+++ b/src/musubi/lifecycle/runner.py
@@ -208,14 +208,15 @@ def build_lifecycle_jobs(
     maturation_jobs: Iterable[Job] | None = None,
     demotion_jobs: Iterable[Job] | None = None,
     synthesis_jobs: Iterable[Job] | None = None,
+    promotion_jobs: Iterable[Job] | None = None,
 ) -> list[Job]:
     """Compose the full job list the production worker drives.
 
     Real job builders replace the placeholder-lambdas emitted by
     :func:`build_default_jobs` for every name they cover. Any job
     name the builders haven't claimed keeps the placeholder (which
-    log-skips). Promotion / reflection / vault_reconcile still use
-    placeholders until their builder slices land.
+    log-skips). Reflection / vault_reconcile still use placeholders
+    until their builder slices land.
 
     Injection points keep unit tests deterministic — a test can
     pass a stub Job without wiring a QdrantClient / Ollama / etc.
@@ -223,7 +224,7 @@ def build_lifecycle_jobs(
     from musubi.lifecycle.scheduler import build_default_jobs
 
     real_jobs: list[Job] = []
-    for group in (maturation_jobs, demotion_jobs, synthesis_jobs):
+    for group in (maturation_jobs, demotion_jobs, synthesis_jobs, promotion_jobs):
         if group is not None:
             real_jobs.extend(group)
 
@@ -274,14 +275,19 @@ async def _main_async() -> None:
         build_maturation_jobs,
         default_ollama_client,
     )
+    from musubi.lifecycle.promotion import PromotionDeps, build_promotion_jobs
     from musubi.lifecycle.synthesis import (
         SynthesisCursor,
         SynthesisOllamaClient,
         build_synthesis_jobs,
     )
+    from musubi.llm.promotion_client import HttpxPromotionClient
     from musubi.planes.concept.plane import ConceptPlane
+    from musubi.planes.curated.plane import CuratedPlane
     from musubi.planes.episodic.plane import EpisodicPlane
     from musubi.planes.thoughts.plane import ThoughtsPlane
+    from musubi.vault.writelog import WriteLog
+    from musubi.vault.writer import VaultWriter as _VaultWriter
 
     logging.basicConfig(
         level=logging.INFO,
@@ -345,10 +351,37 @@ async def _main_async() -> None:
         cursor=synth_cursor,
         lock_dir=lock_dir,
     )
+
+    # Promotion needs the real VaultWriter + a first-party HttpxPromotionClient.
+    # We reuse the lifecycle sqlite dir as the write-log home so the vault
+    # watcher (if running in the same deploy) shares the echo-filter state.
+    write_log_db = Path(settings.lifecycle_sqlite_path).parent / "vault-writelog.db"
+    vault_writer = _VaultWriter(
+        vault_root=settings.vault_path,
+        write_log=WriteLog(db_path=write_log_db),
+    )
+    promotion_llm = HttpxPromotionClient(
+        base_url=str(settings.ollama_url),
+        model=settings.llm_model,
+    )
+    curated_plane = CuratedPlane(client=qdrant, embedder=embedder)
+    prom_jobs = build_promotion_jobs(
+        deps=PromotionDeps(
+            qdrant=qdrant,
+            concept_plane=concept_plane,
+            curated_plane=curated_plane,
+            events=sink,
+            llm=promotion_llm,
+            vault_writer=vault_writer,
+            thoughts=thought_emitter,
+        ),
+        lock_dir=lock_dir,
+    )
     jobs = build_lifecycle_jobs(
         maturation_jobs=mat_jobs,
         demotion_jobs=dem_jobs,
         synthesis_jobs=syn_jobs,
+        promotion_jobs=prom_jobs,
     )
 
     runner = LifecycleRunner(jobs=jobs)

--- a/src/musubi/llm/promotion_client.py
+++ b/src/musubi/llm/promotion_client.py
@@ -1,0 +1,151 @@
+"""httpx-backed client satisfying :class:`PromotionLLM`.
+
+Contract differences from :class:`musubi.llm.HttpxOllamaClient`:
+
+- **Failure modes raise** rather than return ``None``. The promotion
+  sweep wraps each render in its own ``try/except`` and records a
+  ``promotion_rejection`` with the error message — silent ``None`` at
+  this layer would be consumed as "rendering succeeded with empty
+  content" which is strictly worse than a loud failure.
+- **Validation is in the Protocol's dataclass** (``PromotionRender``
+  has its own ``model_validator`` that enforces H2 presence and
+  rejects AI-disclaimer strings). On validation failure we re-raise
+  :class:`pydantic.ValidationError` as a :class:`ValueError` so the
+  sweep's rejection reason string reads cleanly.
+
+A separate class (rather than another method on ``HttpxOllamaClient``)
+keeps the two Protocol contracts — outage-returns-None for maturation
+/ synthesis vs raise-on-failure for promotion — from leaking into the
+same code path.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from importlib.resources import files
+from typing import Any
+
+import httpx
+from pydantic import BaseModel, Field, ValidationError
+
+from musubi.lifecycle.promotion import PromotionRender
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT_S = 180.0  # Qwen on CPU fallback can take 90s+ for long renders
+_PROMPT_VERSION = "v1"
+
+
+class _PromotionResponse(BaseModel):
+    """Wire-level shape from the LLM — upgraded to :class:`PromotionRender`
+    before return so the sweep's Protocol contract carries the tighter
+    validation (H2 required, disclaimer strings rejected).
+    """
+
+    body: str = Field(min_length=1)
+    wikilinks: list[str] = Field(default_factory=list)
+    sections: list[str] = Field(default_factory=list)
+
+
+def _load_prompt(name: str, version: str) -> str:
+    resource = files("musubi.llm.prompts").joinpath(name).joinpath(f"{version}.txt")
+    return resource.read_text(encoding="utf-8")
+
+
+def _render_prompt(*, title: str, content: str, rationale: str, top_memories: list[str]) -> str:
+    tpl = _load_prompt("promotion-render", _PROMPT_VERSION)
+    memories_block = "\n".join(f"  - {m}" for m in top_memories) if top_memories else "  (none)"
+    return (
+        tpl.replace("{TITLE}", title)
+        .replace("{CONTENT}", content)
+        .replace("{RATIONALE}", rationale)
+        .replace("{TOP_MEMORIES}", memories_block)
+    )
+
+
+def _extract_message_content(body: Any) -> str | None:
+    """Duplicates :func:`musubi.llm.ollama._extract_message_content`
+    deliberately — keeps the two clients' failure-mode code paths
+    independent. If a third caller appears, promote to a shared home.
+    """
+    if not isinstance(body, dict):
+        return None
+    msg = body.get("message")
+    if isinstance(msg, dict):
+        content = msg.get("content")
+        if isinstance(content, str) and content.strip():
+            return content
+    resp = body.get("response")
+    if isinstance(resp, str) and resp.strip():
+        return resp
+    return None
+
+
+class HttpxPromotionClient:
+    """Production satisfier of the ``PromotionLLM`` Protocol."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        model: str,
+        timeout_s: float = _DEFAULT_TIMEOUT_S,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._model = model
+        self._timeout_s = timeout_s
+
+    async def render_curated_markdown(
+        self,
+        title: str,
+        content: str,
+        rationale: str,
+        top_memories: list[str],
+    ) -> PromotionRender:
+        """Render a synthesized concept as curated markdown."""
+        prompt = _render_prompt(
+            title=title,
+            content=content,
+            rationale=rationale,
+            top_memories=top_memories,
+        )
+        raw = await self._chat(prompt)
+        try:
+            wire = _PromotionResponse.model_validate_json(raw)
+        except (ValidationError, ValueError) as exc:
+            raise ValueError(f"promotion-render envelope invalid: {exc}") from exc
+
+        try:
+            return PromotionRender(
+                body=wire.body,
+                wikilinks=wire.wikilinks,
+                sections=wire.sections,
+            )
+        except ValidationError as exc:
+            raise ValueError(f"promotion-render body rejected: {exc}") from exc
+
+    async def _chat(self, prompt: str) -> str:
+        url = f"{self._base_url}/api/chat"
+        payload: dict[str, Any] = {
+            "model": self._model,
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": False,
+            "format": "json",
+            "options": {"temperature": 0.2},
+        }
+        async with httpx.AsyncClient(timeout=self._timeout_s) as client:
+            response = await client.post(url, json=payload)
+        response.raise_for_status()
+        try:
+            body = response.json()
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"promotion-render envelope not JSON: {exc}") from exc
+
+        content = _extract_message_content(body)
+        if content is None:
+            raise ValueError("promotion-render envelope missing assistant message content")
+        return content
+
+
+__all__ = ["HttpxPromotionClient"]

--- a/src/musubi/llm/prompts/promotion-render/v1.txt
+++ b/src/musubi/llm/prompts/promotion-render/v1.txt
@@ -1,0 +1,22 @@
+You render a synthesized concept into a human-readable curated markdown note for an Obsidian vault.
+
+Given the concept below, produce a self-contained markdown body that an engineer could read cold and understand the concept without the AI context.
+
+Guidelines:
+- At least one H2 section (`## ...`).
+- Body between 100 and 20000 characters, written in the user's voice (first person where natural; never "as an AI" or "as a language model").
+- Wikilinks: surface any `[[wikilink]]` references that make sense given the concept's topic; return the flat list in the `wikilinks` field.
+- Sections: return the H2 section titles you produced in the `sections` field.
+- Do NOT include frontmatter; the writer appends frontmatter itself.
+- Do NOT include AI disclaimers ("as an AI", "as a language model", "I cannot", etc.) — those are rejected by the content validator.
+
+Concept:
+- Title: {TITLE}
+- Content: {CONTENT}
+- Rationale: {RATIONALE}
+- Top supporting memories:
+{TOP_MEMORIES}
+
+Respond in this exact JSON shape, no commentary:
+
+{"body": "<markdown>", "wikilinks": ["<wikilink>", ...], "sections": ["<section title>", ...]}

--- a/tests/lifecycle/test_runner.py
+++ b/tests/lifecycle/test_runner.py
@@ -334,3 +334,66 @@ def test_build_lifecycle_jobs_merges_maturation_and_demotion() -> None:
     assert by_name["demotion_concept"] is dem_stub
     # A name from neither real group stays placeholder.
     assert by_name["synthesis"].func.__name__ == "_run"
+
+
+def test_build_lifecycle_jobs_wires_promotion_builders() -> None:
+    """A stub promotion Job replaces the default placeholder; other
+    slots keep their placeholders."""
+    prom_stub = Job(
+        name="promotion",
+        trigger_kind="cron",
+        trigger_kwargs={"hour": 4, "minute": 0},
+        func=lambda: None,
+        grace_time_s=3600,
+    )
+    jobs = build_lifecycle_jobs(promotion_jobs=[prom_stub])
+    by_name = {j.name: j for j in jobs}
+    assert by_name["promotion"] is prom_stub
+    # Other names stay placeholder.
+    assert by_name["synthesis"].func.__name__ == "_run"
+    assert by_name["reflection_digest"].func.__name__ == "_run"
+
+
+def test_build_lifecycle_jobs_merges_all_four_builder_groups() -> None:
+    """Maturation + demotion + synthesis + promotion stubs all compose."""
+    mat = Job(
+        name="maturation_episodic",
+        trigger_kind="cron",
+        trigger_kwargs={"minute": 13},
+        func=lambda: None,
+        grace_time_s=900,
+    )
+    dem = Job(
+        name="demotion_concept",
+        trigger_kind="cron",
+        trigger_kwargs={"hour": 5, "minute": 0},
+        func=lambda: None,
+        grace_time_s=3600,
+    )
+    syn = Job(
+        name="synthesis",
+        trigger_kind="cron",
+        trigger_kwargs={"hour": 3, "minute": 0},
+        func=lambda: None,
+        grace_time_s=3600,
+    )
+    prom = Job(
+        name="promotion",
+        trigger_kind="cron",
+        trigger_kwargs={"hour": 4, "minute": 0},
+        func=lambda: None,
+        grace_time_s=3600,
+    )
+    jobs = build_lifecycle_jobs(
+        maturation_jobs=[mat],
+        demotion_jobs=[dem],
+        synthesis_jobs=[syn],
+        promotion_jobs=[prom],
+    )
+    by_name = {j.name: j for j in jobs}
+    assert by_name["maturation_episodic"] is mat
+    assert by_name["demotion_concept"] is dem
+    assert by_name["synthesis"] is syn
+    assert by_name["promotion"] is prom
+    # reflection_digest still placeholder.
+    assert by_name["reflection_digest"].func.__name__ == "_run"

--- a/tests/llm/test_promotion_client.py
+++ b/tests/llm/test_promotion_client.py
@@ -1,0 +1,188 @@
+"""Unit tests for :class:`musubi.llm.promotion_client.HttpxPromotionClient`.
+
+The Protocol contract (:class:`musubi.lifecycle.promotion.PromotionLLM`):
+
+- Happy path → returns a :class:`PromotionRender` with at least one H2
+  section, body between 100 and 20k chars, no AI-disclaimer strings.
+- Network failure / timeout / HTTP 4xx/5xx → raise (the sweep wraps
+  each call in try/except and records a rejection — see
+  ``_promote_concept``). Returning ``None`` like the maturation Ollama
+  client would be silently consumed as "rendering succeeded with no
+  content," which is worse than a loud failure.
+- Envelope parse failure → raise ``ValueError``.
+- Validation failure (body too short, no H2, AI disclaimer) → raise
+  ``ValueError`` with the concrete message — lets the sweep record a
+  specific rejection reason.
+
+Tests drive the client through ``pytest-httpx`` so no live Ollama is
+required.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from pytest_httpx import HTTPXMock
+
+from musubi.llm.promotion_client import HttpxPromotionClient
+
+_BASE_URL = "http://ollama:11434"
+_MODEL = "qwen3:4b"
+
+_VALID_BODY = (
+    "## Overview\n\n"
+    "This is a curated note about the concept. It contains enough content\n"
+    "to clear the 100-character minimum set by the validator, written in a\n"
+    "neutral voice that matches the user's style.\n\n"
+    "## Details\n\nAnother section with more depth and a couple of links.\n"
+)
+
+
+def _chat_body(payload: dict[str, object]) -> dict[str, object]:
+    return {"message": {"role": "assistant", "content": json.dumps(payload)}}
+
+
+def _valid_payload() -> dict[str, object]:
+    return {
+        "body": _VALID_BODY,
+        "wikilinks": ["[[concept-a]]", "[[topic-b]]"],
+        "sections": ["Overview", "Details"],
+    }
+
+
+def _client() -> HttpxPromotionClient:
+    return HttpxPromotionClient(base_url=_BASE_URL, model=_MODEL)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_render_curated_markdown_happy_path(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url=f"{_BASE_URL}/api/chat",
+        method="POST",
+        json=_chat_body(_valid_payload()),
+    )
+    client = _client()
+    render = await client.render_curated_markdown(
+        title="A concept",
+        content="Concept body.",
+        rationale="Concept rationale.",
+        top_memories=["memory one", "memory two"],
+    )
+    assert "## Overview" in render.body
+    assert render.wikilinks == ["[[concept-a]]", "[[topic-b]]"]
+    assert render.sections == ["Overview", "Details"]
+
+
+async def test_render_includes_top_memories_in_prompt(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url=f"{_BASE_URL}/api/chat",
+        method="POST",
+        json=_chat_body(_valid_payload()),
+    )
+    client = _client()
+    await client.render_curated_markdown(
+        title="T",
+        content="C",
+        rationale="R",
+        top_memories=["the-tell-tale-memory-string"],
+    )
+    request = httpx_mock.get_request()
+    assert request is not None
+    body = json.loads(request.content)
+    user_prompt = body["messages"][-1]["content"]
+    assert "the-tell-tale-memory-string" in user_prompt
+
+
+# ---------------------------------------------------------------------------
+# Failure paths — Protocol contract says RAISE, not return None
+# ---------------------------------------------------------------------------
+
+
+async def test_render_raises_on_network_failure(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_exception(httpx.ConnectError("boom"))
+    client = _client()
+    with pytest.raises(httpx.ConnectError):
+        await client.render_curated_markdown(
+            title="T", content="C", rationale="R", top_memories=[]
+        )
+
+
+async def test_render_raises_on_http_500(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url=f"{_BASE_URL}/api/chat",
+        method="POST",
+        status_code=500,
+        text="internal error",
+    )
+    client = _client()
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.render_curated_markdown(
+            title="T", content="C", rationale="R", top_memories=[]
+        )
+
+
+async def test_render_raises_on_invalid_envelope(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url=f"{_BASE_URL}/api/chat",
+        method="POST",
+        json={"unexpected": "shape"},
+    )
+    client = _client()
+    with pytest.raises(ValueError, match="envelope"):
+        await client.render_curated_markdown(
+            title="T", content="C", rationale="R", top_memories=[]
+        )
+
+
+async def test_render_raises_when_body_has_no_h2(httpx_mock: HTTPXMock) -> None:
+    bad = dict(_valid_payload())
+    bad["body"] = "Just a paragraph, no heading at all, but long enough to pass the 100 char minimum check easily so pydantic's length clears."
+    httpx_mock.add_response(
+        url=f"{_BASE_URL}/api/chat",
+        method="POST",
+        json=_chat_body(bad),
+    )
+    client = _client()
+    with pytest.raises(ValueError):
+        await client.render_curated_markdown(
+            title="T", content="C", rationale="R", top_memories=[]
+        )
+
+
+async def test_render_raises_on_ai_disclaimer(httpx_mock: HTTPXMock) -> None:
+    bad = dict(_valid_payload())
+    bad["body"] = (
+        "## Note\n\nAs an AI model I cannot have personal experiences, but this is my "
+        "attempt to render the concept as requested above."
+    )
+    httpx_mock.add_response(
+        url=f"{_BASE_URL}/api/chat",
+        method="POST",
+        json=_chat_body(bad),
+    )
+    client = _client()
+    with pytest.raises(ValueError):
+        await client.render_curated_markdown(
+            title="T", content="C", rationale="R", top_memories=[]
+        )
+
+
+async def test_render_raises_on_body_too_short(httpx_mock: HTTPXMock) -> None:
+    bad = dict(_valid_payload())
+    bad["body"] = "## Too short"
+    httpx_mock.add_response(
+        url=f"{_BASE_URL}/api/chat",
+        method="POST",
+        json=_chat_body(bad),
+    )
+    client = _client()
+    with pytest.raises(ValueError):
+        await client.render_curated_markdown(
+            title="T", content="C", rationale="R", top_memories=[]
+        )

--- a/tests/llm/test_promotion_client.py
+++ b/tests/llm/test_promotion_client.py
@@ -108,9 +108,7 @@ async def test_render_raises_on_network_failure(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_exception(httpx.ConnectError("boom"))
     client = _client()
     with pytest.raises(httpx.ConnectError):
-        await client.render_curated_markdown(
-            title="T", content="C", rationale="R", top_memories=[]
-        )
+        await client.render_curated_markdown(title="T", content="C", rationale="R", top_memories=[])
 
 
 async def test_render_raises_on_http_500(httpx_mock: HTTPXMock) -> None:
@@ -122,9 +120,7 @@ async def test_render_raises_on_http_500(httpx_mock: HTTPXMock) -> None:
     )
     client = _client()
     with pytest.raises(httpx.HTTPStatusError):
-        await client.render_curated_markdown(
-            title="T", content="C", rationale="R", top_memories=[]
-        )
+        await client.render_curated_markdown(title="T", content="C", rationale="R", top_memories=[])
 
 
 async def test_render_raises_on_invalid_envelope(httpx_mock: HTTPXMock) -> None:
@@ -135,14 +131,14 @@ async def test_render_raises_on_invalid_envelope(httpx_mock: HTTPXMock) -> None:
     )
     client = _client()
     with pytest.raises(ValueError, match="envelope"):
-        await client.render_curated_markdown(
-            title="T", content="C", rationale="R", top_memories=[]
-        )
+        await client.render_curated_markdown(title="T", content="C", rationale="R", top_memories=[])
 
 
 async def test_render_raises_when_body_has_no_h2(httpx_mock: HTTPXMock) -> None:
     bad = dict(_valid_payload())
-    bad["body"] = "Just a paragraph, no heading at all, but long enough to pass the 100 char minimum check easily so pydantic's length clears."
+    bad["body"] = (
+        "Just a paragraph, no heading at all, but long enough to pass the 100 char minimum check easily so pydantic's length clears."
+    )
     httpx_mock.add_response(
         url=f"{_BASE_URL}/api/chat",
         method="POST",
@@ -150,9 +146,7 @@ async def test_render_raises_when_body_has_no_h2(httpx_mock: HTTPXMock) -> None:
     )
     client = _client()
     with pytest.raises(ValueError):
-        await client.render_curated_markdown(
-            title="T", content="C", rationale="R", top_memories=[]
-        )
+        await client.render_curated_markdown(title="T", content="C", rationale="R", top_memories=[])
 
 
 async def test_render_raises_on_ai_disclaimer(httpx_mock: HTTPXMock) -> None:
@@ -168,9 +162,7 @@ async def test_render_raises_on_ai_disclaimer(httpx_mock: HTTPXMock) -> None:
     )
     client = _client()
     with pytest.raises(ValueError):
-        await client.render_curated_markdown(
-            title="T", content="C", rationale="R", top_memories=[]
-        )
+        await client.render_curated_markdown(title="T", content="C", rationale="R", top_memories=[])
 
 
 async def test_render_raises_on_body_too_short(httpx_mock: HTTPXMock) -> None:
@@ -183,6 +175,4 @@ async def test_render_raises_on_body_too_short(httpx_mock: HTTPXMock) -> None:
     )
     client = _client()
     with pytest.raises(ValueError):
-        await client.render_curated_markdown(
-            title="T", content="C", rationale="R", top_memories=[]
-        )
+        await client.render_curated_markdown(title="T", content="C", rationale="R", top_memories=[])


### PR DESCRIPTION
Closes #156.

## Summary
Third of the four P3 builders. Wires `run_promotion_sweep` into the production lifecycle runner, cron at `04:00` UTC. Promotes mature concepts to curated markdown files under `vault/<ns>/concepts/`.

## What's new
- `src/musubi/llm/promotion_client.py` — `HttpxPromotionClient` satisfying `PromotionLLM`. **Raises** on failure rather than returning `None` (the sweep wraps each render in try/except and records a specific rejection reason; a silent `None` would be consumed as "render succeeded with empty content").
- `src/musubi/llm/prompts/promotion-render/v1.txt` — first-party prompt grounded in `PromotionRender`'s validators.
- `src/musubi/lifecycle/promotion.py` — additive `build_promotion_jobs()`; imports `Job` + `file_lock`. No edits to existing sweep logic.
- `src/musubi/lifecycle/runner.py` — `build_lifecycle_jobs()` grown a `promotion_jobs=` kwarg; `_main_async()` composes the real `VaultWriter` (lifted from `src/musubi/vault/writer.py`) + `HttpxPromotionClient` + the shared `ThoughtsPlaneEmitter` into `PromotionDeps`.

## Design notes
- **Failure-mode divergence is deliberate.** `HttpxOllamaClient` returns `None` on outage because the maturation/synthesis sweeps treat missing data as fallback-worthy. Promotion can't degrade: a failed render means "record the rejection and move on," not "silently skip a gated write." The separate class keeps the two contracts from leaking.
- **Shared WriteLog.** The runner instantiates `WriteLog` at `settings.lifecycle_sqlite_path.parent / "vault-writelog.db"` so the vault watcher (when wired) sees the same echo-filter state.

## Test plan
- [x] `make check` → 1134 passed / 231 skipped (+10 new).
- [x] Tests-first commit ordering: test file + prompt landed in `test(llm): initial test contract for slice-lifecycle-promotion-builder`; feat commit followed.
- [x] New tests in `tests/llm/test_promotion_client.py` (8) cover happy + 6 failure modes.
- [x] New tests in `tests/lifecycle/test_runner.py` (2) cover wiring in isolation and merged with all three prior builders.
- [ ] End-to-end against `musubi.mey.house` after merge (deferred to deploy step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)