### PR TITLE
chore(repo): scrub homelab topology for public release

### DIFF
--- a/deploy/ansible/README.md
+++ b/deploy/ansible/README.md
@@ -8,37 +8,37 @@ the control-host setup below.
 ## Control-host model
 
 Playbooks are run from an ansible control host. In this environment that's
-`yua` (`10.0.20.53`) alongside the homelab fleet's own `~/ansible/` repo. The
+the ansible control host alongside the homelab fleet's own `~/ansible/` repo. The
 control host:
 
 - Clones this repo to `~/musubi` (fresh `git pull` before each deploy).
 - Keeps Musubi-specific secrets + inventory overrides under
-  `~/.musubi-secrets/` (gitignored directory, 700-perm).
+ `~/.musubi-secrets/` (gitignored directory, 700-perm).
 - Reuses `~/ansible/.vault_pass` as the ansible-vault password file so the
-  Musubi vault and the homelab fleet vault share one secret-management story.
+ Musubi vault and the homelab fleet vault share one secret-management story.
 
 Running playbooks from this repo's working tree on a developer laptop is
 possible for `--syntax-check` and `--check --diff` dry-runs, but the
-operational path is always yua → playbook → musubi workload host.
+operational path is always the ansible control host → playbook → musubi workload host.
 
 ## Layout
 
-| Path                              | Role                                                           |
+| Path | Role |
 |-----------------------------------|----------------------------------------------------------------|
-| `inventory.yml`                   | Parametrised inventory — Jinja vars for hostnames, IPs, users. |
-| `group_vars/all.yml`              | Defaults: filesystem paths, image pins, health URLs, Ollama model. |
-| `bootstrap.yml`                   | Fresh Ubuntu 24.04 → Docker + NVIDIA + users + dirs + firewall. |
-| `deploy.yml`                      | Compose stack bring-up (pull images, start, health gate).      |
-| `config.yml`                      | Refresh `.env.production`, restart stack on config change.     |
-| `health.yml`                      | Ad-hoc host + Docker + Musubi + Core + Ollama checks.          |
-| `vault.example.yml`               | Template for `~/.musubi-secrets/vault.yml`.                    |
-| `setup-control-host.sh`           | One-shot bootstrap: creates `~/.musubi-secrets/` + seeds files. |
-| `requirements.yml`                | Ansible Galaxy collection deps.                                |
+| `inventory.yml` | Parametrised inventory — Jinja vars for hostnames, IPs, users. |
+| `group_vars/all.yml` | Defaults: filesystem paths, image pins, health URLs, Ollama model. |
+| `bootstrap.yml` | Fresh Ubuntu 24.04 → Docker + NVIDIA + users + dirs + firewall. |
+| `deploy.yml` | Compose stack bring-up (pull images, start, health gate). |
+| `config.yml` | Refresh `.env.production`, restart stack on config change. |
+| `health.yml` | Ad-hoc host + Docker + Musubi + Core + Ollama checks. |
+| `vault.example.yml` | Template for `~/.musubi-secrets/vault.yml`. |
+| `setup-control-host.sh` | One-shot bootstrap: creates `~/.musubi-secrets/` + seeds files. |
+| `requirements.yml` | Ansible Galaxy collection deps. |
 
-## First-time control-host bootstrap (on yua)
+## First-time control-host bootstrap (on the ansible control host)
 
 ```bash
-ssh yua
+ssh <ansible-host>
 git clone git@github.com:ericmey/musubi.git ~/musubi
 cd ~/musubi
 ansible-galaxy collection install -r deploy/ansible/requirements.yml
@@ -52,26 +52,26 @@ existing files are preserved.
 After it prints the next-steps banner:
 
 1. Edit `~/.musubi-secrets/inventory-vars.yml` — fill in `musubi_host`,
-   `musubi_ip`, `operator_ssh_user` (and Kong vars if/when Kong is
-   re-enabled per [ADR 0024](../../docs/Musubi/13-decisions/0024-kong-deferred-for-musubi-v1.md)).
+ `musubi_ip`, `operator_ssh_user` (and Kong vars if/when Kong is
+ re-enabled per [ADR 0024](../../docs/Musubi/13-decisions/0024-kong-deferred-for-musubi-v1.md)).
 2. Edit `~/.musubi-secrets/vault.yml` with real secret values (see
-   `vault.example.yml` for the key list).
+ `vault.example.yml` for the key list).
 3. Encrypt it:
-   ```bash
-   ansible-vault encrypt ~/.musubi-secrets/vault.yml
-   ```
+ ```bash
+ ansible-vault encrypt ~/.musubi-secrets/vault.yml
+ ```
 
-## Per-deploy workflow (on yua)
+## Per-deploy workflow (on the ansible control host)
 
 ```bash
 cd ~/musubi && git pull --ff-only
 
 ANSIBLE_VAULT_PASSWORD_FILE=~/ansible/.vault_pass \
-  ansible-playbook \
-  -i deploy/ansible/inventory.yml \
-  -e @~/.musubi-secrets/inventory-vars.yml \
-  -e @~/.musubi-secrets/vault.yml \
-  deploy/ansible/<playbook>.yml
+ ansible-playbook \
+ -i deploy/ansible/inventory.yml \
+ -e @~/.musubi-secrets/inventory-vars.yml \
+ -e @~/.musubi-secrets/vault.yml \
+ deploy/ansible/<playbook>.yml
 ```
 
 Where `<playbook>` is one of `bootstrap`, `config`, `deploy`, `health`.
@@ -92,26 +92,26 @@ ansible-playbook -i deploy/ansible/inventory.yml --syntax-check deploy/ansible/b
 
 # health.yml without vault, targeting a resolved musubi_host:
 ansible-playbook \
-  -i deploy/ansible/inventory.yml \
-  -e musubi_host=musubi.mey.house -e musubi_ip=10.0.20.45 \
-  -e ansible_become=false \
-  --check --diff \
-  deploy/ansible/health.yml
+ -i deploy/ansible/inventory.yml \
+ -e musubi_host=musubi.example.local -e musubi_ip=10.0.0.45 \
+ -e ansible_become=false \
+ --check --diff \
+ deploy/ansible/health.yml
 ```
 
 The real `bootstrap.yml`, `config.yml`, and `deploy.yml` need the encrypted
-vault — they must run from yua.
+vault — they must run from the ansible control host.
 
 ## Why this split
 
 - **Repo = single source of truth.** Playbook edits go through PR review.
 - **Secrets live outside any git clone.** `~/.musubi-secrets/` survives
-  `rm -rf ~/musubi && git clone` and can't be accidentally `git add`ed.
+ `rm -rf ~/musubi && git clone` and can't be accidentally `git add`ed.
 - **One vault password across the homelab.** Reusing `~/ansible/.vault_pass`
-  keeps a single ansible-vault story, not two.
+ keeps a single ansible-vault story, not two.
 - **The committed inventory is a valid template**, not a file that has to
-  be hand-patched before use. Running it unparameterised fails fast with a
-  clear Jinja undefined-variable error.
+ be hand-patched before use. Running it unparameterised fails fast with a
+ clear Jinja undefined-variable error.
 
 ## Boundaries
 

--- a/deploy/ansible/bootstrap.yml
+++ b/deploy/ansible/bootstrap.yml
@@ -154,7 +154,7 @@
         rule: allow
         port: "{{ musubi_core_port }}"
         proto: tcp
-        from_ip: "{{ musubi_vlan_cidr | default('10.0.20.0/24') }}"
+        from_ip: "{{ musubi_vlan_cidr | default('10.0.0.0/24') }}"
         comment: "VLAN-internal access — remove when Kong fronts Musubi (ADR 0024)"
       when: musubi_kong_ip | default('') | length == 0
 

--- a/deploy/ansible/inventory.yml
+++ b/deploy/ansible/inventory.yml
@@ -3,27 +3,27 @@
 #
 # All host-specific values are Jinja references. They resolve at runtime from
 # either (a) -e @~/.musubi-secrets/inventory-vars.yml (the preferred path when
-# running from yua) or (b) -e key=value flags. If a variable is unset, the
+# running from the ansible control host) or (b) -e key=value flags. If a variable is unset, the
 # playbook fails fast — no placeholder string ever reaches SSH.
 #
-# To bootstrap a control host (typically yua), run the
+# To bootstrap a control host , run the
 # deploy/ansible/setup-control-host.sh script; it seeds the secrets dir and
 # tells you what to fill in.
 all:
-  children:
-    ansible_control:
-      hosts:
-        ansible-controller:
-          ansible_host: "{{ ansible_control_host | default('localhost') }}"
-          ansible_user: "{{ operator_ssh_user }}"
-          ansible_connection: "{{ ansible_control_connection | default('local') }}"
-    musubi:
-      hosts:
-        musubi-workload:
-          ansible_host: "{{ musubi_host }}"
-          ansible_user: "{{ operator_ssh_user }}"
-          ansible_become: true
-          musubi_hostname: "{{ musubi_host }}"
-          musubi_core_bind: "{{ musubi_ip }}"
-          musubi_kong_gateway: "{{ kong_gateway | default('') }}"
-          musubi_kong_ip: "{{ kong_ip | default('') }}"
+ children:
+ ansible_control:
+ hosts:
+ ansible-controller:
+ ansible_host: "{{ ansible_control_host | default('localhost') }}"
+ ansible_user: "{{ operator_ssh_user }}"
+ ansible_connection: "{{ ansible_control_connection | default('local') }}"
+ musubi:
+ hosts:
+ musubi-workload:
+ ansible_host: "{{ musubi_host }}"
+ ansible_user: "{{ operator_ssh_user }}"
+ ansible_become: true
+ musubi_hostname: "{{ musubi_host }}"
+ musubi_core_bind: "{{ musubi_ip }}"
+ musubi_kong_gateway: "{{ kong_gateway | default('') }}"
+ musubi_kong_ip: "{{ kong_ip | default('') }}"

--- a/deploy/ansible/setup-control-host.sh
+++ b/deploy/ansible/setup-control-host.sh
@@ -2,15 +2,15 @@
 #
 # deploy/ansible/setup-control-host.sh
 #
-# One-shot bootstrap for a Musubi ansible control host (typically yua).
+# One-shot bootstrap for a Musubi ansible control host .
 # Creates ~/.musubi-secrets/ with the inventory-vars + vault.yml templates
 # and a local README. Safe to re-run — existing files are preserved.
 #
 # Usage:
-#   deploy/ansible/setup-control-host.sh
+# deploy/ansible/setup-control-host.sh
 #
 # Override the secrets directory location with MUSUBI_SECRETS_DIR:
-#   MUSUBI_SECRETS_DIR=/path/to/secrets deploy/ansible/setup-control-host.sh
+# MUSUBI_SECRETS_DIR=/path/to/secrets deploy/ansible/setup-control-host.sh
 
 set -euo pipefail
 
@@ -20,8 +20,8 @@ SECRETS_DIR="${MUSUBI_SECRETS_DIR:-$HOME/.musubi-secrets}"
 VAULT_PASS_HINT="${ANSIBLE_VAULT_PASSWORD_FILE:-$HOME/ansible/.vault_pass}"
 
 echo "=== Musubi ansible control-host bootstrap ==="
-echo "Repo:            $REPO_ROOT"
-echo "Secrets dir:     $SECRETS_DIR"
+echo "Repo: $REPO_ROOT"
+echo "Secrets dir: $SECRETS_DIR"
 echo "Vault pass file: $VAULT_PASS_HINT (will be used at playbook runtime)"
 echo
 
@@ -31,7 +31,7 @@ chmod 700 "$SECRETS_DIR"
 # --- inventory-vars.yml (non-secret operator overrides) -----------------------
 INVENTORY_VARS="$SECRETS_DIR/inventory-vars.yml"
 if [[ ! -f "$INVENTORY_VARS" ]]; then
-  cat > "$INVENTORY_VARS" <<'YAML'
+ cat > "$INVENTORY_VARS" <<'YAML'
 ---
 # Musubi ansible inventory overrides (operator-only, NOT encrypted).
 #
@@ -46,39 +46,39 @@ if [[ ! -f "$INVENTORY_VARS" ]]; then
 operator_ssh_user: "ericmey"
 
 # Musubi workload host (DNS name + VLAN IP)
-musubi_host: ""   # e.g. musubi.mey.house
-musubi_ip: ""     # e.g. 10.0.20.45
+musubi_host: "" # e.g. musubi.example.local
+musubi_ip: "" # e.g. 10.0.0.45
 
 # Kong API gateway — only needed if/when Kong re-enters the deploy path
 # (see docs/Musubi/13-decisions/0024-kong-deferred-for-musubi-v1.md).
 # Leave empty for VLAN-internal v1 deploys.
-kong_gateway: ""  # e.g. rin.mey.house
-kong_ip: ""       # e.g. 10.0.20.50
+kong_gateway: "" # e.g. kong.example.local
+kong_ip: "" # e.g. 10.0.0.50
 YAML
-  chmod 600 "$INVENTORY_VARS"
-  echo "created  $INVENTORY_VARS"
-  INVENTORY_VARS_CREATED=1
+ chmod 600 "$INVENTORY_VARS"
+ echo "created $INVENTORY_VARS"
+ INVENTORY_VARS_CREATED=1
 else
-  echo "skipped  $INVENTORY_VARS (already exists)"
-  INVENTORY_VARS_CREATED=0
+ echo "skipped $INVENTORY_VARS (already exists)"
+ INVENTORY_VARS_CREATED=0
 fi
 
 # --- vault.yml (encrypted secrets) --------------------------------------------
 VAULT_YML="$SECRETS_DIR/vault.yml"
 if [[ ! -f "$VAULT_YML" ]]; then
-  cp "$ANSIBLE_DIR/vault.example.yml" "$VAULT_YML"
-  chmod 600 "$VAULT_YML"
-  echo "created  $VAULT_YML (from vault.example.yml — NOT YET ENCRYPTED)"
-  VAULT_CREATED=1
+ cp "$ANSIBLE_DIR/vault.example.yml" "$VAULT_YML"
+ chmod 600 "$VAULT_YML"
+ echo "created $VAULT_YML (from vault.example.yml — NOT YET ENCRYPTED)"
+ VAULT_CREATED=1
 else
-  echo "skipped  $VAULT_YML (already exists)"
-  VAULT_CREATED=0
+ echo "skipped $VAULT_YML (already exists)"
+ VAULT_CREATED=0
 fi
 
 # --- README.md (local reference, doesn't replace the repo README) ------------
 LOCAL_README="$SECRETS_DIR/README.md"
 if [[ ! -f "$LOCAL_README" ]]; then
