### PR TITLE
chore(repo): public-repo hygiene — LICENSE, SECURITY, CONTRIBUTING, CoC, README rewrite

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,87 @@
+name: 🐛 Bug report
+description: Something is broken or misbehaving in Musubi core, the SDK, an adapter, or the deployment.
+title: "bug: <short description>"
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug report. Please fill in what you can — a clear, reproducible bug gets fixed much faster than a vague one.
+
+        **Security-related bugs do NOT go here.** If you've found a vulnerability, use [GitHub's private vulnerability reporting](https://github.com/ericmey/musubi/security/advisories/new) instead. See [SECURITY.md](https://github.com/ericmey/musubi/blob/main/SECURITY.md).
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences describing the bug.
+      placeholder: "Maturation sweep fails with ValidationError on items missing `updated_epoch`."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How to reproduce
+      description: Minimal steps. A code snippet or command is ideal.
+      placeholder: |
+        1. Start a fresh stack via `ansible-playbook deploy/ansible/deploy.yml`.
+        2. POST an episodic capture that omits `topics`.
+        3. Wait for the next maturation tick (hourly at :13 UTC).
+        4. Check `docker logs musubi-lifecycle-worker-1` — see the ValidationError.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What happened instead? Paste the stack trace or error message if there is one.
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Musubi version
+      description: "`docker exec musubi-core-1 python -c 'import musubi; print(musubi.__version__)'` or your git SHA."
+      placeholder: "v0.3.0 / commit <sha>"
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Python version, Qdrant / TEI / Ollama versions if relevant, GPU / CPU-only, Docker / Compose / Ansible deploy.
+      placeholder: |
+        - OS: Ubuntu 24.04
+        - Python: 3.12.7
+        - Deploy: Docker Compose via deploy/ansible/deploy.yml
+        - GPU: RTX 3080 (CUDA 12.4) / or CPU-only
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Relevant log lines — from `docker logs`, the ansible playbook, or wherever. Redact any secrets first.
+      render: shell
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing issues and haven't found a duplicate.
+          required: true
+        - label: This is not a security vulnerability (if it is, I'll use the private reporting channel instead).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Discussions
+    url: https://github.com/ericmey/musubi/discussions
+    about: For design questions, architecture discussions, "how do I…" and anything that isn't a bug report or a concrete feature request.
+  - name: 🔒 Security vulnerability
+    url: https://github.com/ericmey/musubi/security/advisories/new
+    about: Do not open a public issue. Use GitHub's private vulnerability reporting — see SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,66 @@
+name: 💡 Feature request
+description: Suggest a new capability for Musubi core, the SDK, an adapter, or the deployment tooling.
+title: "feat: <short description>"
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Musubi is a personal project with a deliberate scope. Feature requests are welcome but won't automatically be accepted — the bar is: the idea fits the three-plane / lifecycle-engine architecture, and either you or someone else is willing to write the slice spec and the implementation.
+
+        For open-ended "what if…" ideas, please start a [Discussion](https://github.com/ericmey/musubi/discussions) instead.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What are you trying to do? What's stopping you today?
+      placeholder: "When running multiple adapters (MCP + LiveKit) on the same deploy, I can't tell which presence originated a thought from the thought's payload alone."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: A concrete sketch of what you'd like to see. API shape, schema change, configuration knob, etc.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches and why you didn't pick them.
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Which module(s) would this touch? Would it be additive or a breaking change? Does it need a new slice spec?
+      placeholder: |
+        - Adds a `source_adapter` field to `Thought`.
+        - Touches `src/musubi/types/thought.py`, `src/musubi/planes/thoughts/plane.py`, the canonical OpenAPI.
+        - Breaking schema change — requires a version bump + ADR.
+
+  - type: dropdown
+    id: willing_to_implement
+    attributes:
+      label: Implementation willingness
+      description: Would you be open to writing the slice yourself, or are you asking someone else to pick it up?
+      options:
+        - "Yes, I'd like to implement this."
+        - "Maybe — depends on complexity / feedback."
+        - "No, I'm only proposing the idea."
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing issues and discussions for a similar request.
+          required: true
+        - label: I've read [CONTRIBUTING.md](https://github.com/ericmey/musubi/blob/main/CONTRIBUTING.md) and understand that outside features require alignment before implementation.
+          required: true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,23 @@
+# Code of Conduct
+
+Musubi adopts the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as its code of conduct. The full text is canonical and hosted upstream; the summary below is for convenience.
+
+## The short version
+
+Participating in this project — as a contributor, reviewer, issue reporter, or any other role — commits you to fostering an open, welcoming, and harassment-free environment for everyone. Treat people with respect. Assume good faith. Disagree on the merits, not the person.
+
+Unacceptable behaviour is defined by the Contributor Covenant and will not be tolerated here. The full list is in the linked text.
+
+## Enforcement
+
+Reports of unacceptable behaviour can be sent to **`ericmey@gmail.com`** with subject prefix `[musubi-coc]`. Reports are reviewed by the project maintainer and handled confidentially. Action taken may range from a warning to a permanent ban from project spaces, proportional to the incident.
+
+If the incident involves the maintainer, or you would prefer a neutral escalation path, please use GitHub's [abuse-report tool](https://support.github.com/contact/report-abuse).
+
+## Scope
+
+This code applies to all project spaces — the repository, issues, pull requests, discussions (once enabled), the wiki, and any off-platform interactions explicitly about Musubi (e.g., a conference talk, a Discord channel tagged `musubi`, etc.).
+
+## Attribution
+
+Adapted from the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/), available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,128 @@
+# Contributing to Musubi
+
+First — thank you for even considering it. This is a personal project that I've opened up for others to follow, fork, and build on; outside contributions aren't required for the project to move forward, but they're genuinely welcome when they fit.
+
+## The short version
+
+1. **Open an issue first.** Bug, feature, or question — having a tracked conversation lets us agree on scope before code gets written.
+2. **One slice per PR.** Small, reviewable diffs. See [Slices](#slices) below.
+3. **Tests first, implementation second.** Every module has a Test Contract; your PR's first commit should be the test file.
+4. **`make check` must pass.** Format, lint, type-check, and full test suite.
+5. **Conventional commits.** The release automation reads them.
+
+Everything else expands on these.
+
+## Before you start
+
+Please read the top of [CLAUDE.md](CLAUDE.md) (for AI agents) or this file's sibling [AGENTS.md](AGENTS.md) (same content; different filename so tools like Claude Code, Cursor, Aider, and Codex all find their canonical config). These capture the non-negotiable rules:
+
+1. **Stay inside your slice.** The slice file in [`docs/Musubi/_slices/`](docs/Musubi/_slices/) declares which paths a slice may write; violating that turns a review into a merge-conflict.
+2. **The canonical API is frozen per version.** Additive changes require an ADR; breaking changes bump the major.
+3. **Tests first.** Period.
+4. **Don't silently rebase the spec.** If your implementation forces a spec change, update the spec file in the same PR and tag the commit with a `spec-update:` trailer.
+
+Full text: [`docs/Musubi/00-index/agent-guardrails.md`](docs/Musubi/00-index/agent-guardrails.md).
+
+## Dev setup
+
+```bash
+# Prerequisites: Python 3.12 + uv (https://docs.astral.sh/uv/)
+
+make install           # uv sync --extra dev
+make fmt               # ruff format
+make lint              # ruff check
+make typecheck         # mypy --strict
+make test              # pytest + coverage (unit)
+make check             # all of the above — the gate for every PR
+
+# Integration + vault hygiene (slower, optional locally):
+make test-integration
+make agent-check       # vault frontmatter + slice DAG + spec hygiene
+```
+
+## Slices
+
+Musubi is built as a sequence of reviewable "slices" — small, independently-reviewable changes that realise one unit of the architecture. Each slice lives as a markdown file in [`docs/Musubi/_slices/`](docs/Musubi/_slices/) with:
+
+- `owns_paths` — files this slice is allowed to write
+- `forbidden_paths` — files it may not touch
+- a **Test Contract** — pytest functions to be written first; code must make them pass
+
+If your contribution maps to an existing slice spec, great — claim the GitHub Issue tracking it and go. If it doesn't map to an existing slice, open an issue describing the work and the spec will be drafted (or you can draft it yourself; see `_templates/` in the vault).
+
+## Workflow
+
+```bash
+# 1. Claim the issue
+gh issue edit <n> --add-assignee @me \
+  --add-label "status:in-progress" --remove-label "status:ready"
+
+# 2. Branch + draft PR immediately (visibility > speed)
+git switch -c slice/<slice-id>
+gh pr create --draft --base main \
+  --title "<type>(<scope>): <subject>" \
+  --body "Closes #<n>."   # exact keyword; auto-closes the issue on merge
+
+# 3. First commit = the test file
+# 4. Implement, commit, push
+# 5. `make check` must pass locally before flipping the PR ready-for-review
+# 6. Another agent / human reviews — we don't self-approve
+
+# 7. After merge, the slice status flips to done; release-please picks it up
+#    for the next version bump.
+```
+
+## Commit style
+
+Conventional Commits. The `type(scope): subject` shape is parsed by release-please:
+
+- `feat(planes): …` — new capability (minor bump)
+- `fix(ci): …` — bug fix (patch bump)
+- `docs(adr): …` — documentation
+- `chore(deps): …` — build / tooling / non-user-visible
+- `perf(retrieve): …`, `refactor(lifecycle): …`, `test(api): …`
+
+First line ≤ 70 chars. Body explains *why* (not *what* — the diff already shows what).
+
+Include a `spec-update: <path>` trailer when your change also edits a spec file in the vault. Include `Co-Authored-By:` trailers if an AI agent (or another human) materially helped — this isn't a hide-the-agent project.
+
+## Pull request expectations
+
+- **First line of the body** must be `Closes #<issue-number>.` (exact keyword; GitHub only auto-closes on `Closes` / `Fixes` / `Resolves`). For PRs without a tracking issue — chore / CI hotfix / docs — include `No tracking Issue: <one-sentence reason>` so the absence is deliberate.
+- **Design note.** If your PR makes a non-obvious choice (which approach, which tradeoff), describe it. Reviewers shouldn't have to reconstruct the decision from the diff.
+- **Test plan.** Bulleted list of what you verified. If anything is deferred (e.g. an integration test that needs the live image), call it out.
+- **CI must be green** before flipping to ready-for-review. `gh pr checks <n>` locally mirrors the sidebar on github.com.
+
+## Style
+
+- Python: black-compatible via ruff. Strict mypy. Full type hints on every public function.
+- Data: pydantic v2 models for every payload. Dicts only at the Qdrant boundary.
+- Errors: `Result[T, E]` at module boundaries — typed error dataclasses, not raised exceptions.
+- Async vs sync: public surface is async. Internal worker loops can be sync if they don't touch I/O.
+- Logging: structured JSON, one field per concept. No f-strings in log messages. Correlation IDs propagate.
+- **No `print()`.**
+- **Comments explain *why*, not *what*.**
+
+Full style guide: [`docs/Musubi/00-index/conventions.md`](docs/Musubi/00-index/conventions.md).
+
+## Prohibited patterns (automatic revert)
+
+- Silent `time.sleep()` in production code paths — use async waits with timeouts.
+- Environment-variable reads outside of `src/musubi/config.py`.
+- Hardcoded hosts, ports, collection names, or thresholds.
+- `except Exception: pass`.
+- `git push --force` on shared branches.
+- `--no-verify` on commits.
+- Committing anything gitignored (`.env.local`, vault secrets, `.agent-context.local.md`).
+
+## Questions
+
+Not sure where something fits? Open an issue with the `question` label — it's the lowest-cost way to start a conversation. Once [Discussions](https://github.com/ericmey/musubi/discussions) is enabled, longer design conversations move there.
+
+## Code of Conduct
+
+This project operates under a [Code of Conduct](CODE_OF_CONDUCT.md) based on the Contributor Covenant. By contributing you agree to abide by it.
+
+---
+
+Thank you again. Even opening an issue that turns into "nah, that doesn't fit" is a contribution — it sharpens the scope.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,62 +1,143 @@
-# Musubi (結び) — v2
+<p align="center">
+  <h1 align="center">Musubi 結び</h1>
+  <p align="center">
+    <em>Shared memory for a small fleet of AI agents — three planes, local inference, a lifecycle engine that matures raw captures into a human-reviewable knowledge base.</em>
+  </p>
+  <p align="center">
+    <a href="https://github.com/ericmey/musubi/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/ericmey/musubi?sort=semver&color=blue"></a>
+    <a href="https://github.com/ericmey/musubi/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/ericmey/musubi/actions/workflows/ci.yml/badge.svg?branch=main"></a>
+    <a href="https://github.com/ericmey/musubi/actions/workflows/publish-core-image.yml"><img alt="Signed image" src="https://github.com/ericmey/musubi/actions/workflows/publish-core-image.yml/badge.svg?branch=main"></a>
+    <a href="LICENSE"><img alt="License: Apache 2.0" src="https://img.shields.io/badge/license-Apache%202.0-blue"></a>
+    <img alt="Python 3.12" src="https://img.shields.io/badge/python-3.12-blue">
+    <img alt="cosign signed" src="https://img.shields.io/badge/cosign-signed-brightgreen">
+  </p>
+</p>
 
-Shared memory + knowledge plane for a small-team AI agent fleet. Three planes:
-**episodic**, **curated**, **source-artifact**; a bridge layer of **synthesised
-concepts**; a lifecycle engine; a canonical HTTP/gRPC API.
+---
 
-The authoritative design lives in the Obsidian vault at
-`~/Vaults/musubi/`. Start at `00-index/reading-tour.md` or the
-`_slices/` registry.
+Musubi (結び — *"to tie, to join, to bind"*) is a memory server built for the moment when a single AI assistant is not enough: you're running several, each with its own role — one drafts notes, one answers questions, one cleans up the vault at 3am — and they need a shared substrate so that what one learns, the others can use.
 
-This repo is being rebuilt slice-by-slice per that design. The `main` branch
-still holds v1 (the FastMCP + Gemini POC); v2 development happens on this `v2`
-branch and will merge to `main` when it reaches feature parity.
+It is a standalone Python service. Every downstream interface (MCP, LiveKit, a CLI, a browser extension) is an adapter that depends on Musubi's SDK. The core owns the memory model and the API; adapters own the surface.
 
-**Monorepo.** Core, SDK, adapters (MCP, Obsidian plugin, CLI), and lifecycle
-worker all live in this one repo under `src/musubi/`. No per-component repo
-split. See ADR 0015 in the vault.
+## The three planes
+
+```
+  ┌──────────────────────────────────────────────────────────────────────────┐
+  │                            MUSUBI CORE                                   │
+  │                                                                          │
+  │    episodic ──────► concept ──────► curated                              │
+  │    (raw captures)   (synthesized    (human-reviewed                      │
+  │                      themes)         Obsidian notes)                     │
+  │                                                                          │
+  │    + artifact plane (binary blobs — images, audio, pdfs)                 │
+  │    + thoughts plane (pub/sub channel for agent ↔ agent messaging)        │
+  │                                                                          │
+  └──────────────────────────────────────────────────────────────────────────┘
+```
+
+- **Episodic** — every sentence, quote, and observation an agent ingests. Written fast, scored by an LLM for importance, matured to `matured` after a dwell window if no contradictions surface.
+
+- **Concept** — a daily pass clusters mature episodics by shared topic + semantic similarity, asks an LLM to summarise each cluster into a `SynthesizedConcept`, checks for contradictions between concepts, and persists the result. Concepts reinforce (not duplicate) when similar clusters recur.
+
+- **Curated** — concepts that clear a promotion gate (reinforcement count + importance + age) are rendered as markdown and written to an [Obsidian](https://obsidian.md) vault. A human reviewer sees them, edits them, moves them around. Edits flow back into Musubi through the vault sync.
+
+A **lifecycle engine** runs five sweeps on cron: maturation (hourly), synthesis (03:00), promotion (04:00), demotion (05:00, sweep unreinforced rows out), reflection (06:00, writes a daily digest back to the vault). Each sweep is file-locked, idempotent, and emits structured events to a SQLite journal.
+
+## Why not a single RAG index?
+
+One reason: **lifecycle**. A plain vector store keeps everything forever and retrieves by cosine. Musubi's episodic rows expire on a TTL if they aren't matured; mature ones flow up through synthesis; promoted ones become curated rows the human owns. Nothing sits in a "everything I've ever said" bucket — the system makes opinions about what's worth keeping and surfaces them for review.
+
+The other reason: **agent ↔ agent memory**. Thoughts are a first-class message channel — agents can `send` and `subscribe` without a coordinator process. It's not a chat log, it's a shared board of short-lived state.
+
+Design choices are captured as ADRs in [`docs/Musubi/13-decisions/`](docs/Musubi/13-decisions/).
+
+## Stack
+
+- **Python 3.12**, `pydantic v2`, strict `mypy`, `ruff` format + lint.
+- **Qdrant** for named-vector hybrid search (dense + sparse + rerank).
+- **TEI (text-embeddings-inference)** for BGE-M3 dense + SPLADE sparse + BGE-reranker — all GPU-hostable, CPU-fallback OK.
+- **Ollama** for LLM calls (maturation scoring, synthesis, promotion rendering, reflection). Defaults to Qwen 2.5 7B; any Ollama-tagged model works.
+- **FastAPI + HTTPX** HTTP surface; **gRPC** generated from `proto/` (partial). Both exposed on the same port.
+- **Docker Compose** for local / single-box deploy. **Ansible** playbooks for a managed-host rollout (`deploy/ansible/`). Every published image is [cosign](https://github.com/sigstore/cosign)-signed by digest, Trivy-scanned, and ships with a CycloneDX SBOM attestation.
+
+## Try it
+
+```bash
+# 1. Clone
+git clone https://github.com/ericmey/musubi && cd musubi
+
+# 2. Install (Python 3.12 + uv required — https://docs.astral.sh/uv/)
+make install
+
+# 3. Run the local test suite
+make check
+```
+
+A single-box Docker Compose deploy is laid out in [`deploy/ansible/templates/docker-compose.yml.j2`](deploy/ansible/templates/docker-compose.yml.j2); a first-deploy runbook lives at [`deploy/runbooks/upgrade-image.md`](deploy/runbooks/upgrade-image.md). The published image is:
+
+```
+ghcr.io/ericmey/musubi-core:v0.3.0
+```
+
+Verify the signature before pinning in production:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp 'https://github.com/ericmey/musubi/.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/ericmey/musubi-core:v0.3.0
+```
+
+## Repository layout
+
+```
+src/musubi/                 importable package
+  types/                    shared pydantic types — the schema is the contract
+  store/                    Qdrant layout, collection names, vector specs
+  embedding/                TEI client + Embedder protocol + FakeEmbedder
+  planes/                   episodic / concept / curated / artifact / thoughts
+  retrieve/                 scoring, hybrid search, fast/deep paths
+  lifecycle/                maturation / synthesis / promotion / demotion / reflection / runner
+  llm/                      Ollama client + frozen prompt files (per-name versioned)
+  api/                      FastAPI app, OpenAPI, /v1/* routes
+  sdk/                      Python client
+  adapters/                 MCP, LiveKit, OpenClaw (SDK + types only)
+  vault/                    Obsidian watcher + writer + write-log
+  observability/            structured logging + Prometheus metrics
+
+tests/                      mirrors src/musubi/ path-for-path
+docs/Musubi/                the architecture vault (Obsidian) — source of truth for design
+deploy/                     ansible, prometheus, grafana, docker-compose templates
+```
 
 ## Status
 
-| Slice | Status |
-|---|---|
-| `slice-types` (pydantic foundation) | in progress — first cut landed 2026-04-17 (MusubiObject/MemoryObject, the 5 concrete object types + ArtifactRef, LifecycleEvent + transition table, Result[T, E]; 110 tests passing) |
-| everything downstream | waiting for slice-types to mark `done` |
+**v0.3.0** (released 2026-04-21) — the first public release. Feature-complete for:
 
-## Dev setup
+- ✅ All five lifecycle sweeps running in production (maturation, synthesis, promotion, demotion, reflection)
+- ✅ Hybrid retrieval (dense BGE-M3 + sparse SPLADE + BGE-reranker)
+- ✅ Full HTTP/gRPC API surface
+- ✅ MCP + LiveKit adapter first cuts
+- ✅ Supply-chain: cosign + SBOM + Trivy on every published image
+- ✅ Homelab deployment wired, containers healthy
 
-Requires **Python 3.12** and [**uv**](https://docs.astral.sh/uv/).
+Not yet:
+- ⏳ Fleet orchestration (V2 runs single-node today; multi-node is post-v1.0)
+- ⏳ Auto-deploy pipeline
+- ⏳ OpenClaw adapter integration tests
 
-```bash
-make install        # uv sync --extra dev
-make check          # fmt + lint + typecheck + test
-```
+Roadmap detail lives in [`docs/Musubi/12-roadmap/`](docs/Musubi/12-roadmap/).
 
-## Layout
+## Contributing
 
-```
-src/musubi/               importable package — all slices land here
-  types/                  shared pydantic types (slice-types)
-  planes/                 episodic, curated, artifact, concept (later slices)
-  retrieve/               scoring, hybrid, fast/deep path (later slices)
-  lifecycle/              maturation, synthesis, promotion (later slices)
-  api/                    FastAPI + OpenAPI/proto (later slice)
-  sdk/                    Python client (later slice)
-  adapters/               mcp/, obsidian/, cli/ (later slices)
+This is a personal project that's been opened up for others to follow along, fork, and riff on. Contributions are welcome but the bar is: opened issue → discussion → PR. See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow and conventions.
 
-tests/                    tests mirror src/musubi/ layout exactly
-```
+The internal design is captured in an Obsidian-style vault at [`docs/Musubi/`](docs/Musubi/). It's readable as-is on GitHub but renders best in Obsidian. Every architectural decision has an ADR; every working module has a `slice` spec with a Test Contract.
 
-## Slice discipline
+## Security
 
-Every PR realises one slice (or a clean part of one). Each slice has a **Test
-Contract** in its spec. Write tests first; code follows. See
-`00-index/agent-guardrails.md` in the vault.
+If you find a vulnerability, please don't open a public issue. See [SECURITY.md](SECURITY.md) for the disclosure process.
 
-## Why v2
+## License
 
-v1 was a single-plane FastMCP server backed by Gemini and a single Qdrant
-collection. v2 is the full three-plane architecture with local inference,
-named-vector hybrid retrieval, a proper lifecycle engine, and the Obsidian
-vault as the curated-plane store of record. See
-`13-decisions/` ADRs in the vault for the load-bearing choices.
+[Apache 2.0](LICENSE) © 2025–2026 Eric Mey.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,75 @@
+# Security Policy
+
+## Supported versions
+
+Musubi is pre-1.0 and moves fast. Security-relevant fixes land on the latest minor, tagged and published as the next patch release. Older tags are not backported.
+
+| Version     | Supported          |
+|-------------|--------------------|
+| `v0.3.x`    | ✅ Yes              |
+| `< v0.3.0`  | ❌ No               |
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security reports.**
+
+Use one of these paths instead:
+
+1. **GitHub Private Vulnerability Reporting** — preferred. Go to the [Security tab](https://github.com/ericmey/musubi/security/advisories/new) on this repo and open a draft advisory. It's routed directly to the maintainer and isn't publicly indexed until published.
+2. **Email** — `ericmey@gmail.com` with subject prefix `[musubi-security]`.
+
+Please include:
+
+- A description of the issue and why you think it's a vulnerability.
+- Reproduction steps (a minimal PoC is ideal).
+- The affected version / commit SHA / image digest.
+- Your assessment of the impact (data exposure, auth bypass, RCE, DoS, etc.).
+- If you'd like credit in the advisory, the name/handle to use.
+
+## Response timeline
+
+This is a personal project with a single maintainer, so response is best-effort rather than SLA-backed. That said:
+
+- **Acknowledgement:** within 72 hours of report.
+- **Initial assessment** (is this reproducible? severity?): within 7 days.
+- **Fix or mitigation timeline:** shared with you once the assessment is done — typically days for low severity, a week or two for moderate, as fast as possible for critical.
+- **Public disclosure:** coordinated. We prefer to release a fix and a CVE-linked advisory at the same time, giving operators a version to upgrade to before the details are public.
+
+## What counts
+
+### In scope
+
+- The Musubi Core service (the Python code under `src/musubi/`, the published container image at `ghcr.io/ericmey/musubi-core`, and the published SDK).
+- The Ansible deployment playbooks under `deploy/ansible/`, to the extent they configure Musubi itself.
+- The HTTP and gRPC API surfaces.
+- Auth / session / token handling.
+- Anything that affects data integrity across the episodic, concept, curated, or thoughts planes.
+
+### Out of scope
+
+- Third-party dependencies with their own security policies (Qdrant, TEI, Ollama, FastAPI). Report those upstream; we'll pick up their fixes when they ship.
+- Denial-of-service against a single-node homelab deployment by an authenticated caller — Musubi has no admission-control hardening for that use case today, and making it robust is on the roadmap rather than a bug.
+- Homelab-specific topology disclosed in historical `refs/pull/*` refs from before the repo went public. The current default branch is scrubbed; see commit [`cbcca0b`](https://github.com/ericmey/musubi/commit/cbcca0b) for details.
+
+## Supply-chain verification
+
+Every published image is signed by a GitHub Actions OIDC identity via [cosign](https://github.com/sigstore/cosign), attested with a CycloneDX SBOM, and scanned by Trivy for CRITICAL CVEs before publication. To verify a given digest before running it:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp 'https://github.com/ericmey/musubi/.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/ericmey/musubi-core@sha256:<digest>
+```
+
+The attestation can be retrieved with:
+
+```bash
+cosign download attestation \
+  --predicate-type 'https://cyclonedx.org/bom' \
+  ghcr.io/ericmey/musubi-core@sha256:<digest>
+```
+
+## No bounties
+
+This is a homelab / portfolio project. There is no bug bounty program, no payouts, no swag. What we can offer in return for a responsible report is recognition in the advisory and a sincere thank-you.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.3.0"
 description = "Shared memory + knowledge plane for a small-team AI agent fleet. See the Obsidian architecture vault for design."
 requires-python = ">=3.12"
 authors = [{ name = "Eric Mey", email = "ericmey@gmail.com" }]
-license = { text = "Private" }
+license = { text = "Apache-2.0" }
 readme = "README.md"
 
 dependencies = [


### PR DESCRIPTION
No tracking Issue: public-repo polish in prep for blogging the project.

## Summary
Fills in all the community-health files GitHub measures the repo on, and rewrites the README for a public audience now that main = V2.

## Files added
- \`LICENSE\` — Apache 2.0 (matches the cosign image label on every published digest).
- \`SECURITY.md\` — supported versions, responsible disclosure (GitHub private-vulnerability-reporting + email), response SLOs, scope, cosign/SBOM verification commands.
- \`CONTRIBUTING.md\` — external-facing contributor workflow: the 4 non-negotiables, slice discipline, commit style, PR expectations.
- \`CODE_OF_CONDUCT.md\` — Contributor Covenant 2.1 *by reference* (not vendored verbatim; the upstream link is canonical and keeps the file short).
- \`.github/ISSUE_TEMPLATE/config.yml\` — disables blank issues, links to Discussions and Security advisories.
- \`.github/ISSUE_TEMPLATE/bug_report.yml\` + \`feature_request.yml\` — structured YAML forms for external reporters.

## Files changed
- \`README.md\` — rewritten. Badges, ASCII three-plane diagram, stack, quickstart, signed image digest + verify command, layout, v0.3.0 status, pointers to CONTRIBUTING / SECURITY. Drops the stale "main still holds v1" framing (main IS V2 now after the branch swap).
- \`pyproject.toml\` — license: \`Private\` → \`Apache-2.0\`.

## Test plan
- [x] \`make check\` → 1143 passed / 231 skipped (unchanged).
- [ ] After merge, GitHub community-profile → 100% (currently 42%).
- [ ] Settings follow-ups (separate from this PR, done via gh api): enable wiki, enable discussions, add topics, enable branch protection on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)