### PR TITLE
feat(lifecycle): reflection-builder closes P3

### DIFF
--- a/docs/Musubi/_slices/slice-lifecycle-reflection-builder.md
+++ b/docs/Musubi/_slices/slice-lifecycle-reflection-builder.md
@@ -3,10 +3,10 @@ title: "Slice: Wire real reflection jobs into the lifecycle runner"
 slice_id: slice-lifecycle-reflection-builder
 section: _slices
 type: slice
-status: ready
-owner: unassigned
+status: in-review
+owner: claude-code-opus-4-7
 phase: "6 Lifecycle"
-tags: [section/slices, status/ready, type/slice, lifecycle, reflection, runner]
+tags: [section/slices, status/in-review, type/slice, lifecycle, reflection, runner]
 updated: 2026-04-21
 reviewed: false
 depends-on: ["[[_slices/slice-lifecycle-reflection]]", "[[_slices/slice-vault-sync]]"]
@@ -78,8 +78,34 @@ Plus:
 
 ## Work log
 
-_(empty — awaiting claim)_
+### 2026-04-21 — claude-code-opus-4-7
+
+Landed on the same day as the other P3 builders. Completes the four-
+builder P3 pass; only `vault_reconcile` remains on its placeholder.
+
+- `src/musubi/llm/prompts/reflection/v1.txt` + `src/musubi/llm/reflection_client.py`:
+  `HttpxReflectionClient` satisfying `ReflectionLLM`. Returns `None` on outage
+  (matches the maturation/synthesis pattern) — the sweep substitutes the
+  documented skip notice.
+- `src/musubi/lifecycle/emitters.py` (additive): new `ReflectionVaultWriter`
+  (async `write_reflection` wrapping the sync vault writer + WriteLog for
+  echo-filter) and `ReflectionThoughtsEmitter` (adapts the reflection
+  sweep's kw-only `emit(namespace, channel, content, importance)` over
+  `ThoughtsPlane.send`).
+- `src/musubi/lifecycle/reflection.py`: added `build_reflection_jobs()`
+  wired to `run_reflection_sweep` behind `file_lock("reflection.lock")`
+  at cron `06:00` UTC.
+- `src/musubi/lifecycle/runner.py`: `build_lifecycle_jobs()` grew a
+  `reflection_jobs=` kwarg; `_main_async()` composes the real
+  `HttpxReflectionClient` + `ReflectionVaultWriter` + `ReflectionThoughtsEmitter`.
+- `tests/llm/test_reflection_client.py` (new): 7 tests covering happy
+  path, empty-items short-circuit, 4 failure modes.
+- `tests/lifecycle/test_runner.py`: two new wiring tests
+  (`_wires_reflection_builders`, `_merges_all_five_builder_groups`).
+
+**Local verification:** `make check` → 1143 passed / 231 skipped. Tests-first
+commit ordering respected.
 
 ## PR links
 
-_(empty)_
+- PR — to be opened after push.

--- a/src/musubi/lifecycle/emitters.py
+++ b/src/musubi/lifecycle/emitters.py
@@ -1,13 +1,19 @@
-"""Adapter: lifecycle sweeps → `ThoughtsPlane`.
+"""Adapter: lifecycle sweeps → `ThoughtsPlane` + `VaultWriter`.
 
-Background: the demotion / promotion / reflection sweeps depend on a
-`ThoughtEmitter` Protocol with a small, channel-oriented surface:
+Background: the demotion / promotion / reflection sweeps depend on
+small, Protocol-shaped surfaces for emitting thoughts and writing
+files:
 
-    async def emit(self, channel: str, content: str, title: str | None = None) -> None
+- demotion / promotion:
+      async def emit(channel: str, content: str, title: str | None) -> None
+- reflection:
+      async def emit(*, namespace: str, channel: str, content: str, importance: int) -> None
+- promotion: sync ``VaultWriter.write_curated``
+- reflection: async ``VaultWriter.write_reflection``
 
 `ThoughtsPlane.send`, the production surface, takes a fully-shaped
-`Thought` object. The two don't meet naturally — an adapter sits
-between them so the sweeps can stay agnostic of ``Thought`` internals
+`Thought` object. The two don't meet naturally — adapters sit between
+them so the sweeps can stay agnostic of ``Thought`` internals
 (namespace shape, importance default, from/to presences) and
 ``ThoughtsPlane`` stays the single mutation path for the thoughts
 collection.