-  cat > "$LOCAL_README" <<EOF
+ cat > "$LOCAL_README" <<EOF
 # Musubi operator secrets (this control host only)
 
 Created by \`$ANSIBLE_DIR/setup-control-host.sh\` on $(date -u +%Y-%m-%dT%H:%M:%SZ).
@@ -89,20 +89,20 @@ be committed anywhere.
 
 - \`inventory-vars.yml\` — non-secret operator overrides (hostnames, IPs, ssh user).
 - \`vault.yml\` — ansible-vault-encrypted secrets. See \`$ANSIBLE_DIR/vault.example.yml\`
-  for the key list. Encrypt with:
-  \`\`\`
-  ansible-vault encrypt $VAULT_YML
-  \`\`\`
+ for the key list. Encrypt with:
+ \`\`\`
+ ansible-vault encrypt $VAULT_YML
+ \`\`\`
 
 ## Running a playbook
 
 \`\`\`bash
 ANSIBLE_VAULT_PASSWORD_FILE=$VAULT_PASS_HINT \\
-  ansible-playbook \\
-  -i $ANSIBLE_DIR/inventory.yml \\
-  -e @$INVENTORY_VARS \\
-  -e @$VAULT_YML \\
-  $ANSIBLE_DIR/<playbook>.yml
+ ansible-playbook \\
+ -i $ANSIBLE_DIR/inventory.yml \\
+ -e @$INVENTORY_VARS \\
+ -e @$VAULT_YML \\
+ $ANSIBLE_DIR/<playbook>.yml
 \`\`\`
 
 Playbooks: \`bootstrap\`, \`config\`, \`deploy\`, \`health\`.
@@ -112,36 +112,36 @@ Playbooks: \`bootstrap\`, \`config\`, \`deploy\`, \`health\`.
 Re-running \`$ANSIBLE_DIR/setup-control-host.sh\` is safe — existing files are
 preserved. Delete individual files and re-run to regenerate.
 EOF
-  chmod 600 "$LOCAL_README"
-  echo "created  $LOCAL_README"
+ chmod 600 "$LOCAL_README"
+ echo "created $LOCAL_README"
 fi
 
 echo
 echo "=== Next steps ==="
 
 if [[ "$INVENTORY_VARS_CREATED" -eq 1 ]]; then
-  echo "1. Edit $INVENTORY_VARS — fill in musubi_host, musubi_ip, operator_ssh_user."
+ echo "1. Edit $INVENTORY_VARS — fill in musubi_host, musubi_ip, operator_ssh_user."
 fi
 
 if [[ "$VAULT_CREATED" -eq 1 ]]; then
-  echo "2. Edit $VAULT_YML with real secret values (template from vault.example.yml)."
-  echo "3. Encrypt it:"
-  echo "     ansible-vault encrypt $VAULT_YML"
+ echo "2. Edit $VAULT_YML with real secret values (template from vault.example.yml)."
+ echo "3. Encrypt it:"
+ echo " ansible-vault encrypt $VAULT_YML"
 fi
 
 if [[ "$INVENTORY_VARS_CREATED" -eq 0 && "$VAULT_CREATED" -eq 0 ]]; then
-  echo "Nothing to do — both files already present. You can run playbooks now."
-  echo "Syntax-check your current setup:"
-  echo "  ansible-playbook -i $ANSIBLE_DIR/inventory.yml --syntax-check $ANSIBLE_DIR/bootstrap.yml"
+ echo "Nothing to do — both files already present. You can run playbooks now."
+ echo "Syntax-check your current setup:"
+ echo " ansible-playbook -i $ANSIBLE_DIR/inventory.yml --syntax-check $ANSIBLE_DIR/bootstrap.yml"
 fi
 
 echo
 echo "=== Per-deploy command ==="
 echo "ANSIBLE_VAULT_PASSWORD_FILE=$VAULT_PASS_HINT \\"
-echo "  ansible-playbook \\"
-echo "  -i $ANSIBLE_DIR/inventory.yml \\"
-echo "  -e @$INVENTORY_VARS \\"
-echo "  -e @$VAULT_YML \\"
-echo "  $ANSIBLE_DIR/<playbook>.yml"
+echo " ansible-playbook \\"
+echo " -i $ANSIBLE_DIR/inventory.yml \\"
+echo " -e @$INVENTORY_VARS \\"
+echo " -e @$VAULT_YML \\"
+echo " $ANSIBLE_DIR/<playbook>.yml"
 echo
 echo "Bootstrap complete."

--- a/deploy/ansible/templates/docker-compose.yml.j2
+++ b/deploy/ansible/templates/docker-compose.yml.j2
@@ -144,7 +144,7 @@ services:
   # retains timeseries for 30 days on disk. Host-local only (bound to
   # 127.0.0.1) — remote operators reach it via SSH tunnel:
   #
-  #     ssh -L 9090:localhost:9090 musubi.mey.house
+  #     ssh -L 9090:localhost:9090 musubi.example.local
   #
   # External exposure would need Kong + auth, which is deferred per ADR
   # 0024. The scrape config at /etc/musubi/prometheus.yml is read-only

--- a/deploy/backup/README.md
+++ b/deploy/backup/README.md
@@ -5,16 +5,16 @@ This directory contains two complementary backup paths for the Musubi host.
 ## 1. Host-local scheduled backups (live today)
 
 [`musubi-backup.sh`](musubi-backup.sh) runs under [`systemd/musubi-backup.timer`](systemd/musubi-backup.timer)
-every six hours on `musubi.mey.house`. It is self-contained — no Ansible,
+every six hours on `musubi.example.local`. It is self-contained — no Ansible,
 no secondary host, no vault password at run time. Recovery does not depend
-on yua being up.
+on the ansible control host being up.
 
 Install + enable (one-shot, from the host):
 
 ```bash
 sudo install -m 0755 deploy/backup/musubi-backup.sh /usr/local/bin/musubi-backup
 sudo install -m 0644 deploy/backup/systemd/musubi-backup.service /etc/systemd/system/
-sudo install -m 0644 deploy/backup/systemd/musubi-backup.timer   /etc/systemd/system/
+sudo install -m 0644 deploy/backup/systemd/musubi-backup.timer /etc/systemd/system/
 sudo install -d -o root -g root -m 0755 /var/lib/musubi/backups
 sudo systemctl daemon-reload
 sudo systemctl enable --now musubi-backup.timer
@@ -31,9 +31,9 @@ Per-run layout (`/var/lib/musubi/backups/<TIMESTAMP>/`):
 
 ```
 qdrant/<collection>.snapshot + SHA256SUMS
-sqlite/work.sqlite                (lifecycle ledger)
-artifact-blobs/                   (content-addressed rsync)
-manifest.json                     (status, epoch, collection list)
+sqlite/work.sqlite (lifecycle ledger)
+artifact-blobs/ (content-addressed rsync)
+manifest.json (status, epoch, collection list)
 ```
 
 Retention: 14 days, pruned only after a green run so we never lose the
@@ -46,7 +46,7 @@ last-known-good backup to a half-failed next one.
 sudo sha256sum -c /var/lib/musubi/backups/<TIMESTAMP>/qdrant/SHA256SUMS
 
 # Manifest says green
-sudo jq .status /var/lib/musubi/backups/<TIMESTAMP>/manifest.json   # → 0
+sudo jq .status /var/lib/musubi/backups/<TIMESTAMP>/manifest.json # → 0
 ```
 
 A `status` of `0` means every store backed up; `2` means at least one

--- a/deploy/backup/musubi-backup.sh
+++ b/deploy/backup/musubi-backup.sh
@@ -8,36 +8,36 @@
 #
 # Why a shell script and not the existing `backup.yml` ansible playbook:
 #
-# - Self-contained. If yua (ansible control host) is down, musubi still
-#   backs itself up. The recovery path should not depend on a second host.
+# - Self-contained. If the ansible control host (ansible control host) is down, musubi still
+# backs itself up. The recovery path should not depend on a second host.
 # - Compose-aware. The ansible playbook targets Qdrant on 127.0.0.1:6333,
-#   which doesn't exist in the compose-era (Qdrant is bound to the
-#   `musubi_default` bridge only). This script shells into the qdrant
-#   container's local network via the shared docker daemon.
+# which doesn't exist in the compose-era (Qdrant is bound to the
+# `musubi_default` bridge only). This script shells into the qdrant
+# container's local network via the shared docker daemon.
 # - No vault password needed at runtime. Secrets are sourced from
-#   `.env.production` (already readable on the host) rather than
-#   `ansible-vault decrypt` of `vault.yml`.
+# `.env.production` (already readable on the host) rather than
+# `ansible-vault decrypt` of `vault.yml`.
 #
 # On-disk layout produced:
 #
-#   /var/lib/musubi/backups/<TIMESTAMP>/
-#     qdrant/
-#       <collection>.snapshot  (file pulled from the qdrant volume)
-#       SHA256SUMS
-#     sqlite/
-#       work.sqlite            (sqlite3 .backup from lifecycle volume)
-#     artifact-blobs/           (rsync mirror, content-addressed so ~idempotent)
-#     manifest.json            (metadata: epoch, script version, qdrant coll list)
+# /var/lib/musubi/backups/<TIMESTAMP>/
+# qdrant/
+# <collection>.snapshot (file pulled from the qdrant volume)
+# SHA256SUMS
+# sqlite/
+# work.sqlite (sqlite3 .backup from lifecycle volume)
+# artifact-blobs/ (rsync mirror, content-addressed so ~idempotent)
+# manifest.json (metadata: epoch, script version, qdrant coll list)
 #
 # Retention: entries older than RETENTION_DAYS (default 14) are deleted
 # after a successful run. Failed runs do NOT rotate — the backup directory
 # survives until the next green run or the operator cleans it up.
 #
 # Exit codes:
-#   0   success (all steps)
-#   1   precondition failed (compose not up, missing env, etc.)
-#   2   one or more snapshot steps failed
-#   3   retention-prune failed (non-fatal but surfaced)
+# 0 success (all steps)
+# 1 precondition failed (compose not up, missing env, etc.)
+# 2 one or more snapshot steps failed
+# 3 retention-prune failed (non-fatal but surfaced)
 
 set -euo pipefail
 
@@ -66,18 +66,18 @@ LOCK_FILE="${LOCK_FILE:-/var/lock/musubi-backup.lock}"
 # ---------------------------------------------------------------------------
 
 log() {
-  # Single-line JSON so journald-to-prometheus is straightforward later.
-  printf '{"ts":"%s","level":"%s","msg":%q}\n' \
-    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" "$2"
+ # Single-line JSON so journald-to-prometheus is straightforward later.
+ printf '{"ts":"%s","level":"%s","msg":%q}\n' \
+ "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" "$2"
 }
 
 die() {
-  log ERROR "$1"
-  exit "${2:-1}"
+ log ERROR "$1"
+ exit "${2:-1}"
 }
 
 require() {
-  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+ command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
 }
 
 # ---------------------------------------------------------------------------
@@ -122,145 +122,145 @@ STATUS=0
 # One round-trip to Qdrant to enumerate. If this fails, every collection
 # snapshot below would fail too — bail early with a clear error.
 discovered="$(
-  docker compose -f "$COMPOSE_FILE" exec -T lifecycle-worker \
-    python -c "
+ docker compose -f "$COMPOSE_FILE" exec -T lifecycle-worker \
+ python -c "
 import os, sys, httpx, json
 r = httpx.get('http://qdrant:6333/collections',
-              headers={'api-key': os.environ['QDRANT_API_KEY']}, timeout=15.0)
+ headers={'api-key': os.environ['QDRANT_API_KEY']}, timeout=15.0)
 if r.status_code != 200:
-    print('FAIL', r.status_code, r.text[:200], file=sys.stderr); sys.exit(1)
+ print('FAIL', r.status_code, r.text[:200], file=sys.stderr); sys.exit(1)
 for c in r.json().get('result', {}).get('collections', []):
-    print(c.get('name', ''))
+ print(c.get('name', ''))
 " 2>&1
 )" || {
-  log ERROR "qdrant-collection-discovery-failed out=${discovered}"
-  die "cannot enumerate Qdrant collections" 2
+ log ERROR "qdrant-collection-discovery-failed out=${discovered}"
+ die "cannot enumerate Qdrant collections" 2
 }
 
 while IFS= read -r line; do
-  name="$(echo "${line}" | tr -d '[:space:]')"
-  [[ -n "${name}" ]] && QDRANT_COLLECTIONS+=("${name}")
+ name="$(echo "${line}" | tr -d '[:space:]')"
+ [[ -n "${name}" ]] && QDRANT_COLLECTIONS+=("${name}")
 done <<< "${discovered}"
 
 if [[ ${#QDRANT_COLLECTIONS[@]} -eq 0 ]]; then
-  log WARNING "qdrant-no-collections-present"
+ log WARNING "qdrant-no-collections-present"
 fi
 log INFO "qdrant-collections-discovered count=${#QDRANT_COLLECTIONS[@]}"
 
 # --- Qdrant snapshots ------------------------------------------------------
 
 for coll in "${QDRANT_COLLECTIONS[@]}"; do
-  # Trigger a snapshot via the qdrant container's own HTTP API. We exec
-  # through the qdrant container's curl — wait, curl isn't in the qdrant
-  # image. Use the host's curl against qdrant's exposed port in the
-  # compose network by shelling into a container that has curl, or run
-  # docker exec with wget… simpler: use the ollama container (minimal
-  # but has wget via busybox? no, also minimal). Use `docker run --rm
-  # --network musubi_default curlimages/curl` — but that pulls a new
-  # image every run. Use a one-shot python from the lifecycle-worker
-  # container which we know has httpx.
-  result="$(
-    docker compose -f "$COMPOSE_FILE" exec -T lifecycle-worker \
-      python -c "
+ # Trigger a snapshot via the qdrant container's own HTTP API. We exec
+ # through the qdrant container's curl — wait, curl isn't in the qdrant
+ # image. Use the host's curl against qdrant's exposed port in the
+ # compose network by shelling into a container that has curl, or run
+ # docker exec with wget… simpler: use the ollama container (minimal
+ # but has wget via busybox? no, also minimal). Use `docker run --rm
+ # --network musubi_default curlimages/curl` — but that pulls a new
+ # image every run. Use a one-shot python from the lifecycle-worker
+ # container which we know has httpx.
+ result="$(
+ docker compose -f "$COMPOSE_FILE" exec -T lifecycle-worker \
+ python -c "
 import os, sys
 import httpx
 api = os.environ['QDRANT_API_KEY']
 r = httpx.post(
-    'http://qdrant:6333/collections/${coll}/snapshots',
-    headers={'api-key': api},
-    timeout=60.0,
+ 'http://qdrant:6333/collections/${coll}/snapshots',
+ headers={'api-key': api},
+ timeout=60.0,
 )
 if r.status_code != 200:
-    print('FAIL', r.status_code, r.text[:200], file=sys.stderr)
-    sys.exit(1)
+ print('FAIL', r.status_code, r.text[:200], file=sys.stderr)
+ sys.exit(1)
 data = r.json().get('result', {})
 print(data.get('name', ''))
 " 2>&1
-  )" || {
-    log ERROR "qdrant-snapshot-api-failed coll=${coll} out=${result}"
-    STATUS=2
-    continue
-  }
+ )" || {
+ log ERROR "qdrant-snapshot-api-failed coll=${coll} out=${result}"
+ STATUS=2
+ continue
+ }
 
-  snapshot_name="$(echo "${result}" | tail -n 1 | tr -d '[:space:]')"
-  if [[ -z "${snapshot_name}" ]]; then
-    log ERROR "qdrant-snapshot-empty-name coll=${coll}"
-    STATUS=2
-    continue
-  fi
+ snapshot_name="$(echo "${result}" | tail -n 1 | tr -d '[:space:]')"
+ if [[ -z "${snapshot_name}" ]]; then
+ log ERROR "qdrant-snapshot-empty-name coll=${coll}"
+ STATUS=2
+ continue
+ fi
 
-  src_file="/var/lib/musubi/qdrant-snapshots/${coll}/${snapshot_name}"
-  if [[ ! -r "${src_file}" ]]; then
-    log ERROR "qdrant-snapshot-file-missing coll=${coll} path=${src_file}"
-    STATUS=2
-    continue
-  fi
+ src_file="/var/lib/musubi/qdrant-snapshots/${coll}/${snapshot_name}"
+ if [[ ! -r "${src_file}" ]]; then
+ log ERROR "qdrant-snapshot-file-missing coll=${coll} path=${src_file}"
+ STATUS=2
+ continue
+ fi
 
-  cp -p "${src_file}" "${DEST}/qdrant/${coll}.snapshot"
-  log INFO "qdrant-snapshot-ok coll=${coll} bytes=$(stat -c%s "${DEST}/qdrant/${coll}.snapshot")"
+ cp -p "${src_file}" "${DEST}/qdrant/${coll}.snapshot"
+ log INFO "qdrant-snapshot-ok coll=${coll} bytes=$(stat -c%s "${DEST}/qdrant/${coll}.snapshot")"
 done
 
 # Checksum everything we pulled.
 if find "${DEST}/qdrant" -type f -name '*.snapshot' -print -quit | grep -q .; then
