### PR TITLE
fix(lifecycle): stop registering demotion jobs from build_maturation_jobs

### DIFF
--- a/src/musubi/lifecycle/maturation.py
+++ b/src/musubi/lifecycle/maturation.py
@@ -966,10 +966,19 @@ def build_maturation_jobs(
     config: MaturationConfig | None = None,
 ) -> list[Job]:
     """Return :class:`Job` objects matching the lifecycle-scheduler default
-    job names (``maturation_episodic``, ``provisional_ttl``,
-    ``demotion_episodic``, ``concept_maturation``, ``demotion_concept``).
+    job names that maturation *owns*: ``maturation_episodic``,
+    ``provisional_ttl``, and ``concept_maturation``.
 
-    The lifecycle worker registers them via ``build_scheduler(jobs=...)``.
+    Demotion used to live here (``demotion_episodic``, ``demotion_concept``)
+    as helper sweeps that predated the dedicated demotion slice. They've
+    since moved to :mod:`musubi.lifecycle.demotion`, which owns the real
+    demotion path with ``DemotionDeps`` (including the thoughts emitter
+    for "concept X demoted" ops notifications). This builder no longer
+    schedules them — see :func:`musubi.lifecycle.demotion.build_demotion_jobs`
+    for the canonical wiring. The legacy sweep functions remain in this
+    module for tests and any caller that still imports them directly,
+    but they are not on the cron anymore.
+
     Each job acquires the documented file lock before running so two
     workers on the same host can't double-execute (covered by spec
     bullet 20).
@@ -996,12 +1005,8 @@ def build_maturation_jobs(
             kwargs, grace = {"minute": 13}, 900
         elif name == "provisional_ttl":
             kwargs, grace = {"minute": 17}, 600
-        elif name == "demotion_episodic":
-            kwargs, grace = {"day_of_week": "sun", "hour": 3, "minute": 45}, 3600
         elif name == "concept_maturation":
             kwargs, grace = {"hour": 3, "minute": 30}, 3600
-        elif name == "demotion_concept":
-            kwargs, grace = {"hour": 5, "minute": 0}, 3600
         else:  # pragma: no cover — every name in the registry above is enumerated
             raise ValueError(f"unknown maturation job name: {name}")
         return Job(
@@ -1024,16 +1029,8 @@ def build_maturation_jobs(
             lambda: provisional_ttl_sweep(client=client, sink=sink, config=cfg),
         ),
         _wrap(
-            "demotion_episodic",
-            lambda: episodic_demotion_sweep(client=client, sink=sink, config=cfg),
-        ),
-        _wrap(
             "concept_maturation",
             lambda: concept_maturation_sweep(client=client, sink=sink, config=cfg),
-        ),
-        _wrap(
-            "demotion_concept",
-            lambda: concept_demotion_sweep(client=client, sink=sink, config=cfg),
         ),
     ]
 

--- a/tests/lifecycle/test_maturation.py
+++ b/tests/lifecycle/test_maturation.py
@@ -984,9 +984,10 @@ def test_build_maturation_jobs_registers_documented_names(
     sink: LifecycleEventSink,
     cursor: MaturationCursor,
 ) -> None:
-    """The five Job names this module owns line up with the lifecycle
-    scheduler's default-job registry exactly. Drift here would silently
-    keep the placeholder lambdas in production."""
+    """The Job names this module owns line up with the lifecycle
+    scheduler's default-job registry. Demotion moved to the dedicated
+    `demotion.py` module after slice-lifecycle-demotion-builder landed;
+    maturation retains the three sweeps that still live here."""
     from musubi.lifecycle.maturation import build_maturation_jobs
 
     jobs = build_maturation_jobs(
@@ -1001,9 +1002,7 @@ def test_build_maturation_jobs_registers_documented_names(
     assert names == {
         "maturation_episodic",
         "provisional_ttl",
-        "demotion_episodic",
         "concept_maturation",
-        "demotion_concept",
     }
     for job in jobs:
         assert callable(job.func)


### PR DESCRIPTION
No tracking Issue: deploy-log wart flagged during v0.3.0 smoke test (\`jobs=[\u2026demotion_episodic\u2026demotion_concept\u2026demotion_episodic\u2026demotion_concept\u2026]\`).

## Summary
Both \`build_maturation_jobs\` (legacy) and \`build_demotion_jobs\` (canonical, shipped in #163) returned Jobs named \`demotion_episodic\` + \`demotion_concept\`. \`build_lifecycle_jobs\` only dedupes real-vs-placeholder, so both were on the scheduler. File locks prevented data corruption, but the second implementation's sweep was wasted work and operator Thoughts fired twice.

Dropping the two entries from \`build_maturation_jobs\` leaves \`demotion.py\`'s DemotionDeps-backed path as the only scheduled demotion.

## Test plan
- [x] Updated \`test_build_maturation_jobs_registers_documented_names\` — now expects \`{maturation_episodic, provisional_ttl, concept_maturation}\`.
- [x] \`make check\` → 1143 passed / 231 skipped.
- [ ] Post-merge deploy + verify the lifecycle-worker startup log no longer duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)