### PR TITLE
docs: scrub internal V1/V2 framing from user-facing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ deploy/                     ansible, prometheus, grafana, docker-compose templat
 - ✅ Homelab deployment wired, containers healthy
 
 Not yet:
-- ⏳ Fleet orchestration (V2 runs single-node today; multi-node is post-v1.0)
+- ⏳ Fleet orchestration — single-node today; multi-node HA is a post-1.0 design space and will require a real ADR
 - ⏳ Auto-deploy pipeline
 - ⏳ OpenClaw adapter integration tests
 

--- a/docs/Musubi/03-system-design/components.md
+++ b/docs/Musubi/03-system-design/components.md
@@ -113,8 +113,8 @@ See [[08-deployment/gpu-inference-topology]] for the VRAM budget and load policy
 
 ## Object Store
 
-- **V1**: plain filesystem at `/srv/musubi/artifacts/`. Content-addressed subdirs: `/sha256[:2]/sha256[2:]/`.
-- **Post-V1 (when multi-host)**: MinIO with S3 API. Drop-in replacement via the `musubi/store/` abstraction.
+- **Today (single-host)**: plain filesystem at `/srv/musubi/artifacts/`. Content-addressed subdirs: `/sha256[:2]/sha256[2:]/`.
+- **Future (when multi-host)**: MinIO with S3 API. Drop-in replacement via the `musubi/store/` abstraction.
 
 ## Adapter projects (separate repos)
 

--- a/docs/Musubi/04-data-model/source-artifact.md
+++ b/docs/Musubi/04-data-model/source-artifact.md
@@ -91,7 +91,7 @@ Chunks are not first-class `MusubiObject`s — they're indexed content owned by 
 
 Two artifacts with the same content (identical sha256) share the blob and can have independent `object_id`s (e.g., ingested under different namespaces or with different metadata). Metadata is deduplicated by object_id.
 
-Post-V1 (when multi-host): swap filesystem for MinIO without changing API surface.
+Future (when multi-host): swap filesystem for MinIO without changing the API surface.
 
 **Qdrant:** collection `musubi_artifact_chunks` stores chunk embeddings.
 

--- a/docs/Musubi/11-migration/phase-2-hybrid-search.md
+++ b/docs/Musubi/11-migration/phase-2-hybrid-search.md
@@ -59,7 +59,7 @@ musubi-cli backfill --collection musubi_episodic_v2 --batch-size 64
 
 Processes in batches. Skips points already backfilled (tracked via a `backfill_cursor` in `lifecycle-work.sqlite`).
 
-At v1 POC scale (few thousand memories), backfill completes in < 1 hour.
+At POC-era scale (few thousand memories), backfill completes in < 1 hour.
 
 ### Retrieve path
 

--- a/docs/Musubi/12-roadmap/ownership-matrix.md
+++ b/docs/Musubi/12-roadmap/ownership-matrix.md
@@ -18,7 +18,7 @@ Musubi is a **single-repo monorepo** per [[13-decisions/0015-monorepo-supersedes
 
 | Repo | Primary owner | Backup | Access | Contents |
 |---|---|---|---|---|
-| `github.com/ericmey/musubi` | Eric | — | private | Everything: Core, SDK, MCP/Obsidian/CLI adapters, contract tests, compose + Ansible under `deploy/`, *and* the Obsidian architecture vault under `docs/Musubi/`. `v2` branch is the rebuild; `main` still holds the v1 POC until V2 cutover. |
+| `github.com/ericmey/musubi` | Eric | — | public | Everything: Core, SDK, MCP/Obsidian/CLI adapters, contract tests, compose + Ansible under `deploy/`, *and* the Obsidian architecture vault under `docs/Musubi/`. `main` carries current development; the original POC is archived on the `alpha-archive` branch for history. |
 
 If a second contributor joins, the "backup" column fills in. For now, Eric holds all bus factor.
 

--- a/docs/Musubi/13-decisions/0016-vault-in-monorepo.md
+++ b/docs/Musubi/13-decisions/0016-vault-in-monorepo.md
@@ -25,7 +25,7 @@ superseded-by: ""
 
 The situation changed quickly:
 
-- V2 development is about to spin up **multiple concurrent coding agents** (Claude Code, Claude Cowork, Codex, and occasionally Grok / Gemini) working on different slices.
+- The rebuild was about to spin up **multiple concurrent coding agents** (Claude Code, Claude Cowork, Codex, and occasionally Grok / Gemini) working on different slices.
 - Every agent, regardless of provider, needs to read the same specs, follow the same guardrails, and update the same slice-state notes to pick up work safely.
 - Keeping the vault in a sibling directory (`~/Vaults/musubi/` outside the code repo) meant each agent needed two clones, cross-repo references, and its own "how to find the vault" onboarding.
 - PRs that correct a spec alongside code (the `spec-update:` trailer convention from [[CLAUDE]]) had to touch two repos with no atomic landing point.


### PR DESCRIPTION
No tracking Issue: docs hygiene — the internal alpha/beta talking points leaked into public-facing docs.

## Summary

V1/V2 were internal monikers for the alpha POC and the rebuild (now \`main\`). A public reader sees "V2 runs single-node; multi-node is post-v1.0" and can't reconcile the two versioning systems — semver is at 0.3.1 heading toward 1.0, while "V2" sounds like "after V1 (which isn't shipped yet?) but post-v1.0 is a future milestone?"

Six targeted edits keep historical framing where it belongs (work logs, ADR decision dates, done slices) and cleanse the forward-looking surface:

- **README.md** — fleet-orchestration bullet rephrased
- **12-roadmap/ownership-matrix.md** — freshened to reflect current reality (\`main\` current, \`alpha-archive\` branch for history, public repo)
- **03-system-design/components.md** — artifact-store "V1 / Post-V1" → "Today / Future"
- **04-data-model/source-artifact.md** — same pattern
- **11-migration/phase-2-hybrid-search.md** — "v1 POC scale" → "POC-era scale"
- **13-decisions/0016-vault-in-monorepo.md** — "V2 development was about to spin up" → "The rebuild was about to spin up" (preserves historical tense)

## Not in scope

- Library versions (pydantic v2, BGE-M3, qdrant v1.17.1) — real product versions
- API path prefix (/v1/...) — canonical API version
- Historical slice work logs / done slices describing POC → rebuild
- SPLADE v2/v3 model-output discussion

## Companion work

- Branch rename \`v1-archive\` → \`alpha-archive\` ships separately (pure git-ref operation; grep shows no code references to the old name)
- Wiki edit to \`Architecture-Overview.md\` pushes to the wiki repo separately

## Test plan

- [x] \`make agent-check\` → 0 errors, 8 pre-existing warnings
- [x] \`grep -rnE "V2 runs|Post-V1|post-v1\.0"\` → empty
- [ ] PR-event Vault hygiene green