-  (cd "${DEST}/qdrant" && sha256sum *.snapshot > SHA256SUMS)
-  log INFO "qdrant-checksums-written"
+ (cd "${DEST}/qdrant" && sha256sum *.snapshot > SHA256SUMS)
+ log INFO "qdrant-checksums-written"
 fi
 
 # --- SQLite (lifecycle ledger + cursors) -----------------------------------
 
 SQLITE_SRC="/var/lib/musubi/lifecycle/work.sqlite"
 if [[ -r "${SQLITE_SRC}" ]]; then
-  sqlite3_via_docker() {
-    docker compose -f "$COMPOSE_FILE" exec -T lifecycle-worker \
-      python -c "
+ sqlite3_via_docker() {
+ docker compose -f "$COMPOSE_FILE" exec -T lifecycle-worker \
+ python -c "
 import sqlite3, sys
 src, dst = sys.argv[1], sys.argv[2]
 with sqlite3.connect(src) as s, sqlite3.connect(dst) as d:
-    s.backup(d)
+ s.backup(d)
 " "$1" "$2"
-  }
+ }
 
-  # The sqlite file is a bind-mount visible inside the lifecycle-worker
-  # container at the same path. Run the .backup there so we get a
-  # consistent copy even if the scheduler is writing.
-  if sqlite3_via_docker "${SQLITE_SRC}" "/var/lib/musubi/lifecycle/work.sqlite.backup-${TIMESTAMP}"; then
-    # Move the backup file out of the live directory into our snapshot tree.
-    mv "/var/lib/musubi/lifecycle/work.sqlite.backup-${TIMESTAMP}" \
-       "${DEST}/sqlite/work.sqlite"
-    log INFO "sqlite-backup-ok bytes=$(stat -c%s "${DEST}/sqlite/work.sqlite")"
-  else
-    log ERROR "sqlite-backup-failed"
-    STATUS=2
-  fi
+ # The sqlite file is a bind-mount visible inside the lifecycle-worker
+ # container at the same path. Run the .backup there so we get a
+ # consistent copy even if the scheduler is writing.
+ if sqlite3_via_docker "${SQLITE_SRC}" "/var/lib/musubi/lifecycle/work.sqlite.backup-${TIMESTAMP}"; then
+ # Move the backup file out of the live directory into our snapshot tree.
+ mv "/var/lib/musubi/lifecycle/work.sqlite.backup-${TIMESTAMP}" \
+ "${DEST}/sqlite/work.sqlite"
+ log INFO "sqlite-backup-ok bytes=$(stat -c%s "${DEST}/sqlite/work.sqlite")"
+ else
+ log ERROR "sqlite-backup-failed"
+ STATUS=2
+ fi
 else
-  log WARNING "sqlite-source-missing path=${SQLITE_SRC}"
+ log WARNING "sqlite-source-missing path=${SQLITE_SRC}"
 fi
 
 # --- Artifact blobs --------------------------------------------------------
 
 if [[ -d /var/lib/musubi/artifact-blobs ]]; then
-  if rsync -a --delete-after \
-       /var/lib/musubi/artifact-blobs/ \
-       "${DEST}/artifact-blobs/"; then
-    blob_count=$(find "${DEST}/artifact-blobs" -type f | wc -l)
-    log INFO "artifact-blobs-rsync-ok count=${blob_count}"
-  else
-    log ERROR "artifact-blobs-rsync-failed"
-    STATUS=2
-  fi
+ if rsync -a --delete-after \
+ /var/lib/musubi/artifact-blobs/ \
+ "${DEST}/artifact-blobs/"; then
+ blob_count=$(find "${DEST}/artifact-blobs" -type f | wc -l)
+ log INFO "artifact-blobs-rsync-ok count=${blob_count}"
+ else
+ log ERROR "artifact-blobs-rsync-failed"
+ STATUS=2
+ fi
 fi
 
 # --- Manifest --------------------------------------------------------------
 
 cat > "${DEST}/manifest.json" <<EOF
 {
-  "schema_version": 1,
-  "timestamp": "${TIMESTAMP}",
-  "epoch": $(date -u +%s),
-  "hostname": "$(hostname)",
-  "script_sha256": "$(sha256sum "$0" | cut -d' ' -f1)",
-  "status": ${STATUS},
-  "qdrant_collections": [$(printf '"%s",' "${QDRANT_COLLECTIONS[@]}" | sed 's/,$//')]
+ "schema_version": 1,
+ "timestamp": "${TIMESTAMP}",
+ "epoch": $(date -u +%s),
+ "hostname": "$(hostname)",
+ "script_sha256": "$(sha256sum "$0" | cut -d' ' -f1)",
+ "status": ${STATUS},
+ "qdrant_collections": [$(printf '"%s",' "${QDRANT_COLLECTIONS[@]}" | sed 's/,$//')]
 }
 EOF
 
@@ -269,15 +269,15 @@ EOF
 # ---------------------------------------------------------------------------
 
 if [[ ${STATUS} -eq 0 ]]; then
-  # Only prune if this run was clean — otherwise keep every backup until an
-  # operator confirms the failure is understood.
-  if find "${BACKUP_ROOT}" -mindepth 1 -maxdepth 1 -type d -mtime "+${RETENTION_DAYS}" \
-       -exec rm -rf {} + 2>/dev/null; then
-    log INFO "retention-prune-ok days=${RETENTION_DAYS}"
-  else
-    log WARNING "retention-prune-failed"
-    STATUS=3
-  fi
+ # Only prune if this run was clean — otherwise keep every backup until an
+ # operator confirms the failure is understood.
+ if find "${BACKUP_ROOT}" -mindepth 1 -maxdepth 1 -type d -mtime "+${RETENTION_DAYS}" \
+ -exec rm -rf {} + 2>/dev/null; then
+ log INFO "retention-prune-ok days=${RETENTION_DAYS}"
+ else
+ log WARNING "retention-prune-failed"
+ STATUS=3
+ fi
 fi
 
 log INFO "backup-complete status=${STATUS}"

--- a/deploy/grafana/alerts/musubi-alerts.yml
+++ b/deploy/grafana/alerts/musubi-alerts.yml
@@ -18,7 +18,7 @@ groups:
           severity: push
         annotations:
           summary: "Musubi Core 5xx rate above 1% for 5m"
-          runbook: "https://docs.musubi.internal/09-operations/runbooks/#core_5xx_high"
+          runbook: "https://docs.musubi.example.local/09-operations/runbooks/#core_5xx_high"
 
       - alert: qdrant_down
         expr: up{job="qdrant"} == 0
@@ -27,7 +27,7 @@ groups:
           severity: push
         annotations:
           summary: "Qdrant unreachable for 2m"
-          runbook: "https://docs.musubi.internal/09-operations/runbooks/#qdrant-down"
+          runbook: "https://docs.musubi.example.local/09-operations/runbooks/#qdrant-down"
 
       - alert: vault_fs_full
         expr: node_filesystem_avail_bytes{mountpoint="/var/lib/musubi"} / node_filesystem_size_bytes{mountpoint="/var/lib/musubi"} < 0.10
@@ -36,7 +36,7 @@ groups:
           severity: push
         annotations:
           summary: "Vault filesystem under 10% free"
-          runbook: "https://docs.musubi.internal/09-operations/runbooks/#vault_fs_full"
+          runbook: "https://docs.musubi.example.local/09-operations/runbooks/#vault_fs_full"
 
       - alert: backup_failure_24h
         expr: time() - musubi_backup_last_success_timestamp > 86400
@@ -45,7 +45,7 @@ groups:
           severity: push
         annotations:
           summary: "No successful Qdrant snapshot in 24h"
-          runbook: "https://docs.musubi.internal/09-operations/runbooks/#backup_failure_24h"
+          runbook: "https://docs.musubi.example.local/09-operations/runbooks/#backup_failure_24h"
 
       - alert: gpu_oom
         expr: increase(container_oom_events_total[10m]) > 0
@@ -54,7 +54,7 @@ groups:
           severity: push
         annotations:
           summary: "Container OOMKilled — likely GPU memory exhaustion"
-          runbook: "https://docs.musubi.internal/09-operations/runbooks/#gpu_oom"
+          runbook: "https://docs.musubi.example.local/09-operations/runbooks/#gpu_oom"
 
       - alert: loop_detected
         expr: rate(musubi_vault_echo_filtered_total[1m]) * 60 > 100
@@ -63,7 +63,7 @@ groups:
           severity: push
         annotations:
           summary: "Vault echo filter catching > 100/min — likely sync loop"
-          runbook: "https://docs.musubi.internal/09-operations/runbooks/#loop_detected"
+          runbook: "https://docs.musubi.example.local/09-operations/runbooks/#loop_detected"
 
       - alert: token_signing_key_missing
         expr: musubi_jwt_signing_key_present == 0
@@ -72,7 +72,7 @@ groups:
           severity: push
         annotations:
           summary: "JWT signing key file missing — all auth fails"
-          runbook: "https://docs.musubi.internal/09-operations/runbooks/#token_signing_key_missing"
+          runbook: "https://docs.musubi.example.local/09-operations/runbooks/#token_signing_key_missing"
 
   - name: musubi-email
     rules:

--- a/deploy/migration/README.md
+++ b/deploy/migration/README.md
@@ -5,7 +5,7 @@ This documents the procedure for migrating legacy Node.js POC data into Musubi v
 ## Prerequisites
 
 1.  **Stop the POC:** Ensure nothing is writing to the old POC database.
-2.  **Start Musubi v1:** The v1 system must be running on `musubi.mey.house`.
+2.  **Start Musubi v1:** The v1 system must be running on `musubi.example.local`.
 3.  **Authentication:** Obtain an operator-scoped token for Musubi v1.
 4.  **BACKUP:** You MUST backup the target Musubi v1 Qdrant database before proceeding.
     ```bash
@@ -14,12 +14,12 @@ This documents the procedure for migrating legacy Node.js POC data into Musubi v
 
 ## Execution
 
-1.  Navigate to the `deploy/migration` directory on `nyla.mey.house`.
+1.  Navigate to the `deploy/migration` directory on `control.example.local`.
 2.  Configure your environment variables:
     ```bash
     export SOURCE_QDRANT_HOST="127.0.0.1"
     export SOURCE_QDRANT_PORT="6333"
-    export MUSUBI_URL="https://musubi.mey.house/v1"
+    export MUSUBI_URL="https://musubi.example.local/v1"
     export MUSUBI_TOKEN="<your-operator-token>"
     ```
 3.  Run a **dry run** to validate schemas and review expected changes:

--- a/deploy/migration/poc-to-v1.py
+++ b/deploy/migration/poc-to-v1.py
@@ -2,7 +2,7 @@
 """Migrates legacy POC Qdrant data to Musubi v1 via the SDK.
 
 Reads from localhost:6333 (the POC Qdrant container) and writes to
-musubi.mey.house via the Musubi v1 SDK. Supports dry-run and resumption.
+musubi.example.local via the Musubi v1 SDK. Supports dry-run and resumption.
 """
 
 from __future__ import annotations
@@ -271,7 +271,7 @@ def main() -> None:
 
     source_host = os.getenv("SOURCE_QDRANT_HOST", "127.0.0.1")
     source_port = int(os.getenv("SOURCE_QDRANT_PORT", "6333"))
-    target_url = os.getenv("MUSUBI_URL", "https://musubi.internal.example.com/v1")
+    target_url = os.getenv("MUSUBI_URL", "https://musubi.example.local.example.com/v1")
     target_token = os.getenv("MUSUBI_TOKEN", "dummy")
 
     try:

--- a/deploy/prometheus/alertmanager.yml
+++ b/deploy/prometheus/alertmanager.yml
@@ -30,6 +30,6 @@ receivers:
   - name: email
     email_configs:
       - to: eric@example.com
-        from: alertmanager@musubi.internal
+        from: alertmanager@musubi.example.local
         smarthost: smtp.example.com:587
         require_tls: true

--- a/deploy/prometheus/prometheus.yml
+++ b/deploy/prometheus/prometheus.yml
@@ -24,7 +24,7 @@ global:
   scrape_timeout: 10s
   external_labels:
     cluster: musubi
-    host: musubi.mey.house
+    host: musubi.example.local
 
 scrape_configs:
   # Musubi Core — HTTP API metrics (request counts, latency histograms,

--- a/deploy/runbooks/upgrade-image.md
+++ b/deploy/runbooks/upgrade-image.md
@@ -1,7 +1,7 @@
 # Upgrade Musubi Core — image bump procedure
 
 Companion to [`.github/workflows/publish-core-image.yml`](../../.github/workflows/publish-core-image.yml).
-Use this when you need to move `musubi.mey.house` to a newer
+Use this when you need to move `musubi.example.local` to a newer
 `ghcr.io/ericmey/musubi-core` digest. For a first-deploy-from-scratch,
 see [`first-deploy.md`](first-deploy.md) instead.
 
@@ -36,7 +36,7 @@ the commit / tag you want to ship.
 
 ```bash
 gh run view --workflow publish-core-image.yml --log \
-  | grep -A 1 '"digest"' | head
+ | grep -A 1 '"digest"' | head
 # or — easier — open the run's summary page and copy the fenced
 # block labelled "Pin in deploy/ansible/group_vars/all.yml as:".
 ```
@@ -58,8 +58,8 @@ gh run view --workflow publish-core-image.yml --log \
 cd ~/Projects/musubi
 git checkout -b ops/core-image-bump-$(date +%Y%m%d)
 sed -i '' \
-  -E 's|^musubi_core_image: .*|musubi_core_image: "ghcr.io/ericmey/musubi-core@sha256:<paste digest here>"|' \
-  deploy/ansible/group_vars/all.yml
+ -E 's|^musubi_core_image: .*|musubi_core_image: "ghcr.io/ericmey/musubi-core@sha256:<paste digest here>"|' \
+ deploy/ansible/group_vars/all.yml
 git add deploy/ansible/group_vars/all.yml
 git commit -m "ops: bump musubi_core_image to @sha256:<first 12 chars>"
 git push -u origin "$(git branch --show-current)"
@@ -83,11 +83,11 @@ has changed yet.
 ```bash
 # After the PR is approved and merged:
 gh pr merge <number> --squash
-ssh yua
+ssh <ansible-host>
 cd ~/musubi
 git pull --ff-only
 ansible-playbook -i ~/.musubi-secrets/inventory-vars.yml \
-  deploy/ansible/deploy.yml --ask-vault-pass
+ deploy/ansible/deploy.yml --ask-vault-pass
 ```
 
 (When [[_slices/slice-ops-update-workflow]] lands, swap the last line
@@ -112,10 +112,10 @@ failed healthcheck after this step means production is degraded.
 **Command:**
 
 ```bash
-# From the operator's workstation (or yua):
-curl -sS http://musubi.mey.house:8100/v1/ops/status | jq .
-ssh ericmey@musubi.mey.house \
-  'sudo docker inspect musubi-core-1 --format "{{.Image}}"'
+# From the operator's workstation (or the control host):
+curl -sS http://musubi.example.local:8100/v1/ops/status | jq .
+ssh ericmey@musubi.example.local \
+ 'sudo docker inspect musubi-core-1 --format "{{.Image}}"'
 ```
 
 **Expected output:**
@@ -142,7 +142,7 @@ git -C ~/musubi revert --no-edit <bump-commit-sha>
 git -C ~/musubi push origin v2
 # Re-run deploy with the older digest:
 ansible-playbook -i ~/.musubi-secrets/inventory-vars.yml \
-  deploy/ansible/deploy.yml --ask-vault-pass
+ deploy/ansible/deploy.yml --ask-vault-pass
 ```
 
 **Expected output:** `docker_compose_v2` recreates `core` with the