@@ -30,8 +36,12 @@ batch.
 
 from __future__ import annotations
 
+import asyncio
+from pathlib import Path
+
 from musubi.planes.thoughts.plane import ThoughtsPlane
 from musubi.types.thought import Thought
+from musubi.vault.writelog import WriteLog
 
 
 class ThoughtsPlaneEmitter:
@@ -86,4 +96,84 @@ class ThoughtsPlaneEmitter:
         await self._thoughts.send(thought)
 
 
-__all__ = ["ThoughtsPlaneEmitter"]
+class ReflectionThoughtsEmitter:
+    """Adapter for the reflection sweep's keyword-only `ThoughtEmitter`.
+
+    The reflection Protocol passes namespace + importance explicitly
+    per-call (the sweep is per-namespace), so we skip the
+    `from_presence/ops/thought` defaulting that :class:`ThoughtsPlaneEmitter`
+    does.
+    """
+
+    def __init__(
+        self,
+        *,
+        thoughts: ThoughtsPlane,
+        from_presence: str = "lifecycle-worker",
+        to_presence: str = "all",
+    ) -> None:
+        if not from_presence:
+            raise ValueError("from_presence is required")
+        self._thoughts = thoughts
+        self._from = from_presence
+        self._to = to_presence
+
+    async def emit(
+        self,
+        *,
+        namespace: str,
+        channel: str,
+        content: str,
+        importance: int,
+    ) -> None:
+        thought = Thought(
+            namespace=namespace,
+            content=content,
+            from_presence=self._from,
+            to_presence=self._to,
+            channel=channel,
+            importance=importance,
+        )
+        await self._thoughts.send(thought)
+
+
+class ReflectionVaultWriter:
+    """Adapter for the reflection sweep's async `write_reflection`.
+
+    Wraps the sync :class:`musubi.vault.writer.VaultWriter` write path:
+    concatenates frontmatter + body, writes the file, records into the
+    shared :class:`WriteLog` so the vault watcher's echo-filter catches
+    our own writes. ``asyncio.to_thread`` keeps the filesystem call off
+    the event loop.
+    """
+
+    def __init__(
+        self,
+        *,
+        vault_root: Path,
+        write_log: WriteLog,
+    ) -> None:
+        self._vault_root = vault_root
+        self._write_log = write_log
+
+    async def write_reflection(self, *, path: str, frontmatter: str, body: str) -> None:
+        def _sync_write() -> None:
+            full = self._vault_root / path.lstrip("/")
+            full.parent.mkdir(parents=True, exist_ok=True)
+            content = frontmatter + body
+            full.write_text(content, encoding="utf-8")
+            # Echo-filter bookkeeping: the watcher sees this write but
+            # consume_if_exists will drop it.
+            import hashlib
+
+            body_hash = hashlib.sha256(body.encode("utf-8")).hexdigest()
+            self._write_log.record_write(path, body_hash)
+
+        await asyncio.to_thread(_sync_write)
+
+
+__all__ = [
+    "ReflectionThoughtsEmitter",
+    "ReflectionVaultWriter",
+    "ThoughtsPlaneEmitter",
+]

--- a/src/musubi/lifecycle/reflection.py
+++ b/src/musubi/lifecycle/reflection.py
@@ -54,12 +54,14 @@ from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from functools import wraps
+from pathlib import Path
 from typing import Any, Protocol
 
 from qdrant_client import QdrantClient, models
 
 from musubi.config import get_settings
 from musubi.lifecycle.events import LifecycleEventSink
+from musubi.lifecycle.scheduler import Job, file_lock
 from musubi.observability import default_registry
 from musubi.planes.curated import CuratedPlane
 from musubi.types.common import KSUID, Namespace, generate_ksuid, utc_now
@@ -868,12 +870,79 @@ def _sha256(text: str) -> str:
 _ = (UTC, Any)
 
 