--- a/deploy/runbooks/upgrade.md
+++ b/deploy/runbooks/upgrade.md
@@ -17,13 +17,13 @@ The `deploy/ansible/update.yml` playbook drives every step below.
 **Command:**
 
 ```bash
-# On yua:
+# On the control host:
 cd ~/musubi
 git pull --ff-only
 
 # Confirm the compose render will succeed with the current vars:
 ansible-playbook -i ~/.musubi-secrets/inventory-vars.yml \
-  deploy/ansible/update.yml --check --ask-vault-pass
+ deploy/ansible/update.yml --check --ask-vault-pass
 ```
 
 **Expected output:**
@@ -52,8 +52,8 @@ gh run list --workflow publish-core-image.yml --limit 3
 # Open a bump PR:
 git checkout -b ops/core-image-bump-$(date +%Y%m%d)
 sed -i '' \
-  -E 's|^musubi_core_image: .*|musubi_core_image: "ghcr.io/ericmey/musubi-core@sha256:<paste>"|' \
-  deploy/ansible/group_vars/all.yml
+ -E 's|^musubi_core_image: .*|musubi_core_image: "ghcr.io/ericmey/musubi-core@sha256:<paste>"|' \
+ deploy/ansible/group_vars/all.yml
 git commit -am "ops: bump musubi_core_image to @sha256:<first 12 chars>"
 gh pr create --base v2 --title "ops: bump musubi_core_image"
 ```
@@ -74,17 +74,17 @@ Single-line diff in `group_vars/all.yml`. PR greens on CI.
 
 ```bash
 ansible-playbook -i ~/.musubi-secrets/inventory-vars.yml \
-  deploy/ansible/update.yml \
-  --check --diff --ask-vault-pass
+ deploy/ansible/update.yml \
+ --check --diff --ask-vault-pass
 ```
 
 **Expected output:**
 
 - The compose-template task shows the old → new `image:` line.
 - The `docker_compose_v2` task reports it will recreate the listed
-  services (defaults to `[core]`).
+ services (defaults to `[core]`).
 - Zero changes to any service you did NOT name — if Qdrant or
-  TEI shows as "recreate", stop and investigate.
+ TEI shows as "recreate", stop and investigate.
 
 **Destructive:** no.
 
@@ -98,19 +98,19 @@ ansible-playbook -i ~/.musubi-secrets/inventory-vars.yml \
 
 ```bash
 ansible-playbook -i ~/.musubi-secrets/inventory-vars.yml \
-  deploy/ansible/update.yml --ask-vault-pass
+ deploy/ansible/update.yml --ask-vault-pass
 # Or for a multi-service bump:
 ansible-playbook -i ~/.musubi-secrets/inventory-vars.yml \
-  deploy/ansible/update.yml \
-  -e changed_services='["core","tei-dense"]' --ask-vault-pass
+ deploy/ansible/update.yml \
+ -e changed_services='["core","tei-dense"]' --ask-vault-pass
 ```
 
 **Expected output:**
 
 - `policy=always` pull task reports "changed" for services whose
-  digest moved, "ok" for the rest.
+ digest moved, "ok" for the rest.
 - `recreate` task finishes with `changed=1` (for the single-service
-  default) and every listed service ends `healthy`.
+ default) and every listed service ends `healthy`.
 - The `probe-core-health` task returns 200 within one retry.
 
 **Destructive:** yes — recreates the named containers. Accept ~10s of
@@ -125,19 +125,19 @@ ansible-playbook -i ~/.musubi-secrets/inventory-vars.yml \
 **Command:**
 
 ```bash
-# From the operator's workstation (or yua):
-curl -sS http://musubi.mey.house:8100/v1/ops/status | jq .
+# From the operator's workstation (or the control host):
+curl -sS http://musubi.example.local:8100/v1/ops/status | jq .
 
 # Inspect the upgrade log:
-ssh ericmey@musubi.mey.house \
-  'sudo tail -1 /var/log/musubi/upgrade-history.jsonl | jq .'
+ssh ericmey@musubi.example.local \
+ 'sudo tail -1 /var/log/musubi/upgrade-history.jsonl | jq .'
 ```
 
 **Expected output:**
 
 - `status` is `ok` and every component is `healthy: true`.
 - The last `upgrade-history.jsonl` entry is this run (matching
-  timestamp, listed services, current `core_image`).
+ timestamp, listed services, current `core_image`).
 
 **Destructive:** no.
 
@@ -156,7 +156,7 @@ upgrade, run in reverse: revert the `group_vars` commit, push, re-run
 **Command:**
 
 ```bash
-# On yua — find the commit to revert:
+# On the ansible control host — find the commit to revert:
 git -C ~/musubi log -p -- deploy/ansible/group_vars/all.yml | head -40
 
 # Revert:
@@ -165,7 +165,7 @@ git -C ~/musubi push origin v2
 
 # Re-run update.yml:
 ansible-playbook -i ~/.musubi-secrets/inventory-vars.yml \
-  deploy/ansible/update.yml --ask-vault-pass
+ deploy/ansible/update.yml --ask-vault-pass
 ```
 
 **Expected output:**

--- a/docs/Musubi/00-index/work-log.md
+++ b/docs/Musubi/00-index/work-log.md
@@ -27,53 +27,53 @@ What it is **not:** a commit log. Code commits live in git. This log is for
 
 ## Entries
 
-### 2026-04-21 — Prometheus scraping musubi.mey.house (P1 observability)
+### 2026-04-21 — Prometheus scraping musubi.example.local (P1 observability)
 
-`musubi.mey.house` now runs a Prometheus container alongside the main
+`musubi.example.local` now runs a Prometheus container alongside the main
 stack. Scrape targets (verified via `/api/v1/query?query=up`, all
 returning `1`):
 
-| Job           | Target               | Exposing                            |
+| Job | Target | Exposing |
 |---------------|----------------------|-------------------------------------|
-| musubi-core   | `core:8100/v1/ops/metrics` | HTTP request counts/duration/5xx (real, live) |
-| tei-dense     | `tei-dense:80/metrics`     | batch latency, queue depth, GPU util |
-| tei-sparse    | `tei-sparse:80/metrics`    | same                                 |
-| tei-reranker  | `tei-reranker:80/metrics`  | same                                 |
-| prometheus    | `localhost:9090/metrics`   | self-scrape                          |
+| musubi-core | `core:8100/v1/ops/metrics` | HTTP request counts/duration/5xx (real, live) |
+| tei-dense | `tei-dense:80/metrics` | batch latency, queue depth, GPU util |
+| tei-sparse | `tei-sparse:80/metrics` | same |
+| tei-reranker | `tei-reranker:80/metrics` | same |
+| prometheus | `localhost:9090/metrics` | self-scrape |
 
-Reachable via SSH tunnel: `ssh -L 9090:localhost:9090 musubi.mey.house`,
+Reachable via SSH tunnel: `ssh -L 9090:localhost:9090 musubi.example.local`,
 then http://localhost:9090. Bound 127.0.0.1-only — Kong deferral per
 ADR 0024 means no external exposure tonight.
 
 Deviations from [[09-operations/observability]]:
 
 - Spec claims `musubi-core:9100`. Reality: `core:8100/v1/ops/metrics`.
-  (`9100` was the old slice-ops-observability plan; the actual endpoint
-  landed on `core:8100` when the router was written.)
+ (`9100` was the old slice-ops-observability plan; the actual endpoint
+ landed on `core:8100` when the router was written.)
 - Spec names `musubi_capture_total`, `musubi_retrieve_total`, lifecycle
-  counters, etc. Code emits `musubi_http_requests_total`,
-  `musubi_http_request_duration_ms`, `musubi_5xx_total`. The per-domain
-  counters are aspirational — wiring them is its own piece of work.
+ counters, etc. Code emits `musubi_http_requests_total`,
+ `musubi_http_request_duration_ms`, `musubi_5xx_total`. The per-domain
+ counters are aspirational — wiring them is its own piece of work.
 - Spec calls for Grafana + Alertmanager. Tonight ships Prometheus only.
-  Grafana + alerts are a separate slice when notification channels
-  (email? ntfy?) are decided.
+ Grafana + alerts are a separate slice when notification channels
+ (email? ntfy?) are decided.
 
 **Not yet scraped (documented in the config):**
 
 - Qdrant `/metrics` returns 401 — requires the `api-key` header. Needs a
-  secret-file wiring that isn't in scope tonight.
+ secret-file wiring that isn't in scope tonight.
 - Ollama has no native Prometheus exporter; leave as-is.
 - Lifecycle worker emits metrics via `default_registry()` but doesn't
-  serve HTTP — scraping it needs an embedded HTTP endpoint in the
-  worker entrypoint. Follow-up.
+ serve HTTP — scraping it needs an embedded HTTP endpoint in the
+ worker entrypoint. Follow-up.
 - Node-exporter for host-level (CPU/mem/disk/GPU) metrics not deployed
-  yet.
+ yet.
 
 13 structural tests in [`tests/ops/test_prometheus.py`](../../../tests/ops/test_prometheus.py).
 
 ### 2026-04-21 — Host-local backup scheduler live (P1 from the first-deploy punchlist)
 
-`musubi.mey.house` now backs itself up every six hours without Ansible.
+`musubi.example.local` now backs itself up every six hours without Ansible.
 [`deploy/backup/musubi-backup.sh`](../../../deploy/backup/musubi-backup.sh) + a
 systemd timer snapshot all seven Qdrant collections (`musubi_artifact`,
 `musubi_artifact_chunks`, `musubi_concept`, `musubi_curated`,
@@ -89,24 +89,24 @@ ansible path targets `127.0.0.1:6333` (which doesn't exist in the
 compose era — Qdrant is only on the `musubi_default` bridge) and
 `/mnt/snapshots/` (which doesn't exist on the current host — the VG has
 0 VFree and snapshot-capable mount was never provisioned). Also: if
-yua is down for maintenance, the backup path shouldn't go down with
+the ansible control host is down for maintenance, the backup path shouldn't go down with
 it. The ansible playbook remains as the canonical drill procedure and
 the future offsite-push path when restic + B2 creds land.
 
 **Deployment gotchas surfaced while wiring this:**
 
 - Qdrant writes snapshots to `/qdrant/snapshots` inside the container,
-  **not** `/qdrant/storage/snapshots`. Default `snapshots_path: ./snapshots`
-  is relative to the working dir (`/qdrant`), not the storage dir.
-  Without a bind mount, snapshots are ephemeral container storage.
-  Added `/var/lib/musubi/qdrant-snapshots:/qdrant/snapshots` to the
-  compose template.
+ **not** `/qdrant/storage/snapshots`. Default `snapshots_path: ./snapshots`
+ is relative to the working dir (`/qdrant`), not the storage dir.
+ Without a bind mount, snapshots are ephemeral container storage.
+ Added `/var/lib/musubi/qdrant-snapshots:/qdrant/snapshots` to the
+ compose template.
 - Collection names in-store drifted from the spec's plan —
-  `musubi_artifact` (not `musubi_artifact_heads`), plus
-  `musubi_lifecycle_events` which was declared in `store/` but not in
-  any spec section's canonical list. The backup driver queries
-  `/collections` at run time and iterates whatever's there, so future
-  collection renames no-op against the script.
+ `musubi_artifact` (not `musubi_artifact_heads`), plus
+ `musubi_lifecycle_events` which was declared in `store/` but not in
+ any spec section's canonical list. The backup driver queries
+ `/collections` at run time and iterates whatever's there, so future
+ collection renames no-op against the script.
 
 **Still on the P1 punchlist:** Prometheus / observability scrape.
 **Still on the P2 punchlist:** offsite backup tier (restic → B2) waiting
@@ -127,39 +127,39 @@ placeholder-lambdas until follow-up slices land real builders.
 **What landed:**
 
 - [`src/musubi/lifecycle/runner.py`](../../src/musubi/lifecycle/runner.py) —
-  tick-driven asyncio scheduler. Design rationale in
-  [[13-decisions/0025-lifecycle-runner-without-apscheduler]] (no
-  APScheduler dependency — rebuild that later when we need
-  persisted-jobstore semantics).
+ tick-driven asyncio scheduler. Design rationale in
+ [[13-decisions/0025-lifecycle-runner-without-apscheduler]] (no
+ APScheduler dependency — rebuild that later when we need
+ persisted-jobstore semantics).
 - [`src/musubi/llm/ollama.py`](../../src/musubi/llm/ollama.py) —
-  httpx-backed `OllamaClient` satisfying the `OllamaClient` Protocol on
-  [[06-ingestion/maturation]]. Returns `None` on outage (sweep falls
-  back to captured values); validates response via pydantic. 17 unit
-  tests, all using `pytest-httpx` — no live Ollama needed for CI.
+ httpx-backed `OllamaClient` satisfying the `OllamaClient` Protocol on
+ [[06-ingestion/maturation]]. Returns `None` on outage (sweep falls
+ back to captured values); validates response via pydantic. 17 unit
+ tests, all using `pytest-httpx` — no live Ollama needed for CI.
 - Prompts: `src/musubi/llm/prompts/{importance,topics}/v1.txt` —
-  frozen per the rule in `docs/Musubi/06-ingestion/CLAUDE.md`.
+ frozen per the rule in `docs/Musubi/06-ingestion/CLAUDE.md`.
 - [`src/musubi/lifecycle/maturation.py`](../../src/musubi/lifecycle/maturation.py) —
-  `default_ollama_client()` now returns the real client instead of the
-  loud stub.
+ `default_ollama_client()` now returns the real client instead of the
+ loud stub.
 - [`deploy/ansible/templates/docker-compose.yml.j2`](../../../deploy/ansible/templates/docker-compose.yml.j2) —
-  added `lifecycle-worker` service using the core image with a new
-  entrypoint. Inherited HEALTHCHECK disabled (worker doesn't serve HTTP).
+ added `lifecycle-worker` service using the core image with a new
+ entrypoint. Inherited HEALTHCHECK disabled (worker doesn't serve HTTP).
 
-**Verification on `musubi.mey.house` (2026-04-21):**
+**Verification on `musubi.example.local` (2026-04-21):**
 
 1. Rebuilt `musubi-core:dev`, transferred via `docker save | ssh docker load`.
 2. Edited `/etc/musubi/docker-compose.yml` in place to add the
-   `lifecycle-worker` block (Ansible is the source-of-truth but the vault
-   pass lives on yua; in-place edit was the pragmatic path).
+ `lifecycle-worker` block (Ansible is the source-of-truth but the vault
+ pass lives on the ansible control host; in-place edit was the pragmatic path).
 3. `docker compose up -d --force-recreate core lifecycle-worker` — both
-   came up clean; compose stack still reports all healthy.
+ came up clean; compose stack still reports all healthy.
 4. Worker logs show `lifecycle-runner-starting jobs=[...] tick_seconds=60`
-   and `concept_maturation` firing at its documented `03:30` cron window.
+ and `concept_maturation` firing at its documented `03:30` cron window.
 5. Forced one manual `episodic_maturation_sweep` via
-   `docker compose exec lifecycle-worker python -c "…"`:
-   `SweepReport(selected=3, transitioned=3, enriched=2, failed=0)`.
+ `docker compose exec lifecycle-worker python -c "…"`:
+ `SweepReport(selected=3, transitioned=3, enriched=2, failed=0)`.
 6. `/v1/retrieve {query_text: "first deploy smoke", namespace: "eric/ops/episodic"}`
-   returns the three matured captures. **Round-trip closed.**
+ returns the three matured captures. **Round-trip closed.**
 
 **What the LLM did:** Qwen-3:4B on the local Ollama returned valid JSON
 matching the pydantic schemas on both prompts. Two of three captures
@@ -169,28 +169,28 @@ the third was a timestamp-only capture — topics correctly empty.
 **Open items for the punchlist:**
 
 - P1 Observability: stand up Prometheus; scrape `core:/v1/ops/metrics` and
-  `lifecycle-worker` (when the metrics exporter slice lands).
+ `lifecycle-worker` (when the metrics exporter slice lands).
 - P1 Qdrant backup cron: `deploy/backup/` scripts exist but aren't
-  scheduled.
+ scheduled.
 - P2 [[_slices/slice-ops-core-image-publish]]: CI-published GHCR image
-  + digest-pinned `group_vars`.
+ + digest-pinned `group_vars`.
 - P2 [[_slices/slice-ops-update-workflow]]: `deploy/ansible/update.yml`
-  with `policy: always` pulls.
+ with `policy: always` pulls.
 - P3 Real builders for the non-maturation sweeps (synthesis, promotion,
-  demotion, reflection, vault_reconcile).
+ demotion, reflection, vault_reconcile).
 
-### 2026-04-20 — Musubi stack live on `musubi.mey.house` (first real deploy)
+### 2026-04-20 — Musubi stack live on `musubi.example.local` (first real deploy)
 
 The six-container Musubi compose stack came up end-to-end against the real
 target host for the first time. All services report `healthy`:
 
 ```
-musubi-core-1           healthy   /v1/ops/health → {"status":"ok","version":"v0"}
-musubi-ollama-1         healthy   qwen3:4b loaded (per [[13-decisions/0019-qwen-on-musubi-gpu-phase-1]])
-musubi-qdrant-1         healthy   v1.17.1, api-key-auth on
-musubi-tei-dense-1      healthy   BGE-M3
-musubi-tei-reranker-1   healthy   BGE-reranker-v2-m3
-musubi-tei-sparse-1     healthy   SPLADE v3
+musubi-core-1 healthy /v1/ops/health → {"status":"ok","version":"v0"}
+musubi-ollama-1 healthy qwen3:4b loaded (per [[13-decisions/0019-qwen-on-musubi-gpu-phase-1]])
+musubi-qdrant-1 healthy v1.17.1, api-key-auth on
+musubi-tei-dense-1 healthy BGE-M3
+musubi-tei-reranker-1 healthy BGE-reranker-v2-m3
+musubi-tei-sparse-1 healthy SPLADE v3
 ```
 
 GPU: 3.3 / 10 GiB VRAM used; room for query-time batching.
@@ -201,70 +201,70 @@ Every one of these was a spec-vs-reality gap that `slice-ops-first-deploy`
 could not have caught because it shipped without ever running against a real
 host. Each fix landed via PR tonight:
 
-- **#146** `chore(ansible): parametrise inventory + yua control-host workflow` —
-  replaced `<placeholder>` literals in `deploy/ansible/inventory.yml` with
-  `{{ jinja_vars }}`, added `deploy/ansible/setup-control-host.sh` to seed
-  `~/.musubi-secrets/` on yua. Musubi playbooks are now run from yua alongside
-  the homelab fleet ansible; vault password is shared (`~/ansible/.vault_pass`).
+- **#146** `chore(ansible): parametrise inventory + the ansible control host control-host workflow` —
+ replaced `<placeholder>` literals in `deploy/ansible/inventory.yml` with
+ `{{ jinja_vars }}`, added `deploy/ansible/setup-control-host.sh` to seed
+ `~/.musubi-secrets/` on the ansible control host. Musubi playbooks are now run from the ansible control host alongside
+ the homelab fleet ansible; vault password is shared (`~/ansible/.vault_pass`).
 - **#147** `chore(ansible): bootstrap.yml adds Docker + NVIDIA apt repos` —
-  `bootstrap.yml` was missing the Docker-CE and NVIDIA container-toolkit apt
-  repo setup; first `apt install` failed immediately. Driver install pattern
-  changed from the rotted `nvidia-driver-560-server` pin to
-  `ubuntu-drivers autoinstall` guarded by an `nvidia-smi` probe (so the
-  pre-staged 580.126.20 isn't downgraded).
+ `bootstrap.yml` was missing the Docker-CE and NVIDIA container-toolkit apt
+ repo setup; first `apt install` failed immediately. Driver install pattern
+ changed from the rotted `nvidia-driver-560-server` pin to
+ `ubuntu-drivers autoinstall` guarded by an `nvidia-smi` probe (so the
+ pre-staged 580.126.20 isn't downgraded).
 - **#148** `feat(ops): musubi-core Dockerfile + compose/env template fixes` —
-  wrote the missing Musubi Core `Dockerfile` (was only referenced as
-  `ghcr.io/example/musubi-core:<digest>` — no such image existed). Rewrote
-  the `.env.production.j2` template against the real `settings.py` field
-  set (it was ~half-missing). Corrected TEI image tag from `1.5-cuda`
-  (doesn't exist on GHCR) to `86-1.2.0` (Ampere compute-8.6 variant). Dropped
-  `--pooling rerank` from the reranker service (rerankers are auto-detected
-  in TEI 1.x; only `cls / mean / splade` are valid pooling values). Decoupled
-  the Ollama healthcheck from model-pull state (the old check deadlocked
-  against `core.depends_on`). Moved every healthcheck off `curl` (not
-  installed in the minimal Qdrant / Ollama / TEI images) to either `bash
-  /dev/tcp` or the service's own CLI. Set `MUSUBI_ALLOW_PLAINTEXT=true` so
-  Core talks HTTP to in-bridge Qdrant (TLS inside the compose network is
-  orthogonal; Kong-deferred per ADR 0024 means Core isn't externally
-  exposed either).
+ wrote the missing Musubi Core `Dockerfile` (was only referenced as
+ `ghcr.io/example/musubi-core:<digest>` — no such image existed). Rewrote
+ the `.env.production.j2` template against the real `settings.py` field
+ set (it was ~half-missing). Corrected TEI image tag from `1.5-cuda`
+ (doesn't exist on GHCR) to `86-1.2.0` (Ampere compute-8.6 variant). Dropped
+ `--pooling rerank` from the reranker service (rerankers are auto-detected
+ in TEI 1.x; only `cls / mean / splade` are valid pooling values). Decoupled
+ the Ollama healthcheck from model-pull state (the old check deadlocked
+ against `core.depends_on`). Moved every healthcheck off `curl` (not
+ installed in the minimal Qdrant / Ollama / TEI images) to either `bash
+ /dev/tcp` or the service's own CLI. Set `MUSUBI_ALLOW_PLAINTEXT=true` so
+ Core talks HTTP to in-bridge Qdrant (TLS inside the compose network is
+ orthogonal; Kong-deferred per ADR 0024 means Core isn't externally
+ exposed either).
 
 ### One-time operator steps that happened outside the playbooks
 
-- `ericmey`'s Mac pubkey added to `yua`'s `authorized_keys` (via Proxmox
-  console — the prior laptop's key didn't follow).
-- `yua`'s `id_ed25519_yua` registered as a read-only GitHub deploy key on
-  `ericmey/musubi` so yua can `git clone` the repo.
+- `ericmey`'s Mac pubkey added to the control host's `authorized_keys` (via Proxmox
+ console — the prior laptop's key didn't follow).
+- the control host's SSH key registered as a read-only GitHub deploy key on
+ `ericmey/musubi` so the ansible control host can `git clone` the repo.
 - Native `qdrant.service` / `ollama.service` / `open-webui.service` stopped,
-  disabled, and purged (binaries, data dirs, service users). Design call per
-  discussion: `bootstrap.yml` assumes a greenfield host going forward; the
-  native services were pre-staging artefacts only.
+ disabled, and purged (binaries, data dirs, service users). Design call per
+ discussion: `bootstrap.yml` assumes a greenfield host going forward; the
+ native services were pre-staging artefacts only.
 - HF cache at `/home/ericmey/musubi-hf-cache/hub/` rsynced into
-  `/var/lib/musubi/tei-models/` so SPLADE v3 loads from cache (it's gated on
-  HuggingFace; download would 401). Automating this is a follow-up (the
-  current `bootstrap.yml` doesn't do it).
+ `/var/lib/musubi/tei-models/` so SPLADE v3 loads from cache (it's gated on
+ HuggingFace; download would 401). Automating this is a follow-up (the
+ current `bootstrap.yml` doesn't do it).
 
 ### Vault changes
 
 - [[08-deployment/host-profile|host-profile.md]] § *Actually deployed state*
-  updated from pre-Compose snapshot (2026-04-18) to post-Compose reality.
+ updated from pre-Compose snapshot (2026-04-18) to post-Compose reality.
 - [[_slices/slice-ops-first-deploy|slice-ops-first-deploy.md]] work-log
-  appended with the execution record and the bugs-found ledger.
+ appended with the execution record and the bugs-found ledger.
 - [[12-roadmap/status|status.md]] v1 progress table updated; Phase 8 Ops
-  rolls over to *first deploy complete*.
+ rolls over to *first deploy complete*.
 
 ### Downstream unblocked
 
 - **First capture → retrieve round-trip** is now testable end-to-end
-  (`deploy/smoke/verify.sh` against `http://10.0.20.45:8100`). Queued for
-  the next session.
+ (`deploy/smoke/verify.sh` against `http://10.0.0.45:8100`). Queued for
+ the next session.
 - **POC → v1 data migration** (`slice-poc-data-migration`) now has a live
-  target Musubi it can push into.
+ target Musubi it can push into.
 - **OpenClaw / LiveKit / MCP adapters** have a real endpoint to integration-
-  test against.
+ test against.
 
 ### 2026-04-20 — slice-poc-data-migration completed via SDK
 
-The POC data migration script `poc-to-v1.py` successfully completed discovery and implementation against `nyla.mey.house`. Connected to the local POC Qdrant source via port 6333, mapped and transformed the `musubi_memories` and `musubi_thoughts` rows with deterministic KSUIDs. 
+The POC data migration script `poc-to-v1.py` successfully completed discovery and implementation against `control.example.local`. Connected to the local POC Qdrant source via port 6333, mapped and transformed the `musubi_memories` and `musubi_thoughts` rows with deterministic KSUIDs. 
 
 During implementation, it was verified that the `MusubiClient.memories.capture` endpoint does not support backdating `created_at`, so `[[_inbox/cross-slice/migrator-needs-created-at-override]]` was opened for the SDK and API teams to implement an override.
 
@@ -458,12 +458,12 @@ add new ones if context evolves.
 When a spec describes infrastructure that has come online, add these fields to
 its frontmatter (in addition to `status:`):
 
-| Field               | When to use                                                              |
+| Field | When to use |
 |---------------------|--------------------------------------------------------------------------|
-| `deployment_status` | `planned` → `provisioned` → `operational` → `retired`                     |
-| `provisioned_at`    | Date the physical/virtual resource came online.                           |
-| `operational_at`    | Date the service began serving production traffic (after config + test).  |
-| `retired_at`        | Date the resource was decommissioned.                                     |
+| `deployment_status` | `planned` → `provisioned` → `operational` → `retired` |
+| `provisioned_at` | Date the physical/virtual resource came online. |
+| `operational_at` | Date the service began serving production traffic (after config + test). |
+| `retired_at` | Date the resource was decommissioned. |
 
 These are optional — use on notes where the spec vs. reality distinction
 matters (host profile, adapter deployments, etc.). Don't bother on purely

--- a/docs/Musubi/07-interfaces/canonical-api.md
+++ b/docs/Musubi/07-interfaces/canonical-api.md
@@ -18,7 +18,7 @@ This document describes the **shape** of the API; the generated OpenAPI/proto fi
 ## Base URL
 
 ```
-https://musubi.internal.<tld>/v1/
+https://musubi.example.local.<tld>/v1/
 ```
 
 HTTPS is mandatory. TLS via Kong reverse-proxy in front of Uvicorn. Local dev uses Kong with a self-signed cert.

--- a/docs/Musubi/07-interfaces/mcp-adapter.md
+++ b/docs/Musubi/07-interfaces/mcp-adapter.md
@@ -191,7 +191,7 @@ Logs include the MCP `request_id` and forward to Musubi Core as `X-Request-Id`.
 
 ```yaml
 # musubi-mcp-adapter.yaml
-musubi_url: https://musubi.internal.example.com/v1
+musubi_url: https://musubi.example.local.example.com/v1
 oauth:
   authority: https://auth.internal.example.com
   client_id: musubi-mcp

--- a/docs/Musubi/07-interfaces/sdk.md
+++ b/docs/Musubi/07-interfaces/sdk.md
@@ -43,7 +43,7 @@ monorepo's release; SDK-only changes still bump that release.
 from musubi.sdk import MusubiClient
 
 client = MusubiClient(
-    base_url="https://musubi.internal.example.com/v1",
+    base_url="https://musubi.example.local.example.com/v1",
     token="eyJhbGc...",
     timeout=30,                         # seconds, overall; per-call timeouts override
     retry=RetryPolicy.default(),

--- a/docs/Musubi/08-deployment/ansible-layout.md
+++ b/docs/Musubi/08-deployment/ansible-layout.md
@@ -30,24 +30,24 @@ We don't use Terraform, Kubernetes, or Helm. The host is fixed; the containers a
 
 ```
 musubi-infra/
-  inventory/
-    hosts.yml                  # host list (one entry for v1)
-    group_vars/
-      all.yml                  # defaults
-      musubi.yml               # musubi-specific overrides
-  roles/
-    base/                      # user, timezone, apt upgrade, ufw, logrotate
-    nvidia/                    # driver install + nvidia-container-toolkit
-    docker/                    # Docker CE + compose plugin
-    musubi-fs/                 # /var/lib/musubi layout + permissions
-    musubi-stack/              # compose.yml render + systemd unit
-    backup/                    # cron entries for snapshot + git push
-  playbooks/
-    musubi.yml                 # full bring-up
-    update.yml                 # pulls compose image digests, restarts
-    rotate.yml                 # log + snapshot retention
-  .vault.yml                   # encrypted secrets (git-crypt or ansible-vault)
-  requirements.yml             # collection deps (community.docker, etc.)
+ inventory/
+ hosts.yml # host list (one entry for v1)
+ group_vars/
+ all.yml # defaults
+ musubi.yml # musubi-specific overrides
+ roles/
+ base/ # user, timezone, apt upgrade, ufw, logrotate
+ nvidia/ # driver install + nvidia-container-toolkit
+ docker/ # Docker CE + compose plugin
+ musubi-fs/ # /var/lib/musubi layout + permissions
+ musubi-stack/ # compose.yml render + systemd unit
+ backup/ # cron entries for snapshot + git push
+ playbooks/
+ musubi.yml # full bring-up
+ update.yml # pulls compose image digests, restarts
+ rotate.yml # log + snapshot retention
+ .vault.yml # encrypted secrets (git-crypt or ansible-vault)
+ requirements.yml # collection deps (community.docker, etc.)
 ```
 
 ## Inventory
@@ -55,15 +55,15 @@ musubi-infra/
 ```yaml
 # inventory/hosts.yml
 all:
-  children:
-    musubi:
-      hosts:
-        musubi-1:
-          ansible_host: 192.168.1.42
-          ansible_user: eric
-          ansible_become: true
-          musubi_hostname: musubi.internal.example.com
-          musubi_cert_mode: selfsigned   # or 'letsencrypt'
+ children:
+ musubi:
+ hosts:
+ musubi-1:
+ ansible_host: 192.168.1.42
+ ansible_user: eric
+ ansible_become: true
+ musubi_hostname: musubi.example.local.example.com
+ musubi_cert_mode: selfsigned # or 'letsencrypt'
 ```
 
 Variables per host keep it clear: change the host, re-run playbook. Secrets live outside this file.
@@ -75,28 +75,28 @@ Variables per host keep it clear: change the host, re-run playbook. Secrets live
 ```yaml
 # roles/base/tasks/main.yml
 - name: Create musubi user
-  ansible.builtin.user:
-    name: musubi
-    groups: docker
-    system: yes
-    shell: /sbin/nologin
+ ansible.builtin.user:
+ name: musubi
+ groups: docker
+ system: yes
+ shell: /sbin/nologin
 
 - name: Install unattended-upgrades
-  ansible.builtin.apt:
-    name: unattended-upgrades
-    state: present
+ ansible.builtin.apt:
+ name: unattended-upgrades
+ state: present
 
 - name: Configure ufw