+# ---------------------------------------------------------------------------
+# Scheduler integration
+# ---------------------------------------------------------------------------
+
+
+def build_reflection_jobs(
+    *,
+    qdrant: QdrantClient,
+    sink: LifecycleEventSink,
+    curated_plane: CuratedPlane,
+    vault: VaultWriter,
+    thoughts: ThoughtEmitter,
+    llm: ReflectionLLM,
+    namespace: Namespace,
+    lock_dir: Path,
+    config: ReflectionConfig | None = None,
+) -> list[Job]:
+    """Return the one-element Job list matching
+    :func:`musubi.lifecycle.scheduler.build_default_jobs`'s
+    ``reflection_digest`` entry (daily at 06:00 UTC).
+
+    File lock ``lock_dir/reflection.lock`` serialises against any other
+    worker attempting the same digest.
+    """
+    import asyncio as _asyncio
+
+    lock_path = lock_dir / "reflection.lock"
+
+    async def _run_once() -> None:
+        try:
+            result = await run_reflection_sweep(
+                qdrant=qdrant,
+                sink=sink,
+                curated_plane=curated_plane,
+                vault=vault,
+                thoughts=thoughts,
+                llm=llm,
+                namespace=namespace,
+                config=config,
+            )
+            log.info(
+                "reflection-done path=%s sections=%s",
+                result.path,
+                result.sections,
+            )
+        except Exception:
+            log.exception("reflection-failed")
+
+    def _runner() -> None:
+        with file_lock(lock_path) as acquired:
+            if not acquired:
+                log.info("lifecycle-job=reflection_digest lock-held; skipping run")
+                return
+            _asyncio.run(_run_once())
+
+    return [
+        Job(
+            name="reflection_digest",
+            trigger_kind="cron",
+            trigger_kwargs={"hour": 6, "minute": 0},
+            func=_runner,
+            grace_time_s=3600,
+        ),
+    ]
+
+
 __all__ = [
     "ReflectionConfig",
     "ReflectionLLM",
     "ReflectionResult",
     "ThoughtEmitter",
     "VaultWriter",
+    "build_reflection_jobs",
     "default_reflection_llm",
     "default_thought_emitter",
     "default_vault_writer",

--- a/src/musubi/lifecycle/runner.py
+++ b/src/musubi/lifecycle/runner.py
@@ -209,14 +209,14 @@ def build_lifecycle_jobs(
     demotion_jobs: Iterable[Job] | None = None,
     synthesis_jobs: Iterable[Job] | None = None,
     promotion_jobs: Iterable[Job] | None = None,
+    reflection_jobs: Iterable[Job] | None = None,
 ) -> list[Job]:
     """Compose the full job list the production worker drives.
 
     Real job builders replace the placeholder-lambdas emitted by
     :func:`build_default_jobs` for every name they cover. Any job
     name the builders haven't claimed keeps the placeholder (which
-    log-skips). Reflection / vault_reconcile still use placeholders
-    until their builder slices land.
+    log-skips). Only ``vault_reconcile`` still uses a placeholder.
 
     Injection points keep unit tests deterministic — a test can
     pass a stub Job without wiring a QdrantClient / Ollama / etc.
@@ -224,7 +224,13 @@ def build_lifecycle_jobs(
     from musubi.lifecycle.scheduler import build_default_jobs
 
     real_jobs: list[Job] = []
-    for group in (maturation_jobs, demotion_jobs, synthesis_jobs, promotion_jobs):
+    for group in (
+        maturation_jobs,
+        demotion_jobs,
+        synthesis_jobs,
+        promotion_jobs,
+        reflection_jobs,
+    ):
         if group is not None:
             real_jobs.extend(group)
 
@@ -268,7 +274,11 @@ async def _main_async() -> None:
     from musubi.config import get_settings
     from musubi.embedding.tei import TEIDenseClient, TEIRerankerClient, TEISparseClient
     from musubi.lifecycle.demotion import DemotionDeps, build_demotion_jobs
-    from musubi.lifecycle.emitters import ThoughtsPlaneEmitter
+    from musubi.lifecycle.emitters import (
+        ReflectionThoughtsEmitter,
+        ReflectionVaultWriter,
+        ThoughtsPlaneEmitter,
+    )
     from musubi.lifecycle.events import LifecycleEventSink
     from musubi.lifecycle.maturation import (
         MaturationCursor,
@@ -276,12 +286,14 @@ async def _main_async() -> None:
         default_ollama_client,
     )
     from musubi.lifecycle.promotion import PromotionDeps, build_promotion_jobs
+    from musubi.lifecycle.reflection import build_reflection_jobs
     from musubi.lifecycle.synthesis import (
         SynthesisCursor,
         SynthesisOllamaClient,
         build_synthesis_jobs,
     )
     from musubi.llm.promotion_client import HttpxPromotionClient
+    from musubi.llm.reflection_client import HttpxReflectionClient
     from musubi.planes.concept.plane import ConceptPlane
     from musubi.planes.curated.plane import CuratedPlane
     from musubi.planes.episodic.plane import EpisodicPlane
@@ -377,11 +389,40 @@ async def _main_async() -> None:
         ),
         lock_dir=lock_dir,
     )
+    # Reflection needs its own shaped adapters (async `write_reflection`,
+    # kw-only `emit`) — see `lifecycle/emitters.py`.
+    reflection_vault = ReflectionVaultWriter(
+        vault_root=settings.vault_path,
+        write_log=vault_writer.write_log,
+    )
+    reflection_thoughts = ReflectionThoughtsEmitter(
+        thoughts=thoughts_plane,
+        from_presence="lifecycle-worker",
+    )
+    reflection_llm = HttpxReflectionClient(
+        base_url=str(settings.ollama_url),
+        model=settings.llm_model,
+    )
+    # Homelab default: one reflection namespace for the whole deploy.
+    # A future namespace-discovery pass (like synthesis) can per-namespace
+    # this when we grow multiple presences.
+    reflection_namespace = "lifecycle-worker/ops/curated"
+    ref_jobs = build_reflection_jobs(
+        qdrant=qdrant,
+        sink=sink,
+        curated_plane=curated_plane,
+        vault=reflection_vault,
+        thoughts=reflection_thoughts,
+        llm=reflection_llm,
+        namespace=reflection_namespace,
+        lock_dir=lock_dir,
+    )
     jobs = build_lifecycle_jobs(
         maturation_jobs=mat_jobs,
         demotion_jobs=dem_jobs,
         synthesis_jobs=syn_jobs,
         promotion_jobs=prom_jobs,
+        reflection_jobs=ref_jobs,
     )
 
     runner = LifecycleRunner(jobs=jobs)

--- a/src/musubi/llm/prompts/reflection/v1.txt
+++ b/src/musubi/llm/prompts/reflection/v1.txt
@@ -1,0 +1,13 @@
+You summarize the day's captured episodic memories into a short "patterns" section for a daily reflection note.
+
+Given the items below (each is `id + topic + one-line summary`), identify 1–4 cross-cutting themes that appeared across multiple memories. For each theme, write a paragraph grounded in the items it draws from — you may cite the episodic id inline in backticks (e.g. `KSUID`), but only ids that appear in the input; do NOT invent ids.
+
+Guidelines:
+- Output is a markdown fragment, not a full document: a sequence of `## Theme Title` blocks with one paragraph each.
+- If the day's items have no coherent theme, return the single line: `No dominant theme in today's captures.`
+- Do not include frontmatter or `# H1` — those are rendered by the calling framework.
+- Do not preface with "Here are the themes" or similar narrator prose.
+- Do not apologize, hedge, or include disclaimers.
+
+Items:
+{ITEMS}

--- a/src/musubi/llm/reflection_client.py
+++ b/src/musubi/llm/reflection_client.py
@@ -1,0 +1,128 @@
+"""httpx-backed client satisfying :class:`ReflectionLLM`.
+
+Contract: returns ``None`` on any outage so the reflection sweep can
+substitute the documented skip notice rather than failing the whole
+digest. Matches the maturation/synthesis pattern — see
+:mod:`musubi.llm.ollama` for the sibling clients.
+
+Why a separate file (rather than another method on
+:class:`HttpxOllamaClient`): the reflection Protocol has a simpler
+surface (no pydantic-validated response — the LLM output *is* the
+markdown) and keeping the two classes independent lets each evolve
+without forcing the other's callers to re-verify.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from importlib.resources import files
+from typing import Any
+
+import httpx
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT_S = 180.0
+_PROMPT_VERSION = "v1"
+
+
+def _load_prompt(name: str, version: str) -> str:
+    resource = files("musubi.llm.prompts").joinpath(name).joinpath(f"{version}.txt")
+    return resource.read_text(encoding="utf-8")
+
+
+def _render_prompt(items: list[dict[str, object]]) -> str:
+    tpl = _load_prompt("reflection", _PROMPT_VERSION)
+    if not items:
+        rendered = "  (no items)"
+    else:
+        rendered = "\n".join(
+            f"- id={it.get('id')} topic={it.get('topic', '')}\n  summary: {it.get('summary', '')}"
+            for it in items
+        )
+    return tpl.replace("{ITEMS}", rendered)
+
+
+def _extract_message_content(body: Any) -> str | None:
+    if not isinstance(body, dict):
+        return None
+    msg = body.get("message")
+    if isinstance(msg, dict):
+        content = msg.get("content")
+        if isinstance(content, str) and content.strip():
+            return content
+    resp = body.get("response")
+    if isinstance(resp, str) and resp.strip():
+        return resp
+    return None
+
+
+class HttpxReflectionClient:
+    """Production satisfier of the ``ReflectionLLM`` Protocol."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        model: str,
+        timeout_s: float = _DEFAULT_TIMEOUT_S,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._model = model
+        self._timeout_s = timeout_s
+
+    async def summarize_patterns(self, items: list[dict[str, object]]) -> str | None:
+        """Ask the LLM to summarise the day's episodics into themes.
+
+        Returns ``None`` on any outage — callers (see
+        :func:`musubi.lifecycle.reflection.run_reflection_sweep`) treat
+        ``None`` as "substitute the skip notice" rather than failing
+        the whole reflection run.
+
+        Empty ``items`` short-circuits to ``""`` without an HTTP call
+        (avoids a pointless round trip and matches the "no dominant
+        theme" case the prompt documents).
+        """
+        if not items:
+            return ""
+
+        prompt = _render_prompt(items)
+        url = f"{self._base_url}/api/chat"
+        payload: dict[str, Any] = {
+            "model": self._model,
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": False,
+            "options": {"temperature": 0.2},
+        }
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout_s) as client:
+                response = await client.post(url, json=payload)
+        except httpx.HTTPError as exc:
+            log.warning(
+                "reflection-network-error type=%s err=%s",
+                type(exc).__name__,
+                exc,
+            )
+            return None
+        if response.status_code >= 400:
+            log.warning(
+                "reflection-http-error status=%d body=%s",
+                response.status_code,
+                response.text[:500],
+            )
+            return None
+        try:
+            body = response.json()
+        except json.JSONDecodeError as exc:
+            log.warning("reflection-envelope-not-json err=%s", exc)
+            return None
+
+        content = _extract_message_content(body)
+        if content is None:
+            log.warning("reflection-empty-content body=%s", str(body)[:200])
+            return None
+        return content
+
+
+__all__ = ["HttpxReflectionClient"]

--- a/tests/lifecycle/test_runner.py
+++ b/tests/lifecycle/test_runner.py
@@ -397,3 +397,76 @@ def test_build_lifecycle_jobs_merges_all_four_builder_groups() -> None:
     assert by_name["promotion"] is prom
     # reflection_digest still placeholder.
     assert by_name["reflection_digest"].func.__name__ == "_run"
+
+
+def test_build_lifecycle_jobs_wires_reflection_builders() -> None:
+    """A stub reflection Job replaces the default placeholder; other
+    slots keep their placeholders."""
+    ref_stub = Job(
+        name="reflection_digest",
+        trigger_kind="cron",
+        trigger_kwargs={"hour": 6, "minute": 0},
+        func=lambda: None,
+        grace_time_s=3600,
+    )
+    jobs = build_lifecycle_jobs(reflection_jobs=[ref_stub])
+    by_name = {j.name: j for j in jobs}
+    assert by_name["reflection_digest"] is ref_stub
+    # Other names stay placeholder.
+    assert by_name["synthesis"].func.__name__ == "_run"
+    assert by_name["promotion"].func.__name__ == "_run"
+
+
+def test_build_lifecycle_jobs_merges_all_five_builder_groups() -> None:
+    """All four P3 builder groups (plus maturation) compose together;
+    only `vault_reconcile` remains on its placeholder."""
+    mat = Job(
+        name="maturation_episodic",
+        trigger_kind="cron",
+        trigger_kwargs={"minute": 13},
+        func=lambda: None,
+        grace_time_s=900,
+    )
+    dem = Job(
+        name="demotion_concept",
+        trigger_kind="cron",
+        trigger_kwargs={"hour": 5, "minute": 0},
+        func=lambda: None,
+        grace_time_s=3600,
+    )
+    syn = Job(
+        name="synthesis",
+        trigger_kind="cron",
+        trigger_kwargs={"hour": 3, "minute": 0},
+        func=lambda: None,
+        grace_time_s=3600,
+    )
+    prom = Job(
+        name="promotion",
+        trigger_kind="cron",
+        trigger_kwargs={"hour": 4, "minute": 0},
+        func=lambda: None,
+        grace_time_s=3600,
+    )
+    ref = Job(
+        name="reflection_digest",
+        trigger_kind="cron",
+        trigger_kwargs={"hour": 6, "minute": 0},
+        func=lambda: None,
+        grace_time_s=3600,
+    )
+    jobs = build_lifecycle_jobs(
+        maturation_jobs=[mat],
+        demotion_jobs=[dem],
+        synthesis_jobs=[syn],
+        promotion_jobs=[prom],
+        reflection_jobs=[ref],
+    )
+    by_name = {j.name: j for j in jobs}
+    assert by_name["maturation_episodic"] is mat
+    assert by_name["demotion_concept"] is dem
+    assert by_name["synthesis"] is syn
+    assert by_name["promotion"] is prom
+    assert by_name["reflection_digest"] is ref
+    # vault_reconcile still placeholder.
+    assert by_name["vault_reconcile"].func.__name__ == "_run"

--- a/tests/llm/test_reflection_client.py
+++ b/tests/llm/test_reflection_client.py
@@ -1,0 +1,129 @@
+"""Unit tests for :class:`musubi.llm.reflection_client.HttpxReflectionClient`.
+
+The Protocol contract (:class:`musubi.lifecycle.reflection.ReflectionLLM`):
+
+    async def summarize_patterns(self, items: list[dict[str, object]]) -> str | None
+
+Failure mode matches the Ollama pattern: return ``None`` on any
+outage / error so the sweep can substitute the documented skip notice
+rather than failing the whole reflection run.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+from pytest_httpx import HTTPXMock
+
+from musubi.llm.reflection_client import HttpxReflectionClient
+
+_BASE_URL = "http://ollama:11434"
+_MODEL = "qwen3:4b"
+
+
+def _chat_body(content: str) -> dict[str, object]:
+    return {"message": {"role": "assistant", "content": content}}
+
+
+def _items(n: int) -> list[dict[str, object]]:
+    return [
+        {"id": f"id-{i}", "topic": f"topic-{i}", "summary": f"summary line {i}"}
+        for i in range(n)
+    ]
+
+
+def _client() -> HttpxReflectionClient:
+    return HttpxReflectionClient(base_url=_BASE_URL, model=_MODEL)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_summarize_patterns_returns_markdown(httpx_mock: HTTPXMock) -> None:
+    content = "## Theme One\n\nA paragraph about the first theme."
+    httpx_mock.add_response(
+        url=f"{_BASE_URL}/api/chat",
+        method="POST",
+        json=_chat_body(content),
+    )
+    out = await _client().summarize_patterns(_items(3))
+    assert out is not None
+    assert "## Theme One" in out
+
+
+async def test_summarize_patterns_passes_items_to_prompt(
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(
+        url=f"{_BASE_URL}/api/chat",
+        method="POST",
+        json=_chat_body("## T\n\nBody."),
+    )
+    await _client().summarize_patterns(
+        [{"id": "zzz", "topic": "vault", "summary": "a marker-summary-string"}]
+    )
+    req = httpx_mock.get_request()
+    assert req is not None
+    body = json.loads(req.content)
+    user_prompt = body["messages"][-1]["content"]
+    assert "marker-summary-string" in user_prompt
+    assert "vault" in user_prompt
+
+
+async def test_summarize_patterns_empty_items_returns_empty_string_without_http(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """No items → no LLM call needed; return the empty string directly."""
+    out = await _client().summarize_patterns([])
+    assert out == ""
+    # No requests were made.
+    assert httpx_mock.get_requests() == []
+
+
+# ---------------------------------------------------------------------------
+# Failure paths — Protocol says return None, not raise
+# ---------------------------------------------------------------------------
+
+
+async def test_summarize_patterns_returns_none_on_network_failure(
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_exception(httpx.ConnectError("boom"))
+    assert await _client().summarize_patterns(_items(2)) is None
+
+
+async def test_summarize_patterns_returns_none_on_http_500(
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(
+        url=f"{_BASE_URL}/api/chat",
+        method="POST",
+        status_code=500,
+        text="internal error",
+    )
+    assert await _client().summarize_patterns(_items(2)) is None
+
+
+async def test_summarize_patterns_returns_none_on_empty_content(
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(
+        url=f"{_BASE_URL}/api/chat",
+        method="POST",
+        json=_chat_body(""),
+    )
+    assert await _client().summarize_patterns(_items(2)) is None
+
+
+async def test_summarize_patterns_returns_none_on_malformed_envelope(
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(
+        url=f"{_BASE_URL}/api/chat",
+        method="POST",
+        json={"totally": "wrong"},
+    )
+    assert await _client().summarize_patterns(_items(2)) is None

--- a/tests/llm/test_reflection_client.py
+++ b/tests/llm/test_reflection_client.py
@@ -28,8 +28,7 @@ def _chat_body(content: str) -> dict[str, object]:
 
 def _items(n: int) -> list[dict[str, object]]:
     return [
-        {"id": f"id-{i}", "topic": f"topic-{i}", "summary": f"summary line {i}"}
-        for i in range(n)
+        {"id": f"id-{i}", "topic": f"topic-{i}", "summary": f"summary line {i}"} for i in range(n)
     ]
 
 


### PR DESCRIPTION
Closes #157.

## Summary
Fourth and final P3 builder. The lifecycle worker now dispatches the real `reflection_digest` sweep at `06:00` UTC. After this merges, only `vault_reconcile` remains on its default placeholder.

## What's new
- `src/musubi/llm/reflection_client.py` — `HttpxReflectionClient` satisfying `ReflectionLLM`. Returns `None` on outage, matching the maturation/synthesis pattern — the reflection sweep substitutes the documented skip notice rather than failing the digest.
- `src/musubi/llm/prompts/reflection/v1.txt` — first-party summarize-patterns prompt.
- `src/musubi/lifecycle/emitters.py` (additive) — `ReflectionVaultWriter` (async `write_reflection` over the sync `vault.writer.VaultWriter` + shared `WriteLog`) and `ReflectionThoughtsEmitter` (kw-only `emit` shape over `ThoughtsPlane.send`).
- `src/musubi/lifecycle/reflection.py` — additive `build_reflection_jobs()`; imports `Job` + `file_lock`.
- `src/musubi/lifecycle/runner.py` — `build_lifecycle_jobs()` grew a `reflection_jobs=` kwarg; `_main_async()` wires all five builder groups.

## Design notes
- **Reflection Protocols are shaped differently from promotion's** (async writer, kw-only emitter). Rather than force the existing adapters to satisfy both contracts, this slice adds purpose-built adapters next to the existing ones in `lifecycle/emitters.py`. Keeps each Protocol's own failure modes local to its wiring.
- **Homelab-default namespace** — `lifecycle-worker/ops/curated`. A future namespace-discovery pass (like synthesis-builder did for the episodic scroll) can per-namespace this when we grow multiple presences.
- **WriteLog sharing** — the reflection writer reuses the `WriteLog` instance created for promotion, so the vault watcher (when eventually wired) sees a consistent echo-filter state across both sweeps.

## Test plan
- [x] `make check` → 1143 passed / 231 skipped (+9 new).
- [x] Tests-first commit: `test(llm): initial test contract for slice-lifecycle-reflection-builder` precedes the `feat(...)` commit.
- [x] `tests/llm/test_reflection_client.py` (7) — happy, empty-short-circuit, 4 failure modes.
- [x] `tests/lifecycle/test_runner.py` (2 new) — wiring test + all-five-builder-groups test.
- [ ] End-to-end against `musubi.mey.house` post-merge (deferred to deploy step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)