-  community.general.ufw:
-    rule: "{{ item.rule }}"
-    port: "{{ item.port }}"
-  loop:
-    - {rule: allow, port: 22}
-    - {rule: allow, port: 443}
+ community.general.ufw:
+ rule: "{{ item.rule }}"
+ port: "{{ item.port }}"
+ loop:
+ - {rule: allow, port: 22}
+ - {rule: allow, port: 443}
 
 - name: Enable ufw
-  community.general.ufw:
-    state: enabled
+ community.general.ufw:
+ state: enabled
 ```
 
 ### `nvidia`
@@ -106,19 +106,19 @@ Installs `nvidia-driver-560` via apt + `nvidia-container-toolkit` so Docker can 
 ```yaml
 # roles/nvidia/tasks/main.yml
 - name: Install NVIDIA driver
-  ansible.builtin.apt:
-    name: nvidia-driver-560-server
-    state: present
-  register: driver
-  notify: reboot if driver changed
+ ansible.builtin.apt:
+ name: nvidia-driver-560-server
+ state: present
+ register: driver
+ notify: reboot if driver changed
 
 - name: Install nvidia-container-toolkit
-  ansible.builtin.apt:
-    name: nvidia-container-toolkit
-    state: present
+ ansible.builtin.apt:
+ name: nvidia-container-toolkit
+ state: present
 
 - name: Configure Docker to use NVIDIA runtime
-  ansible.builtin.shell: nvidia-ctk runtime configure --runtime=docker
+ ansible.builtin.shell: nvidia-ctk runtime configure --runtime=docker
 ```
 
 Driver changes trigger a reboot (handler), otherwise CUDA visibility is flaky.
@@ -148,39 +148,39 @@ The core role:
 ```yaml
 # roles/musubi-stack/tasks/main.yml
 - name: Render docker-compose.yml
-  ansible.builtin.template:
-    src: docker-compose.yml.j2
-    dest: /etc/musubi/docker-compose.yml
-    owner: root
-    group: root
-    mode: "0644"
+ ansible.builtin.template:
+ src: docker-compose.yml.j2
+ dest: /etc/musubi/docker-compose.yml
+ owner: root
+ group: root
+ mode: "0644"
 
 - name: Seed .env
-  ansible.builtin.template:
-    src: env.j2
-    dest: /etc/musubi/.env
-    owner: root
-    group: docker
-    mode: "0640"
-  no_log: true
+ ansible.builtin.template:
+ src: env.j2
+ dest: /etc/musubi/.env
+ owner: root
+ group: docker
+ mode: "0640"
+ no_log: true
 
 - name: Pre-pull images
-  community.docker.docker_image:
-    name: "{{ item }}"
-    source: pull
-  loop: "{{ musubi_images }}"
+ community.docker.docker_image:
+ name: "{{ item }}"
+ source: pull
+ loop: "{{ musubi_images }}"
 
 - name: Install systemd unit
-  ansible.builtin.template:
-    src: musubi.service.j2
-    dest: /etc/systemd/system/musubi.service
-  notify: systemd daemon-reload
+ ansible.builtin.template:
+ src: musubi.service.j2
+ dest: /etc/systemd/system/musubi.service
+ notify: systemd daemon-reload
 
 - name: Enable musubi service
-  ansible.builtin.systemd:
-    name: musubi
-    enabled: yes
-    state: started
+ ansible.builtin.systemd:
+ name: musubi
+ enabled: yes
+ state: started
 ```
 
 ### Gateway (lives elsewhere)
@@ -211,15 +211,15 @@ Full detail: [[09-operations/backup-restore]].
 
 ```yaml
 - name: Provision Musubi host
-  hosts: musubi
-  become: true
-  roles:
-    - base
-    - nvidia
-    - docker
-    - musubi-fs
-    - musubi-stack
-    - backup
+ hosts: musubi
+ become: true
+ roles:
+ - base
+ - nvidia
+ - docker
+ - musubi-fs
+ - musubi-stack
+ - backup
 ```
 
 ### `playbooks/update.yml`
@@ -228,18 +228,18 @@ Pulls new image digests (respecting `compose.override.yml` pins) and recreates c
 
 ```yaml
 - name: Update Musubi stack
-  hosts: musubi
-  become: true
-  tasks:
-    - name: Pull new images
-      community.docker.docker_compose_v2_pull:
-        project_src: /etc/musubi
+ hosts: musubi
+ become: true
+ tasks:
+ - name: Pull new images
+ community.docker.docker_compose_v2_pull:
+ project_src: /etc/musubi
 
-    - name: Recreate changed services
-      community.docker.docker_compose_v2:
-        project_src: /etc/musubi
-        state: present
-        recreate: smart    # only changed containers
+ - name: Recreate changed services
+ community.docker.docker_compose_v2:
+ project_src: /etc/musubi
+ state: present
+ recreate: smart # only changed containers
 ```
 
 ### `playbooks/rotate.yml`

--- a/docs/Musubi/08-deployment/gpu-inference-topology.md
+++ b/docs/Musubi/08-deployment/gpu-inference-topology.md
@@ -13,7 +13,7 @@ implements: "tests/test_embedding.py"
 
 How 10 GB of VRAM hosts BGE-M3, SPLADE++ V3, BGE-reranker-v2-m3, and a Qwen 3 4B LLM simultaneously — without OOMs.
 
-**Host:** `musubi.mey.house` — bare-metal Ubuntu 24.04, RTX 3080 10 GB, dedicated to Musubi. See [[13-decisions/0019-qwen-on-musubi-gpu-phase-1]] for the phase-gated LLM placement decision behind the model choice below.
+**Host:** `musubi.example.local` — bare-metal Ubuntu 24.04, RTX 3080 10 GB, dedicated to Musubi. See [[13-decisions/0019-qwen-on-musubi-gpu-phase-1]] for the phase-gated LLM placement decision behind the model choice below.
 
 ## The constraint
 
@@ -32,7 +32,7 @@ Workable. Leaves ~0.7-1.2 GB headroom. Tight enough that growth (larger TEI batc
 
 ## Phase 2 triggers (summary)
 
-Move Qwen off musubi — either to `photo-club.mey.house` (5070 Ti 16 GB) over the VLAN, or upgrade musubi's GPU — if any of:
+Move Qwen off musubi — either to `photo.example.local` (5070 Ti 16 GB) over the VLAN, or upgrade musubi's GPU — if any of:
 
 - VRAM OOM / model-eviction events >1 per week
 - Sweep wall-time exceeds schedule window (hourly >15 min, daily >2 hours)

--- a/docs/Musubi/09-operations/alerts.md
+++ b/docs/Musubi/09-operations/alerts.md
@@ -95,7 +95,7 @@ Every push alert has a linked runbook in [[09-operations/runbooks]]:
 # alertmanager template snippet
 annotations:
   summary: "Qdrant is not responding"
-  runbook: "https://docs.musubi.internal/09-operations/runbooks/#qdrant-down"
+  runbook: "https://docs.musubi.example.local/09-operations/runbooks/#qdrant-down"
 ```
 
 If an alert doesn't have a runbook, it doesn't fire. Period.
@@ -151,7 +151,7 @@ receivers:
   - name: email
     email_configs:
       - to: eric@example.com
-        from: alertmanager@musubi.internal
+        from: alertmanager@musubi.example.local
         smarthost: smtp.example.com:587
 ```
 

--- a/docs/Musubi/11-migration/phase-7-adapters.md
+++ b/docs/Musubi/11-migration/phase-7-adapters.md
@@ -61,7 +61,7 @@ New repo `musubi-contract-tests`. See [[07-interfaces/contract-tests]]. Each ada
 
 ### Kong
 
-Add Kong in front for TLS + rate limits. See [[08-deployment/kong]]. Before this phase, adapters talked directly to `localhost:8100`; now they go through `https://musubi.internal.example.com`.
+Add Kong in front for TLS + rate limits. See [[08-deployment/kong]]. Before this phase, adapters talked directly to `localhost:8100`; now they go through `https://musubi.example.local.example.com`.
 
 ## Done signal
 
@@ -87,7 +87,7 @@ If the SDK is broken, adapters can temporarily call HTTP directly.
 
 # MCP via HTTP:
 curl -H "Authorization: Bearer $T" -d '{...}' \
-  https://musubi.internal.example.com/v1/memories
+  https://musubi.example.local.example.com/v1/memories
 
 # LiveKit (in a test harness):
 # Start voice session → speak → Slow Thinker prefetches → Fast Talker replies with context.
@@ -96,7 +96,7 @@ curl -H "Authorization: Bearer $T" -d '{...}' \
 # Highlight text → "Remember this" → memory appears in retrieval.
 
 # Contract suite:
-pytest --contract=canonical --musubi-url=https://musubi.internal.example.com/v1
+pytest --contract=canonical --musubi-url=https://musubi.example.local.example.com/v1
 ```
 
 ## Estimate

--- a/docs/Musubi/11-migration/phase-8-ops.md
+++ b/docs/Musubi/11-migration/phase-8-ops.md
@@ -80,7 +80,7 @@ Each component is additive; none of them changes application behavior. Remove on
 ansible-playbook playbooks/musubi.yml
 
 # Run the smoke suite:
-pytest --contract=smoke --musubi-url=https://musubi.internal.example.com/v1
+pytest --contract=smoke --musubi-url=https://musubi.example.local.example.com/v1
 
 # Run a chaos probe:
 docker stop musubi-qdrant-1

--- a/docs/Musubi/12-roadmap/status.md
+++ b/docs/Musubi/12-roadmap/status.md
@@ -34,7 +34,7 @@ external consumer needs thin wheels), 1 retired.
 | 5. Vault | **done** | Watcher + vault-sync shipped via `slice-vault-sync`. |
 | 6. Lifecycle | **done** | Engine, maturation, synthesis, promotion, reflection all shipped. |
 | 7. Adapters | **done** | MCP adapter shipped; LiveKit + OpenClaw (OpenClaw retired) landed. |
-| 8. Ops | **done (first deploy)** | Ansible + Compose + observability + backup + hardening + first-deploy runbook shipped AND executed: Musubi is live on `musubi.mey.house` as of 2026-04-20. See [[00-index/work-log]]. |
+| 8. Ops | **done (first deploy)** | Ansible + Compose + observability + backup + hardening + first-deploy runbook shipped AND executed: Musubi is live on `musubi.example.local` as of 2026-04-20. See [[00-index/work-log]]. |
 
 Phase 8's "first deploy" doesn't mean Ops is perfect forever — it means the
 stack was brought up end-to-end on the reference host, the health endpoint
@@ -54,33 +54,33 @@ See [[02-current-state/index]] for detail.
 ## What's in flight (2026-04-20)
 
 - First end-to-end smoke test against the live deploy
-  (`deploy/smoke/verify.sh` → capture → retrieve round-trip). Queued.
+ (`deploy/smoke/verify.sh` → capture → retrieve round-trip). Queued.
 - POC → v1 data migration execution (`slice-poc-data-migration`) against
-  the now-live target.
+ the now-live target.
 - Harden / automate the operator-only steps that happened manually during
-  tonight's first deploy (see [[_slices/slice-ops-first-deploy|first-deploy
-  slice]]'s post-mortem section for the list).
+ tonight's first deploy (see [[_slices/slice-ops-first-deploy|first-deploy
+ slice]]'s post-mortem section for the list).
 
 ## Next up
 
 1. Smoke-test the live deploy, wire failures (if any) as ordinary slices.
 2. Publish Musubi Core to GHCR + pin external image digests, replacing the
-   `docker save | ssh | docker load` transfer the first deploy used.
+ `docker save | ssh | docker load` transfer the first deploy used.
 3. Automate the HF-cache rsync step in `bootstrap.yml` so a fresh host
-   matches the current one without manual intervention.
+ matches the current one without manual intervention.
 4. Resolve the `[R]` findings in [[_inbox/operator-notes]] (Ollama model
-   drift — closed in tonight's deploy; health-URL contradiction — still
-   open, `health.yml` probes Qdrant/Ollama on localhost but compose makes
-   them bridge-only).
+ drift — closed in tonight's deploy; health-URL contradiction — still
+ open, `health.yml` probes Qdrant/Ollama on localhost but compose makes
+ them bridge-only).
 
 ## Recently completed
 
-- **2026-04-20** — First real deploy of Musubi stack on `musubi.mey.house`.
-  All six services healthy. See [[00-index/work-log]] for the full entry.
+- **2026-04-20** — First real deploy of Musubi stack on `musubi.example.local`.
+ All six services healthy. See [[00-index/work-log]] for the full entry.
 - **2026-04-20** — ADR 0023 (Qdrant 1.15 → 1.17 pin bump) + ADR 0024 (Kong
-  deferred for v1) + runbook reconciliation.
+ deferred for v1) + runbook reconciliation.
 - **2026-04-20** — `docs/architecture/` → `docs/Musubi/` vault rename
-  landed atomically with history preserved.
+ landed atomically with history preserved.
 
 ## Blockers
 

--- a/docs/Musubi/13-decisions/0019-qwen-on-musubi-gpu-phase-1.md
+++ b/docs/Musubi/13-decisions/0019-qwen-on-musubi-gpu-phase-1.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0019: Qwen 3 4B on musubi.mey.house GPU (Phase 1)"
+title: "ADR-0019: Qwen 3 4B on musubi.example.local GPU (Phase 1)"
 section: 13-decisions
 type: adr
 status: accepted
@@ -7,7 +7,7 @@ tags: [section/decisions, status/accepted, type/adr, llm, gpu, deployment]
 updated: 2026-04-19
 ---
 
-# ADR-0019: Qwen 3 4B on musubi.mey.house GPU (Phase 1)
+# ADR-0019: Qwen 3 4B on musubi.example.local GPU (Phase 1)
 
 ## Status
 
@@ -19,16 +19,16 @@ Musubi's lifecycle sweeps (maturation, synthesis, reflection, future promotion) 
 
 Two material facts reshape the decision:
 
-1. **Target host is `musubi.mey.house`** — purpose-built dedicated bare-metal server with an RTX 3080 (10 GB VRAM), not shared. Dedicated to Musubi + dependent services.
-2. **Operator has two other GPU hosts** in the homelab — `photo-club.mey.house` (5070 Ti 16 GB) and `av-club.mey.house` (5090 32 GB) — currently load-balancing image-gen. Photo-Club is a viable fallback LLM host if needed.
+1. **Target host is `musubi.example.local`** — purpose-built dedicated bare-metal server with an RTX 3080 (10 GB VRAM), not shared. Dedicated to Musubi + dependent services.
+2. **Operator has two other GPU hosts** in the homelab — `photo.example.local` (5070 Ti 16 GB) and `av.example.local` (5090 32 GB) — currently load-balancing image-gen. Photo-Club is a viable fallback LLM host if needed.
 
 The original 7B placement would leave ~0.4 GB headroom on the 10 GB card — workable, but fragile under real load.
 
 ## Decision
 
-**Phase 1 (initial deploy):** Run **Qwen 3 4B Q4_K_M** (~2.5 GB) co-resident with the three TEI services on musubi.mey.house's 3080. Keep the full stack self-contained on one box.
+**Phase 1 (initial deploy):** Run **Qwen 3 4B Q4_K_M** (~2.5 GB) co-resident with the three TEI services on musubi.example.local's 3080. Keep the full stack self-contained on one box.
 
-**Phase 2 (triggered by objective criteria; see below):** If Phase 1 fails on any criterion, move Qwen to Photo-Club (5070 Ti 16 GB) as a dedicated LLM host reachable over the `mey.house` VLAN, OR upgrade musubi's GPU.
+**Phase 2 (triggered by objective criteria; see below):** If Phase 1 fails on any criterion, move Qwen to Photo-Club (5070 Ti 16 GB) as a dedicated LLM host reachable over the `example.local` VLAN, OR upgrade musubi's GPU.
 
 This is a phase-gated decision, not a permanent choice. The point is to ship the simplest viable configuration, measure, and upgrade on evidence.
 
@@ -68,7 +68,7 @@ Listed in preference order:
 1. **Move Qwen to Photo-Club** (repurpose from image gen)
    - Qwen 3 8B or Qwen 2.5 7B Q4 comfortably fits with room for a second (uncensored / Dolphin-class) model alongside
    - All TEI stays on musubi; musubi's 10 GB becomes comfortable (~5 GB headroom)
-   - Ollama exposed on `photo-club.mey.house:11434`; musubi reaches it via VLAN
+   - Ollama exposed on `photo.example.local:11434`; musubi reaches it via VLAN
    - Cost: ~50 % loss of parallel image-gen burst throughput (AV-Club alone handles image gen)
 
 2. **Upgrade musubi's GPU** (e.g. 4090 24 GB or similar)
@@ -120,7 +120,7 @@ Listed in preference order:
 
 ## Review trigger
 
-Re-evaluate this ADR at Day 14 after first real capture on musubi.mey.house. Document the outcome in the ADR's `status` field:
+Re-evaluate this ADR at Day 14 after first real capture on musubi.example.local. Document the outcome in the ADR's `status` field:
 
 - `accepted` (current) — Phase 1 is the steady state.
 - `superseded` — Phase 2 triggered; link to the superseding ADR.

--- a/docs/Musubi/13-decisions/0022-extension-ecosystem-naming.md
+++ b/docs/Musubi/13-decisions/0022-extension-ecosystem-naming.md
@@ -48,7 +48,7 @@ where `<system>` names the host system the component targets.
 
 | Component | Language | Source location | Install into consumer |
 |---|---|---|---|
-| Musubi server | Python | `src/musubi/` → future `packages/musubi-server/` | Operator deploys on `musubi.mey.house` |
+| Musubi server | Python | `src/musubi/` → future `packages/musubi-server/` | Operator deploys on `musubi.example.local` |
 | Musubi Python SDK | Python | `src/musubi/sdk/` → future `packages/musubi-client/` | `pip install musubi-client` |
 | MCP server (remote HTTP + SSE) | Python | `src/musubi/adapters/mcp/` → future `packages/musubi-mcp/` | Deploys with Musubi; Kong-fronts it |
 | MCP local stdio plugin *(if ever built)* | Python | `packages/musubi-mcp-stdio/` *(future subpackage)* | `pip install musubi-mcp-stdio` on agent host |

--- a/docs/Musubi/_slices/slice-api-app-bootstrap.md
+++ b/docs/Musubi/_slices/slice-api-app-bootstrap.md
@@ -68,7 +68,7 @@ All done:
 - `test_artifact_upload_multipart_then_retrieve_blob` (bullet 12)
 
 Also unblocks:
-- **First real deploy on musubi.mey.house** — can't deploy a server that 500s on first request.
+- **First real deploy on musubi.example.local** — can't deploy a server that 500s on first request.
 - **POC → v1 migration** — migrator writes via the API; can't write to a non-functional API.
 - **OpenClaw v0.1 integration** — same reason.
 

--- a/docs/Musubi/_slices/slice-lifecycle-synthesis-builder.md
+++ b/docs/Musubi/_slices/slice-lifecycle-synthesis-builder.md
@@ -87,8 +87,8 @@ Plus:
 - [x] `python -m musubi.lifecycle.runner` logs `lifecycle-job-dispatch
       name=synthesis` at the next `03:00` cron window. *(Verified in
       unit tests — `test_build_lifecycle_jobs_wires_synthesis_builders`.
-      Production cron-fire awaits the next deploy to musubi.mey.house.)*
-- [ ] Against `musubi.mey.house`, a forced run produces a
+      Production cron-fire awaits the next deploy to musubi.example.local.)*
+- [ ] Against `musubi.example.local`, a forced run produces a
       `SynthesisReport` with `concepts_created > 0` or
       `contradictions_detected > 0` when synthetic data is present.
       *(Deferred to the end-to-end deploy step after merge.)*

--- a/docs/Musubi/_slices/slice-ops-ansible.md
+++ b/docs/Musubi/_slices/slice-ops-ansible.md
@@ -25,22 +25,22 @@ blocks: ["[[_slices/slice-ops-backup]]", "[[_slices/slice-ops-compose]]", "[[_sl
 
 ## Owned paths (you MAY write here)
 
-  - `deploy/ansible/`
+ - `deploy/ansible/`
 
 ## Forbidden paths (you MUST NOT write here — open a cross-slice ticket if needed)
 
-  - `musubi/`
+ - `musubi/`
 
 ## Depends on
 
-  - _(no upstream slices)_
+ - _(no upstream slices)_
 
 Start this slice only after every upstream slice has `status: done`.
 
 ## Unblocks
 
-  - [[_slices/slice-ops-observability]]
-  - [[_slices/slice-ops-backup]]
+ - [[_slices/slice-ops-observability]]
+ - [[_slices/slice-ops-backup]]
 
 ## Definition of Done
 

--- a/docs/Musubi/_slices/slice-ops-backup.md
+++ b/docs/Musubi/_slices/slice-ops-backup.md
@@ -26,22 +26,22 @@ blocks: ["[[_slices/slice-ops-first-deploy]]"]
 
 ## Owned paths (you MAY write here)
 
-  - `deploy/backup/`
-  - `musubi/ops/backup.py`
+ - `deploy/backup/`
+ - `musubi/ops/backup.py`
 
 ## Forbidden paths (you MUST NOT write here — open a cross-slice ticket if needed)
 
-  - `musubi/planes/`
+ - `musubi/planes/`
 
 ## Depends on
 
-  - [[_slices/slice-ops-ansible]]
+ - [[_slices/slice-ops-ansible]]
 
 Start this slice only after every upstream slice has `status: done`.
 
 ## Unblocks
 
-  - _(no downstream slices)_
+ - _(no downstream slices)_
 
 ## Definition of Done
 

--- a/docs/Musubi/_slices/slice-ops-core-image-publish.md
+++ b/docs/Musubi/_slices/slice-ops-core-image-publish.md
@@ -16,7 +16,7 @@ blocks: ["[[_slices/slice-ops-update-workflow]]"]
 # Slice: Publish musubi-core to GHCR via CI
 
 > Replace the one-time `docker save | ssh | docker load` transfer that
-> brought Musubi Core onto `musubi.mey.house` with a GitHub Actions
+> brought Musubi Core onto `musubi.example.local` with a GitHub Actions
 > workflow that builds and publishes `ghcr.io/ericmey/musubi-core` on
 > every tag (and optionally on every merge to `v2`), so any host can
 > `docker pull` the image by digest.
@@ -27,7 +27,7 @@ blocks: ["[[_slices/slice-ops-update-workflow]]"]
 
 The first deploy on 2026-04-20 built the Musubi Core image locally on
 Eric's Mac (`docker buildx build --platform linux/amd64`), then
-transferred it to `musubi.mey.house` via a `docker save | ssh | docker
+transferred it to `musubi.example.local` via a `docker save | ssh | docker
 load` pipe. That worked for the single-host first-deploy but creates three
 problems as soon as we leave that narrow path:
 
@@ -102,7 +102,7 @@ trailer (see Cross-slice tickets below). -->
 - [[_slices/slice-ops-update-workflow]] — needs a real registry source
   to pull from; it can't upgrade an image that only lives on one Mac.
 - **Fresh-host provisioning.** Once the image is on GHCR, a new
-  `musubi.mey.house` replacement host can run `bootstrap.yml` +
+  `musubi.example.local` replacement host can run `bootstrap.yml` +
   `deploy.yml` end-to-end without any manual image transfer.
 - **Rollback on-deploy.** A digest pin means the runbook's "rollback"
   step can be "pin the prior digest and re-run deploy.yml" — currently
@@ -199,7 +199,7 @@ Plus slice-specific:
       `ghcr.io/ericmey/musubi-core` with the expected tag + digest.
 - [ ] `group_vars/all.yml` flipped from the local-build tag to a
       digest-pinned GHCR reference.
-- [ ] `ansible-playbook deploy.yml` run against `musubi.mey.house`
+- [ ] `ansible-playbook deploy.yml` run against `musubi.example.local`
       pulls from GHCR successfully (no `docker save | ssh` needed).
       Recorded in `[[00-index/work-log]]`.
 - [ ] Runbook updated to reflect the new pre-deploy image-publish

--- a/docs/Musubi/_slices/slice-ops-first-deploy.md
+++ b/docs/Musubi/_slices/slice-ops-first-deploy.md
@@ -15,7 +15,7 @@ blocks: ["[[_slices/slice-ops-core-image-publish]]"]
 
 # Slice: First-deploy runbook + validation
 
-> Authors the step-by-step first-deploy procedure for `musubi.mey.house`, the systemd units + Kong config stitching the shipped Ansible/compose/backup/observability work together, and the post-deploy smoke + verify scripts. Ships the operator runbook; operator (Eric) executes the deploy with the runbook open.
+> Authors the step-by-step first-deploy procedure for `musubi.example.local`, the systemd units + Kong config stitching the shipped Ansible/compose/backup/observability work together, and the post-deploy smoke + verify scripts. Ships the operator runbook; operator (Eric) executes the deploy with the runbook open.
 
 **Phase:** 8 Ops · **Status:** `done` · **Owner:** `codex-gpt5`
 
@@ -28,7 +28,7 @@ The four foundational ops slices are shipped:
 - `slice-ops-backup` — backup/restore scripts
 - `slice-ops-observability` — metrics + logs + traces instrumentation + dashboards
 
-What's missing: **the authored procedure that binds them into a single "go live on musubi.mey.house" sequence.** Without this slice, the operator (Eric) has to stitch ansible + compose + DNS + Kong + certs + systemd + smoke-verify from memory each time. The first real deploy needs a deterministic, ordered, resumable runbook.
+What's missing: **the authored procedure that binds them into a single "go live on musubi.example.local" sequence.** Without this slice, the operator (Eric) has to stitch ansible + compose + DNS + Kong + certs + systemd + smoke-verify from memory each time. The first real deploy needs a deterministic, ordered, resumable runbook.
 
 This slice does NOT execute the deploy — Eric does that. This slice ships the **runbook + scripts + systemd units + verification harness** so Eric can pull the trigger with confidence.
 
@@ -40,30 +40,30 @@ This slice does NOT execute the deploy — Eric does that. This slice ships the 
 
 ## Owned paths (you MAY write here)
 
-- `deploy/runbooks/first-deploy.md`                  (new — the authored step-by-step procedure)
-- `deploy/systemd/`                                  (new — unit files for api, lifecycle-worker, vault-sync)
-- `deploy/smoke/`                                    (new — post-deploy verification scripts)
-- `deploy/kong/`                                     (parent done in ops-compose — extend with route stubs for prod)
-- `tests/ops/test_first_deploy_smoke.py`             (new — unit tests for smoke scripts)
-- `docs/Musubi/09-operations/runbooks.md`      (parent done — add first-deploy cross-link)
+- `deploy/runbooks/first-deploy.md` (new — the authored step-by-step procedure)
+- `deploy/systemd/` (new — unit files for api, lifecycle-worker, vault-sync)
+- `deploy/smoke/` (new — post-deploy verification scripts)
+- `deploy/kong/` (parent done in ops-compose — extend with route stubs for prod)
+- `tests/ops/test_first_deploy_smoke.py` (new — unit tests for smoke scripts)
+- `docs/Musubi/09-operations/runbooks.md` (parent done — add first-deploy cross-link)
 
 ## Forbidden paths (you MUST NOT write here — open a cross-slice ticket if needed)
 
-- `src/musubi/`                   (no code changes; this is deploy orchestration)
-- `docs/Musubi/07-interfaces/`  (API contract)
+- `src/musubi/` (no code changes; this is deploy orchestration)
+- `docs/Musubi/07-interfaces/` (API contract)
 - `openapi.yaml`, `proto/`
-- `.github/workflows/`            (CI is not deploy; separate concern)
+- `.github/workflows/` (CI is not deploy; separate concern)
 
 ## Depends on
 
-- [[_slices/slice-ops-ansible]]          (done — playbooks authored)
-- [[_slices/slice-ops-compose]]          (done — compose stack authored)
-- [[_slices/slice-ops-backup]]           (done — backup strategy authored)
-- [[_slices/slice-ops-observability]]    (done — health-probe endpoints wired)
+- [[_slices/slice-ops-ansible]] (done — playbooks authored)
+- [[_slices/slice-ops-compose]] (done — compose stack authored)
+- [[_slices/slice-ops-backup]] (done — backup strategy authored)
+- [[_slices/slice-ops-observability]] (done — health-probe endpoints wired)
 
 ## Unblocks
 
-- **First real deploy to `musubi.mey.house`** — Eric executes the runbook; this slice ships the procedure.
+- **First real deploy to `musubi.example.local`** — Eric executes the runbook; this slice ships the procedure.
 - **POC → v1 migration execution** — migration (#109) needs a running target Musubi; this slice makes v1 runnable.
 - **OpenClaw v0.1 integration test** — Aoi's client needs a real Musubi endpoint to hit; this slice gets one running.
 - **All Phase 2 activities** — perf baselines, load tests, chaos scenarios — all need a running deployed instance.
@@ -74,8 +74,8 @@ This slice does NOT execute the deploy — Eric does that. This slice ships the 
 
 Step-by-step operator procedure. Structure:
 
-1. **Pre-flight** — DNS A record for musubi.mey.house pointing at 10.0.20.45; operator has SSH access; ansible control node at 10.0.20.53 (yua) has the musubi repo cloned; secrets materialized per `.env.example`.
-2. **Snapshot target host** — ZFS snapshot / system-image backup of musubi.mey.house before first boot.
+1. **Pre-flight** — DNS A record for musubi.example.local pointing at 10.0.0.45; operator has SSH access; ansible control node at 10.0.0.53 (the control host) has the musubi repo cloned; secrets materialized per `.env.example`.
+2. **Snapshot target host** — ZFS snapshot / system-image backup of musubi.example.local before first boot.
 3. **Run ansible playbook** — `ansible-playbook deploy/ansible/site.yml -i inventory/prod.yml`. Expected output. Failure modes + recovery.
 4. **Bring up compose stack** — `docker compose -f docker-compose.yml up -d`. Health-gate on Qdrant + TEI + Ollama ready.
 5. **Install systemd units** — `deploy/systemd/*.service` placed at /etc/systemd/system/; enable + start.
@@ -127,7 +127,7 @@ Plus slice-specific:
 
 - [ ] `deploy/runbooks/first-deploy.md` is complete + reviewable in one sitting (<2k lines).
 - [ ] Every numbered step in the runbook has command, expected output, failure-mode guidance.
-- [ ] Systemd units install cleanly on a Ubuntu 24.04 VM (dry-run test — a VM on harem-001 is fine; doesn't need the real box).
+- [ ] Systemd units install cleanly on a Ubuntu 24.04 VM (dry-run test — a VM on workload-001 is fine; doesn't need the real box).
 - [ ] Smoke scripts unit-tested via `tests/ops/test_first_deploy_smoke.py` against mocked Musubi responses.
 - [ ] Kong config is declarative (decK) + example-documented per endpoint family.
 - [ ] Rollback procedure is documented + tested against the VM dry-run target.
@@ -136,7 +136,7 @@ Plus slice-specific:
 
 **Explicitly NOT in scope** (and Codex should NOT do these — these are Eric's operator work):
 
-- Executing the actual first deploy on `musubi.mey.house`.
+- Executing the actual first deploy on `musubi.example.local`.
 - Registering the OAuth client with whatever identity provider Eric chooses.
 - Obtaining real TLS certificates.
 - Configuring the DNS A record.
@@ -225,8 +225,8 @@ The playbooks shipped in PR #121 were not executed end-to-end against a real
 host at merge time. Tonight's deploy session did that; several real bugs
 surfaced and were fixed in follow-up PRs. All fixes are on `v2`.
 
-**Outcome:** full Musubi compose stack is live on `musubi.mey.house`. All six
-services healthy. `curl http://10.0.20.45:8100/v1/ops/health →
+**Outcome:** full Musubi compose stack is live on `musubi.example.local`. All six
+services healthy. `curl http://10.0.0.45:8100/v1/ops/health →
 {"status":"ok","version":"v0"}`. See [[00-index/work-log]] 2026-04-20 entry
 for the full ledger.
 
@@ -234,40 +234,40 @@ for the full ledger.
 no end-to-end run had ever happened):**
 
 1. [PR #146] Inventory hard-coded `<placeholder>` literals; replaced with
-   `{{ jinja_vars }}` + added `setup-control-host.sh` for yua.
+ `{{ jinja_vars }}` + added `setup-control-host.sh` for the control host.
 2. [PR #147] `bootstrap.yml` couldn't install `docker-ce` without first
-   adding Docker's apt repo. Same for `nvidia-container-toolkit`. The pinned
-   `nvidia-driver-560-server` would have downgraded the 580.126.20 on the
-   target host. Added pre-tasks for both repos + an idempotent driver probe.
+ adding Docker's apt repo. Same for `nvidia-container-toolkit`. The pinned
+ `nvidia-driver-560-server` would have downgraded the 580.126.20 on the
+ target host. Added pre-tasks for both repos + an idempotent driver probe.
 3. [PR #148] Musubi Core had no `Dockerfile` in the repo (compose referenced
-   `ghcr.io/example/musubi-core@sha256:<core-digest>` — no such image). Wrote
-   the Dockerfile. Rewrote `.env.production.j2` to match `settings.py` (was
-   ~half missing + wrong field names). TEI image tag `1.5-cuda` doesn't
-   exist on GHCR → correct form is `86-1.2.0` (Ampere compute-8.6). TEI
-   `--pooling rerank` not a valid value; rerankers auto-detect. All health-
-   checks moved off `curl` to `bash /dev/tcp` / `ollama list` (minimal
-   images have no curl). Ollama healthcheck decoupled from model-pull state
-   (would deadlock otherwise). `MUSUBI_ALLOW_PLAINTEXT=true` set so Core
-   can talk plain HTTP to in-bridge Qdrant.
+ `ghcr.io/example/musubi-core@sha256:<core-digest>` — no such image). Wrote
+ the Dockerfile. Rewrote `.env.production.j2` to match `settings.py` (was
+ ~half missing + wrong field names). TEI image tag `1.5-cuda` doesn't
+ exist on GHCR → correct form is `86-1.2.0` (Ampere compute-8.6). TEI
+ `--pooling rerank` not a valid value; rerankers auto-detect. All health-
+ checks moved off `curl` to `bash /dev/tcp` / `ollama list` (minimal
+ images have no curl). Ollama healthcheck decoupled from model-pull state
+ (would deadlock otherwise). `MUSUBI_ALLOW_PLAINTEXT=true` set so Core
+ can talk plain HTTP to in-bridge Qdrant.
 
 **Operator-only one-time steps** (outside the playbooks; captured in
 `.agent-context.local.md` so they reproduce):
 
 - Native Qdrant / Ollama / Open WebUI purged before first run.
 - HF cache rsynced into `/var/lib/musubi/tei-models/` so SPLADE v3 loads
-  from local cache (HF-gated; would 401).
-- yua's deploy key added to `ericmey/musubi` on GitHub.
+ from local cache (HF-gated; would 401).
+- the control host's deploy key added to `ericmey/musubi` on GitHub.
 
 **What the slice's Test Contract did NOT catch** (follow-up for the
 post-incident review):
 
 - Structural tests of the runbook/systemd/smoke/Kong files passed in CI
-  but no test actually ran `ansible-playbook` against a real (or
-  containerised-real) target. That's why the repo-missing, env-template-
-  wrong, TEI-tag-invalid, curl-missing problems all landed as production
-  bugs instead of CI failures. A `tests/ops/test_compose_boots.py` that
-  stands the stack up in a nested VM or on a self-hosted runner would have
-  caught most of these.
+ but no test actually ran `ansible-playbook` against a real (or
+ containerised-real) target. That's why the repo-missing, env-template-
+ wrong, TEI-tag-invalid, curl-missing problems all landed as production
+ bugs instead of CI failures. A `tests/ops/test_compose_boots.py` that
+ stands the stack up in a nested VM or on a self-hosted runner would have
+ caught most of these.
 
 ## PR links
 

--- a/docs/Musubi/_slices/slice-ops-update-workflow.md
+++ b/docs/Musubi/_slices/slice-ops-update-workflow.md
@@ -196,14 +196,14 @@ Operator procedure. Structure mirrors `first-deploy.md`:
    confirm a `qdrant`/`tei`/`ollama` version bump is in `group_vars`.
 2. **Bump the pin** — commit `musubi_core_image` (or other image) to
    the new `@sha256:<digest>` in `group_vars/all.yml`; push; pull on
-   yua. (A future PR could automate this via Dependabot/Renovate.)
-3. **Dry-run** — `ansible-playbook update.yml --check --diff` from yua
+   the control host. (A future PR could automate this via Dependabot/Renovate.)
+3. **Dry-run** — `ansible-playbook update.yml --check --diff` from the control host
    against musubi. Expected output: the compose-up task shows the
    image change + which containers will recreate.
 4. **Apply** — `ansible-playbook update.yml` without `--check`.
 5. **Verify** — `deploy/smoke/verify.sh` round-trip; `/var/log/musubi/
    upgrade-history.jsonl` has a new entry.
-6. **Rollback** — revert the `group_vars` commit; push; pull on yua;
+6. **Rollback** — revert the `group_vars` commit; push; pull on the control host;
    re-run `update.yml`. Operator decision: a dedicated `--rollback`
    flag is out of scope for this slice (keep the revert-and-rerun
    pattern until a real rollback story is needed).
@@ -239,13 +239,13 @@ didn't work).
 Plus slice-specific:
 
 - [ ] `ansible-playbook --syntax-check update.yml` passes.
-- [ ] `--check --diff` against the live `musubi.mey.house` (before the
+- [ ] `--check --diff` against the live `musubi.example.local` (before the
       pin bump) shows zero changes (idempotent no-op on an up-to-date
       stack).
 - [ ] After a scratch `musubi_core_image` bump, `--check --diff` shows
       exactly one image pull + one container recreate, no unrelated
       churn.
-- [ ] Real apply against `musubi.mey.house` recreates Core cleanly;
+- [ ] Real apply against `musubi.example.local` recreates Core cleanly;
       `/v1/ops/health` returns 200 post-apply;
       `upgrade-history.jsonl` has a new entry.
 - [ ] `deploy/runbooks/upgrade.md` reads top-to-bottom as an operator

--- a/docs/Musubi/_slices/slice-poc-data-migration.md
+++ b/docs/Musubi/_slices/slice-poc-data-migration.md
@@ -21,17 +21,17 @@ blocks: []
 
 ## Why this slice exists
 
-Musubi v1 ships with a clean-slate Qdrant schema per the per-plane data-model specs in `docs/Musubi/04-data-model/` + `src/musubi/store/specs.py`. Eric's POC is currently running on `nyla.mey.house` (10.0.20.25) with its own memory store. Before v1 is operationally useful as a memory system for Eric's agent fleet, the POC's accumulated memory has to migrate into the v1 layout on `musubi.mey.house`.
+Musubi v1 ships with a clean-slate Qdrant schema per the per-plane data-model specs in `docs/Musubi/04-data-model/` + `src/musubi/store/specs.py`. Eric's POC is currently running on `control.example.local` (10.0.0.25) with its own memory store. Before v1 is operationally useful as a memory system for Eric's agent fleet, the POC's accumulated memory has to migrate into the v1 layout on `musubi.example.local`.
 
 ## Source: confirmed
 
-**Source host:** `nyla.mey.house` (10.0.20.25 — bare-metal Ubuntu server).
+**Source host:** `control.example.local` (10.0.0.25 — bare-metal Ubuntu server).
 
 **Source is a running POC service** on that host. The "Nyla" coding agent (Gemini 3.1 Pro) runs on the same machine, which means it can introspect the live POC directly: `ps`, `systemctl`, config files, whatever storage backend the POC uses (Qdrant collections, SQLite, JSONL on disk — TBD at claim time).
 
 **Routing:** this slice is best claimed by the **Nyla coding agent**. Any other agent would need Eric to proxy the POC source data over the network.
 
-**Format: discover at claim time.** First substantive commit on the branch is a **discovery commit**: Nyla walks the running POC on `nyla.mey.house`, identifies the storage shape (inspecting the running process, its config, its open file descriptors, and whatever HTTP / gRPC / socket it exposes), writes findings into this slice file's work log via `docs(slice): POC discovery on nyla.mey.house`, and lands a `spec-update:` trailer to `11-migration/phase-1-schema.md` with the confirmed source shape. Only AFTER discovery does the migration script start.
+**Format: discover at claim time.** First substantive commit on the branch is a **discovery commit**: Nyla walks the running POC on `control.example.local`, identifies the storage shape (inspecting the running process, its config, its open file descriptors, and whatever HTTP / gRPC / socket it exposes), writes findings into this slice file's work log via `docs(slice): POC discovery on control.example.local`, and lands a `spec-update:` trailer to `11-migration/phase-1-schema.md` with the confirmed source shape. Only AFTER discovery does the migration script start.
 
 **Discovery surfaces (unknowns at carve time):**
 - Which planes have POC data (episodic, curated, concept, artifact, thoughts — any subset).
@@ -65,14 +65,14 @@ Design notes below assume the most likely case — Qdrant-on-nyla to Qdrant-on-m
 
 ## Unblocks
 
-- **First real deploy** — `musubi.mey.house` becomes useful for Eric's daily agent use once his POC memories land.
+- **First real deploy** — `musubi.example.local` becomes useful for Eric's daily agent use once his POC memories land.
 - **Acceptance testing** — "does v1 actually share memory better than POC?" can't be answered with an empty v1.
 
 ## Design notes (working assumptions — confirm at claim time)
 
 **Assumed shape: Qdrant-to-Qdrant migration.**
 
-1. **Connect to POC source** (Qdrant instance) + **target** (v1 Qdrant on musubi.mey.house).
+1. **Connect to POC source** (Qdrant instance) + **target** (v1 Qdrant on musubi.example.local).
 2. **Enumerate source collections.** Expected names: `musubi_episodic_v0`, `musubi_curated_v0`, etc.; adjust if different.
 3. **For each source row:**
    a. Parse payload into v0 schema.
@@ -127,9 +127,9 @@ Plus slice-specific:
 - Encountered a limitation: `MusubiClient` does not have a backdoor for `created_at` or custom fields (rejected by `CaptureRequest`). Since modifying the `api` or `sdk` paths is forbidden, I opened `_inbox/cross-slice/migrator-needs-created-at-override.md` and skipped the `test_migrator_preserves_created_at_on_target` test until the cross-slice API/SDK changes land.
 - PR #128 is ready for review.
 
-### 2026-04-20 01:30 — gemini-3-1-pro-nyla — POC discovery on nyla.mey.house
+### 2026-04-20 01:30 — gemini-3-1-pro-nyla — POC discovery on control.example.local
 
-- Looked into `nyla.mey.house` local instance. OpenClaw memory exists at `~/.openclaw/memory/` but that's just its client-side cache.
+- Looked into `control.example.local` local instance. OpenClaw memory exists at `~/.openclaw/memory/` but that's just its client-side cache.
 - Found the actual Musubi POC at `~/.openclaw/musubi/` running via an MCP `FastMCP` server (`musubi/server.py`).
 - The storage backend is **Qdrant**, running in a Docker container on port 6333 (`musubi-qdrant`).
 - Volume: small (167 memories, 57 thoughts).
@@ -137,17 +137,17 @@ Plus slice-specific:
   - `musubi_memories` (payload: `content`, `type`, `agent`, `tags`, `context`, `created_at`, `access_count`)
   - `musubi_thoughts` (payload: `content`, `from_presence`, `to_presence`, `read`, `read_by`, `created_at`)
 - IDs are standard UUID v4 strings, not ULIDs or KSUIDs.
-- Migration will just read from localhost:6333, map payloads, generate deterministic KSUIDs from UUIDs or created_at epochs, and write to `musubi.mey.house` via the SDK.
+- Migration will just read from localhost:6333, map payloads, generate deterministic KSUIDs from UUIDs or created_at epochs, and write to `musubi.example.local` via the SDK.
 
 ### 2026-04-20 01:25 — gemini-3-1-pro-nyla — claim
 
-- Claimed slice #109. Proceeding with discovery phase to inspect the local `nyla.mey.house` environment to ascertain the actual POC storage backend.
+- Claimed slice #109. Proceeding with discovery phase to inspect the local `control.example.local` environment to ascertain the actual POC storage backend.
 
 ### 2026-04-19 — operator — slice carved
 
 - Phase 2 critical path per tonight's roadmap discussion with Eric.
 - **Implementing agent MUST confirm POC source shape with operator at claim time** — see ⚠ operator-decision block above. The slice file's design notes are working assumptions, not confirmed.
-- Targets the first-real-deploy moment on `musubi.mey.house`; v1 isn't operationally useful without migrated data.
+- Targets the first-real-deploy moment on `musubi.example.local`; v1 isn't operationally useful without migrated data.
 
 ## Cross-slice tickets opened by this slice
 

--- a/src/musubi/settings.py
+++ b/src/musubi/settings.py
@@ -125,7 +125,7 @@ class Settings(BaseSettings):
         default=AnyHttpUrl("http://localhost:8100/v1"),
         description="URL of the Musubi API the MCP server should call. "
         "Defaults to localhost when the MCP server runs on the same host "
-        "as Musubi Core (the typical `mcp.musubi.mey.house` deployment).",
+        "as Musubi Core (the typical `mcp.musubi.example.local` deployment).",
     )
     musubi_token: SecretStr = Field(
         default=SecretStr(""),

--- a/uv.lock
+++ b/uv.lock
@@ -732,7 +732,7 @@ wheels = [
 
 [[package]]
 name = "musubi"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
No tracking Issue: pre-public-release hygiene pass.

## Summary
Replaces internal hostnames + IPs across 36 files with placeholder values from the `<musubi-host> / <musubi-ip> / <ansible-host>` vocabulary the operator context already defines. Zero functional change; all 1143 tests still pass.

## Replacement map
| From | To |
|---|---|
| \`*.mey.house\` | \`*.example.local\` |
| \`10.0.20.{25,45,50,53}\` | \`10.0.0.{25,45,50,53}\` |
| \`10.0.20.0/24\` | \`10.0.0.0/24\` |
| \`musubi.internal\` | \`musubi.example.local\` |
| \`harem-001/002\` | \`workload-001/002\` |
| \`yua\` (control host) | "the control host" / \`<ansible-host>\` |

## Intentionally preserved
- \`yua-cowork\` / \`nyla-*\` as fictional example agent-IDs in the PR template + skill docs.
- \`harem.world\` (the genuinely public domain) — untouched.
- Real values continue to live in the gitignored \`.agent-context.local.md\`.

## Follow-up flagged, not blocking
The single example hostname in \`src/musubi/settings.py:128\` is in a docstring. A proper fix is a Settings field with an env-backed default; deferred to v1 polish.

## What this does NOT do
- History rewrite. Older commits still contain the real hostnames + the \`ericmey@nyla.mey.house\` author email on the initial commit. Phase 2 (\`git filter-repo --replace-text\` + \`--mailmap\` + force-push) is a separate operation to run after this lands and before flipping the repo visibility to Public.

## Test plan
- [x] \`make check\` → 1143 passed / 231 skipped (unchanged vs. pre-scrub).
- [x] \`git grep\` sweep for \`mey.house | harem-00[12] | 10.0.20.(25|45|50|53) | musubi.internal\` returns no matches (outside CHANGELOG.md which is auto-regenerated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)