### PR TITLE
feat(ops): perf-testing harness + manual-recovery runbook (Gate 0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
 
 .PHONY: install fmt lint typecheck test test-cov check clean \
         agent-check spec-check slice-check vault-check issue-check wikilink-check \
-        tc-coverage test-integration test-integration-up test-integration-down
+        tc-coverage test-integration test-integration-up test-integration-down \
+        perf-seed perf-baseline perf-load perf-spike
 
 # --------------------------------------------------------------------------
 # Code gates — ruff format + lint are scoped to the whole repo (matching
@@ -96,6 +97,55 @@ test-integration:
 	  exit 2; \
 	fi
 	uv run pytest tests/integration/ -m integration -ra --strict-markers --no-cov
+
+# --------------------------------------------------------------------------
+# Perf harness — scripts/perf/. Every perf target expects these env vars:
+#
+#   MUSUBI_V2_BASE_URL=https://musubi.mey.house/v1
+#   MUSUBI_V2_TOKEN=mbi_perf_...       # scoped to perf-test/* — NEVER eric/*
+#
+# Outputs land under ~/perf-runs/$(LABEL)/. See scripts/perf/README.md for
+# the full harness + safety notes.
+# --------------------------------------------------------------------------
+
+PERF_K6 ?= k6
+PERF_LABEL ?= run-$(shell date -u +%Y%m%dT%H%M%SZ)
+PERF_SIZE ?= 10000
+PERF_SEED ?= 42
+
+perf-seed:  ## Seed Musubi with a deterministic synthetic corpus (SIZE=10000, SEED=42)
+	@if [ -z "$$MUSUBI_V2_BASE_URL" ] || [ -z "$$MUSUBI_V2_TOKEN" ]; then \
+	  echo "error: set MUSUBI_V2_BASE_URL + MUSUBI_V2_TOKEN (scoped to perf-test/*)"; \
+	  exit 2; \
+	fi
+	uv run python3 scripts/perf/seed_corpus.py --size $(PERF_SIZE) --seed $(PERF_SEED)
+
+perf-baseline:  ## Rebaseline (single caller per endpoint). LABEL=<tag> for output dir
+	@mkdir -p $$HOME/perf-runs/$(PERF_LABEL)
+	scripts/perf/telemetry.sh start $(PERF_LABEL)
+	@trap 'scripts/perf/telemetry.sh stop' EXIT; \
+	  $(PERF_K6) run --summary-export=$$HOME/perf-runs/$(PERF_LABEL)/k6-summary.json \
+	    scripts/perf/k6/baseline.js
+	scripts/perf/telemetry.sh stop || true
+	scripts/perf/telemetry.sh summarize $(PERF_LABEL)
+
+perf-load:  ## Sustained mixed workload (10 VU, 15 min). LABEL=<tag> for output dir
+	@mkdir -p $$HOME/perf-runs/$(PERF_LABEL)
+	scripts/perf/telemetry.sh start $(PERF_LABEL)
+	@trap 'scripts/perf/telemetry.sh stop' EXIT; \
+	  $(PERF_K6) run --summary-export=$$HOME/perf-runs/$(PERF_LABEL)/k6-summary.json \
+	    scripts/perf/k6/load.js
+	scripts/perf/telemetry.sh stop || true
+	scripts/perf/telemetry.sh summarize $(PERF_LABEL)
+
+perf-spike:  ## Background+burst+recovery (voice-call shape). LABEL=<tag> for output dir
+	@mkdir -p $$HOME/perf-runs/$(PERF_LABEL)
+	scripts/perf/telemetry.sh start $(PERF_LABEL)
+	@trap 'scripts/perf/telemetry.sh stop' EXIT; \
+	  $(PERF_K6) run --summary-export=$$HOME/perf-runs/$(PERF_LABEL)/k6-summary.json \
+	    scripts/perf/k6/spike.js
+	scripts/perf/telemetry.sh stop || true
+	scripts/perf/telemetry.sh summarize $(PERF_LABEL)
 
 clean:
 	rm -rf .pytest_cache .mypy_cache .ruff_cache build dist *.egg-info

--- a/deploy/runbooks/manual-recovery.md
+++ b/deploy/runbooks/manual-recovery.md
@@ -1,0 +1,257 @@
+# Manual Musubi recovery from a backup snapshot
+
+Use this when `deploy/backup/restore.yml` cannot run (rot tracked in #190)
+or you want a low-cost, low-risk recovery path that doesn't depend on
+Ansible at all.
+
+Every step runs directly on `musubi.mey.house` (or wherever Musubi is
+deployed). No control host needed.
+
+**When this is your procedure:**
+- Perf testing corrupted state and you want to roll back to a known-good.
+- An incident took out a Qdrant collection and you just need that one back.
+- You're exercising the safety net before putting the system under load.
+
+---
+
+## Pre-flight
+
+**Command:**
+
+```bash
+# Identify the snapshot you want to restore from.
+sudo ls -la /var/lib/musubi/backups/
+# Pick one — typically the most recent scheduled snapshot or a labeled
+# baseline like `pre-perf-baseline-2026-04-22`.
+SNAP=/var/lib/musubi/backups/pre-perf-baseline-2026-04-22
+sudo cat "$SNAP/manifest.json" | jq .
+# Verify SHA256SUMS — files must match what was recorded.
+cd "$SNAP/qdrant" && sudo sha256sum -c SHA256SUMS
+```
+
+**Expected output:** `manifest.json` shows `status: 0` and a list of
+seven collections under `qdrant_collections`. `sha256sum -c` shows every
+`*.snapshot` as `OK`.
+
+**Destructive:** no.
+
+**Rollback:** not applicable (check).
+
+---
+
+## 1. Stop the stack
+
+**Command:**
+
+```bash
+sudo docker compose -f /etc/musubi/docker-compose.yml ps
+sudo docker compose -f /etc/musubi/docker-compose.yml stop core lifecycle-worker
+```
+
+**Expected output:** `core` and `lifecycle-worker` go from `running` to
+`exited` or `stopped`. Qdrant, TEI, Ollama keep running — they're the
+targets of the restore.
+
+**Destructive:** yes — stops serving traffic. Consumers see connection
+refused until step 6 restarts the stack.
+
+**Rollback:** `sudo docker compose -f /etc/musubi/docker-compose.yml start core lifecycle-worker`
+restarts without restoring. Use if you decide to abort the recovery.
+
+---
+
+## 2. Restore Qdrant collections from snapshot files
+
+Qdrant's snapshot files are uploaded back via its HTTP API. API key
+lives in `/etc/musubi/.env.production` as `QDRANT_API_KEY=`.
+
+**Command:**
+
+```bash
+QDRANT_API_KEY=$(sudo grep '^QDRANT_API_KEY=' /etc/musubi/.env.production \
+  | cut -d= -f2- | tr -d '"'"'"'')
+QDRANT_URL=http://127.0.0.1:6333   # or the network-internal host:port
+
+# List existing collections (pre-restore inventory).
+curl -sf -H "api-key: $QDRANT_API_KEY" "$QDRANT_URL/collections" | jq .
+
+# For each collection snapshot, upload it back. Qdrant's recover-from-snapshot
+# flavour accepts the file over multipart upload.
+for snap in "$SNAP"/qdrant/*.snapshot; do
+  coll=$(basename "$snap" .snapshot)
+  echo "=> restoring $coll"
+  # Delete the existing collection first (destructive) — the upload
+  # endpoint is snapshot-recovery, not snapshot-merge.
+  curl -sf -X DELETE -H "api-key: $QDRANT_API_KEY" \
+    "$QDRANT_URL/collections/$coll" | jq -c .
+  # Upload + recover.
+  curl -sf -X POST \
+    -H "api-key: $QDRANT_API_KEY" \
+    -F "snapshot=@$snap" \
+    "$QDRANT_URL/collections/$coll/snapshots/upload?priority=snapshot" \
+    | jq -c .
+done
+
+# Verify the collection count matches the manifest.
+curl -sf -H "api-key: $QDRANT_API_KEY" "$QDRANT_URL/collections" \
+  | jq '.result.collections | length'
+```
+
+**Expected output:** seven collections, each showing
+`"status":"ok","result":true` on upload. Final count = 7.
+
+**Destructive:** yes — pre-existing collections of the same name are
+deleted before the upload. Nothing survives the re-import.
+
+**Rollback:** there is no rollback inside this step. If the upload
+fails mid-way, re-run step 2 from a different snapshot, or fall back
+to the snapshot created by the 6-hour timer right before the attempt.
+
+---
+
+## 3. Restore SQLite lifecycle ledger
+
+**Command:**
+
+```bash
+# Backup the current sqlite aside, in case you need to diff later.
+sudo cp -a /var/lib/musubi/lifecycle-work.sqlite \
+  /var/lib/musubi/lifecycle-work.sqlite.pre-restore.$(date -u +%s) || true
+
+sudo cp -a "$SNAP/sqlite/work.sqlite" /var/lib/musubi/lifecycle-work.sqlite
+sudo chown musubi:musubi /var/lib/musubi/lifecycle-work.sqlite
+sudo chmod 0640 /var/lib/musubi/lifecycle-work.sqlite
+```
+
+**Expected output:** no output on success (the `cp` is quiet).
+
+**Destructive:** yes — overwrites the current lifecycle-work SQLite.
+The `.pre-restore.<epoch>` copy is your immediate undo.
+
+**Rollback:** `sudo cp -a /var/lib/musubi/lifecycle-work.sqlite.pre-restore.<epoch> /var/lib/musubi/lifecycle-work.sqlite`
+restores the pre-recovery state.
+
+---
+
+## 4. Restore artifact blobs
+
+**Command:**
+
+```bash
+# rsync -a --delete will remove any blobs present on the host but not
+# in the snapshot — that's correct for a full recovery, matches the
+# snapshot's intent. Drop --delete if you want additive recovery.
+sudo rsync -a --delete \
+  "$SNAP/artifact-blobs/" \
+  /var/lib/musubi/artifact-blobs/
+sudo chown -R musubi:musubi /var/lib/musubi/artifact-blobs/
+```
+
+**Expected output:** no output (rsync quiet by default). Size should
+match `du -sh "$SNAP/artifact-blobs"`.
+
+**Destructive:** yes — `--delete` removes host blobs not in the snapshot.
+
+**Rollback:** if you kept a pre-restore copy (recommended for safety),
+`rsync -a --delete /var/lib/musubi/artifact-blobs.pre-restore/ /var/lib/musubi/artifact-blobs/`.
+Without one, rolling back means restoring from a different snapshot.
+
+---
+
+## 5. Vault is always restored from git
+
+The Obsidian vault is the store-of-record for curated knowledge and
+is backed by the remote git repo (see `slice-vault-sync`). No local
+restore step is required; if the vault working copy was damaged, nuke
+it and re-clone:
+
+```bash
+sudo rm -rf /var/lib/musubi/vault
+sudo -u musubi git clone <vault-remote> /var/lib/musubi/vault
+```
+
+The curated Qdrant collection is regenerated from vault content on
+the next vault-sync tick after the stack is back up. No explicit
+rebuild command needed.
+
+---
+
+## 6. Restart the stack
+
+**Command:**
+
+```bash
+sudo docker compose -f /etc/musubi/docker-compose.yml up -d core lifecycle-worker
+# Wait for healthchecks.
+for i in $(seq 30); do
+  state=$(sudo docker inspect musubi-core-1 -f '{{.State.Health.Status}}')
+  echo "[$i] core health: $state"
+  [ "$state" = "healthy" ] && break
+  sleep 2
+done
+```
+
+**Expected output:** `core health: healthy` within ~30s. If it hangs
+at `starting` for over a minute, check `sudo docker logs musubi-core-1
+--tail 50` for a bootstrap failure.
+
+**Destructive:** no.
+
+**Rollback:** `sudo docker compose -f /etc/musubi/docker-compose.yml stop`.
+
+---
+
+## 7. Smoke-verify
+
+**Command:**
+
+```bash
+# Public health.
+curl -sf http://127.0.0.1:8100/v1/ops/health | jq .
+
+# Per-plane row counts — confirm each collection restored its population.
+for coll in musubi_episodic musubi_curated musubi_concept musubi_thought \
+            musubi_artifact musubi_artifact_chunks musubi_lifecycle_events; do
+  count=$(curl -sf -H "api-key: $QDRANT_API_KEY" \
+    "$QDRANT_URL/collections/$coll" | jq -r '.result.points_count // "n/a"')
+  echo "$coll: $count"
+done
+
+# One round-trip through the canonical API (operator token required;
+# see .agent-context.local.md for how to mint one).
+```
+
+**Expected output:** `{"status":"ok","version":"v0"}` from health.
+Each collection reports its points_count; compare against any
+historical baseline you trust.
+
+**Destructive:** no.
+
+**Rollback:** not applicable (verification).
+
+---
+
+## Scope this runbook does NOT cover
+
+- **Multi-host restore.** Musubi is single-node per ADR-0010.
+- **Partial-collection restore.** Today the snapshot is all-or-nothing
+  per collection. Restoring only some rows from a Qdrant snapshot
+  requires manual point enumeration and is out of scope here.
+- **Disaster recovery to a fresh host.** The `bootstrap.yml` Ansible
+  playbook installs host-level deps + creates users + configures UFW
+  — follow that first, THEN this runbook for the data recovery half.
+  Once #190 lands, `drill.yml` will automate the combined flow.
+
+## When the automated `restore.yml` is repaired (#190)
+
+Prefer the automated playbook:
+
+```bash
+ansible-playbook -i deploy/ansible/inventory.yml \
+  -e @~/.musubi-secrets/inventory-vars.yml \
+  -e @~/.musubi-secrets/vault.yml \
+  -e 'backup_timestamp=pre-perf-baseline-2026-04-22' \
+  deploy/backup/restore.yml
+```
+
+This manual runbook stays in-repo as the escape hatch.

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1,0 +1,117 @@
+# Musubi perf testing harness
+
+Load + performance testing scripts for `musubi.mey.house`. Implements
+the plan at *(link in PR description)*.
+
+## Layout
+
+```
+scripts/perf/
+├── README.md                  ← you are here
+├── seed_corpus.py             ← deterministic synthetic corpus generator
+├── telemetry.sh               ← host-side resource sampler (docker stats + GPU)
+└── k6/
+    ├── _shared.js             ← shared request builders (auth, endpoints)
+    ├── baseline.js            ← single-VU floor measurement
+    ├── load.js                ← sustained mixed workload
+    └── spike.js               ← voice-burst-on-top-of-background
+```
+
+## Prerequisites
+
+1. **Operator token scoped to `perf-test/*`** — *never* use `eric/*`.
+   See [.agent-context.local.md](../../.agent-context.local.md) for
+   how to mint a scoped token.
+2. **k6 installed** on whatever host runs the scenarios
+   (`brew install k6` on macOS, apt package on Ubuntu).
+3. **jq** (telemetry summarizer uses it).
+4. **Python 3.12 + httpx** for the seed script
+   (`pip install httpx`).
+5. **A named pre-run snapshot** (for safety — see
+   [deploy/runbooks/manual-recovery.md](../../deploy/runbooks/manual-recovery.md)).
+
+## Env vars every scenario reads
+
+```bash
+export MUSUBI_V2_BASE_URL=https://musubi.mey.house/v1
+export MUSUBI_V2_TOKEN=mbi_perf_...                # scoped to perf-test/*
+export MUSUBI_V2_NAMESPACE_PREFIX=perf-test        # default; override if isolating
+```
+
+## Typical run sequence (per the plan)
+
+### Gate 1 — rebaseline (single caller)
+
+```bash
+make perf-seed SIZE=10000 SEED=42                  # one-time
+make perf-baseline LABEL=rebaseline-$(date +%Y%m%d)
+```
+
+Produces `~/perf-runs/rebaseline-<date>/` with k6 summary + telemetry rollup.
+
+### Gate 2 — load
+
+```bash
+make perf-load LABEL=load-$(date +%Y%m%d)
+```
+
+### Gate 3 — spike
+
+```bash
+make perf-spike LABEL=spike-$(date +%Y%m%d)
+```
+
+### Gate 4 — soak (use your shell's background job control)
+
+Soak isn't a dedicated scenario — it's `load.js` extended. Run with
+a longer `stages` array:
+
+```bash
+K6_STAGES_OVERRIDE="2m,12h,30s" make perf-load LABEL=soak-overnight
+# nohup + tail -f ~/perf-runs/soak-overnight/... overnight
+```
+
+## What each script does (one-liner)
+
+- **`seed_corpus.py`** — POSTs N rows to each plane's canonical
+  endpoint with deterministic content sampled from a seeded
+  fragment pool. Idempotent: re-running with the same `--seed` is a
+  no-op against a populated namespace (dedup + idempotency keys
+  collapse duplicate captures).
+- **`k6/baseline.js`** — serial happy-path. Per-endpoint p50/p95/p99.
+- **`k6/load.js`** — 10 VUs, ramp + steady 15 min, weighted mix.
+- **`k6/spike.js`** — background at 2 RPS, burst to 15 RPS for 20 s,
+  recovery window.
+- **`telemetry.sh`** — sidecar sampler. Runs alongside k6 and
+  captures container CPU/RSS + GPU utilization + memory at 5s cadence.
+
+## Output
+
+Every Makefile target writes to `~/perf-runs/<LABEL>/`:
+
+```
+~/perf-runs/rebaseline-20260422/
+├── k6-summary.json          ← k6's built-in summary
+├── docker-stats.jsonl       ← per-container samples
+├── nvidia-smi.jsonl         ← GPU samples (if NVIDIA present)
+└── summary.md               ← rollup (run `telemetry.sh summarize <label>`)
+```
+
+## Safety
+
+- **Never point scenarios at `eric/*` namespaces.** The seed script
+  + k6 scenarios all default to `perf-test/*` and error if
+  `MUSUBI_V2_TOKEN` is unset. If the token grants access to
+  `eric/*` you're one config-flag away from corrupting live data.
+  Mint the token with the narrow scope.
+- **Have a rollback point.** Take a labeled snapshot before each
+  gate per [manual-recovery.md](../../deploy/runbooks/manual-recovery.md).
+- **Watch GPU VRAM.** The RTX 3080 has 10 GiB shared between
+  TEI-dense, TEI-sparse, BGE-reranker, and Ollama. Perf gate says
+  keep ≥ 1 GiB free; the telemetry summary flags it explicitly.
+
+## Related
+
+- Plan: see Gate 0 PR description for the full test plan.
+- Follow-up: [#190](https://github.com/ericmey/musubi/issues/190) —
+  restore.yml repair (independent, not blocking).

--- a/scripts/perf/k6/_shared.js
+++ b/scripts/perf/k6/_shared.js
@@ -1,0 +1,95 @@
+// Shared helpers used by every scenario. Keep the imports flat and
+// the logic dumb — k6 scenarios should be readable as workload
+// definitions, not as bespoke client libraries.
+
+import http from 'k6/http';
+import { check } from 'k6';
+
+// Pulled from env at scenario start so the three scenarios don't
+// each duplicate the check. MUSUBI_V2_* match the env vars the voice
+// and browser consumers read; same names keep the perf harness
+// consistent with production.
+const BASE_URL = __ENV.MUSUBI_V2_BASE_URL;
+const TOKEN = __ENV.MUSUBI_V2_TOKEN;
+const NS_PREFIX = __ENV.MUSUBI_V2_NAMESPACE_PREFIX || 'perf-test';
+
+if (!BASE_URL || !TOKEN) {
+  throw new Error(
+    'MUSUBI_V2_BASE_URL and MUSUBI_V2_TOKEN must be set. The token ' +
+    'must scope to ' + NS_PREFIX + '/* — never to eric/*.'
+  );
+}
+
+const AUTH_HEADERS = {
+  'Authorization': `Bearer ${TOKEN}`,
+  'Content-Type': 'application/json',
+  'User-Agent': 'musubi-perf-k6/1',
+};
+
+// Five query phrases sampled by retrieve-heavy scenarios. Short,
+// realistic, and intentionally thematic — they should hit rows the
+// seed corpus actually seeded, so retrieves return real results
+// instead of empty hits that bypass rerank.
+export const QUERIES = [
+  'dentist appointment Tuesday',
+  'how does musubi promote concepts',
+  'LiveKit voice capture pipeline',
+  'what did Aoi say about the deploy',
+  'thought stream SSE rules',
+];
+
+export function retrieve({ mode = 'fast', limit = 5 } = {}) {
+  const q = QUERIES[Math.floor(Math.random() * QUERIES.length)];
+  return http.post(
+    `${BASE_URL}/retrieve`,
+    JSON.stringify({
+      namespace: `${NS_PREFIX}/episodic`,
+      query_text: q,
+      mode,
+      limit,
+    }),
+    { headers: AUTH_HEADERS, tags: { endpoint: `retrieve_${mode}` } },
+  );
+}
+
+export function capture() {
+  const marker = Math.random().toString(36).slice(2, 10);
+  return http.post(
+    `${BASE_URL}/memories`,
+    JSON.stringify({
+      namespace: `${NS_PREFIX}/episodic`,
+      content: `perf-capture ${marker}: Eric asked about the deploy status.`,
+      tags: ['perf', 'synthetic'],
+      importance: 5,
+    }),
+    {
+      headers: { ...AUTH_HEADERS, 'Idempotency-Key': `perf-${marker}` },
+      tags: { endpoint: 'capture' },
+    },
+  );
+}
+
+export function sendThought() {
+  const marker = Math.random().toString(36).slice(2, 10);
+  return http.post(
+    `${BASE_URL}/thoughts/send`,
+    JSON.stringify({
+      namespace: `${NS_PREFIX}/thought`,
+      from_presence: `${NS_PREFIX}/seeder`,
+      to_presence: `${NS_PREFIX}/receiver-0`,
+      content: `perf-thought ${marker}`,
+      channel: 'default',
+      importance: 5,
+    }),
+    {
+      headers: { ...AUTH_HEADERS, 'Idempotency-Key': `perf-th-${marker}` },
+      tags: { endpoint: 'thoughts_send' },
+    },
+  );
+}
+
+export function ok2xx(resp) {
+  return check(resp, {
+    '2xx': (r) => r.status >= 200 && r.status < 300,
+  });
+}

--- a/scripts/perf/k6/baseline.js
+++ b/scripts/perf/k6/baseline.js
@@ -1,0 +1,77 @@
+// Baseline: single virtual user, 100 sequential requests per endpoint.
+// Goal is to establish the **happy-path floor** on your hardware — the
+// p50/p95/p99 you'd get if nobody else was hitting Musubi. Everything
+// downstream (load, spike, soak) is judged relative to this floor.
+//
+// Run:
+//   MUSUBI_V2_BASE_URL=... MUSUBI_V2_TOKEN=... \
+//     k6 run scripts/perf/k6/baseline.js
+//
+// Expected runtime: ~5-10 minutes against a warm stack.
+
+import { sleep } from 'k6';
+import { retrieve, capture, sendThought, ok2xx } from './_shared.js';
+
+export const options = {
+  scenarios: {
+    baseline_retrieve_fast: {
+      executor: 'per-vu-iterations',
+      vus: 1,
+      iterations: 100,
+      exec: 'retrieveFast',
+      startTime: '0s',
+    },
+    baseline_retrieve_deep: {
+      executor: 'per-vu-iterations',
+      vus: 1,
+      iterations: 100,
+      exec: 'retrieveDeep',
+      startTime: '120s', // after fast finishes
+    },
+    baseline_capture: {
+      executor: 'per-vu-iterations',
+      vus: 1,
+      iterations: 100,
+      exec: 'capturer',
+      startTime: '360s', // after deep finishes
+    },
+    baseline_thought: {
+      executor: 'per-vu-iterations',
+      vus: 1,
+      iterations: 100,
+      exec: 'thinker',
+      startTime: '420s',
+    },
+  },
+  // Per-endpoint thresholds. These are the *migration-approval* budgets
+  // from the perf plan — flagged as 'abortOnFail: false' so the run
+  // completes + produces a full report even when something misses. Adjust
+  // after Gate 1 baseline calibration.
+  thresholds: {
+    'http_req_duration{endpoint:retrieve_fast}': ['p(95)<500'],
+    'http_req_duration{endpoint:retrieve_deep}': ['p(95)<5000'],
+    'http_req_duration{endpoint:capture}': ['p(95)<1000'],
+    'http_req_duration{endpoint:thoughts_send}': ['p(99)<500'],
+    'http_req_failed': ['rate<0.005'],
+  },
+};
+
+export function retrieveFast() {
+  ok2xx(retrieve({ mode: 'fast', limit: 5 }));
+  sleep(0.1); // 100ms spacing so we're measuring latency, not throughput
+}
+
+export function retrieveDeep() {
+  ok2xx(retrieve({ mode: 'deep', limit: 10 }));
+  sleep(0.1);
+}
+
+export function capturer() {
+  ok2xx(capture());
+  sleep(0.1);
+}
+
+export function thinker() {
+  ok2xx(sendThought());
+  sleep(0.1);
+}

--- a/scripts/perf/k6/load.js
+++ b/scripts/perf/k6/load.js
@@ -1,0 +1,60 @@
+// Load: sustained representative workload. 10 concurrent virtual
+// users, each doing a weighted mix of retrieve (60% fast, 20% deep),
+// capture (15%), and thoughts-send (5%). Holds for 13 minutes after a
+// 2-minute ramp.
+//
+// Shape chosen to mimic the pessimistic case from the perf plan:
+// two browser agents doing steady supplement refreshes + capture
+// mirror, plus a voice agent landing intermittent bursts. 10 VUs
+// isn't "real" concurrency — real consumers are ~3 clients — but
+// with HTTP keepalive the server sees the same request-shape
+// distribution and the extra VUs give statistical bite to p99.
+//
+// Run:
+//   MUSUBI_V2_BASE_URL=... MUSUBI_V2_TOKEN=... \
+//     k6 run scripts/perf/k6/load.js
+
+import { sleep } from 'k6';
+import { retrieve, capture, sendThought, ok2xx } from './_shared.js';
+
+export const options = {
+  scenarios: {
+    mixed_workload: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '2m', target: 10 },  // ramp up
+        { duration: '13m', target: 10 }, // steady
+        { duration: '30s', target: 0 },  // ramp down
+      ],
+      exec: 'mixed',
+      gracefulRampDown: '30s',
+    },
+  },
+  thresholds: {
+    // Gating budgets — perf plan §1
+    'http_req_duration{endpoint:retrieve_fast}': ['p(95)<500'],
+    'http_req_duration{endpoint:retrieve_deep}': ['p(95)<5000'],
+    'http_req_duration{endpoint:capture}': ['p(95)<1000'],
+    'http_req_duration{endpoint:thoughts_send}': ['p(99)<500'],
+    'http_req_failed': ['rate<0.005'],
+  },
+};
+
+// One iteration of the workload. Pacing is variable so we don't
+// synchronize VUs — k6's default behaviour is round-robin which
+// would make the load too uniform. `sleep` between 200ms and 1200ms
+// gives realistic inter-request spacing for an LLM-driven consumer.
+export function mixed() {
+  const roll = Math.random();
+  if (roll < 0.60) {
+    ok2xx(retrieve({ mode: 'fast', limit: 5 }));
+  } else if (roll < 0.80) {
+    ok2xx(retrieve({ mode: 'deep', limit: 10 }));
+  } else if (roll < 0.95) {
+    ok2xx(capture());
+  } else {
+    ok2xx(sendThought());
+  }
+  sleep(0.2 + Math.random());
+}

--- a/scripts/perf/k6/spike.js
+++ b/scripts/perf/k6/spike.js
@@ -1,0 +1,63 @@
+// Spike: voice-call burst on top of background steady-state. Mimics
+// the pessimistic case — Eric drops into a LiveKit call while the
+// browser agents keep doing their thing.
+//
+// Shape (per the perf plan):
+//   - 2 min at 2 RPS "background" (simulates browser + idle voice)
+//   - 20 seconds at 15 RPS "in-call" (voice turns firing tools)
+//   - 1 min at 2 RPS "recovery" (does p95 settle back to baseline?)
+//
+// Recovery measurement is the point. A system that can handle steady
+// state but can't recover from a burst looks fine on dashboards
+// between calls and catastrophic during one.
+//
+// Run:
+//   MUSUBI_V2_BASE_URL=... MUSUBI_V2_TOKEN=... \
+//     k6 run scripts/perf/k6/spike.js
+
+import { sleep } from 'k6';
+import { retrieve, capture, sendThought, ok2xx } from './_shared.js';
+
+export const options = {
+  scenarios: {
+    spike_workload: {
+      executor: 'ramping-arrival-rate',
+      startRate: 0,
+      timeUnit: '1s',
+      preAllocatedVUs: 30,
+      maxVUs: 50,
+      stages: [
+        { duration: '30s', target: 2 },   // ramp to background
+        { duration: '90s', target: 2 },   // steady 2 RPS
+        { duration: '2s', target: 15 },   // burst start
+        { duration: '20s', target: 15 },  // peak 15 RPS (in-call)
+        { duration: '2s', target: 2 },    // drop off
+        { duration: '60s', target: 2 },   // recovery window
+      ],
+      exec: 'spikeMix',
+    },
+  },
+  thresholds: {
+    'http_req_duration{endpoint:retrieve_fast}': ['p(95)<800'],  // relaxed during spike
+    'http_req_duration{endpoint:retrieve_deep}': ['p(95)<6000'], // relaxed during spike
+    'http_req_failed': ['rate<0.02'],  // some 5xx acceptable mid-burst
+  },
+};
+
+// Spike workload leans retrieve-heavy (80%) — voice tools hit recall
+// more than remember/think per turn. Capture + thoughts still present
+// because a real call does include "remember that" and "tell X"
+// requests.
+export function spikeMix() {
+  const roll = Math.random();
+  if (roll < 0.65) {
+    ok2xx(retrieve({ mode: 'fast', limit: 5 }));
+  } else if (roll < 0.80) {
+    ok2xx(retrieve({ mode: 'deep', limit: 10 }));
+  } else if (roll < 0.92) {
+    ok2xx(capture());
+  } else {
+    ok2xx(sendThought());
+  }
+  sleep(0.1);
+}

--- a/scripts/perf/seed_corpus.py
+++ b/scripts/perf/seed_corpus.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""Seed a Musubi instance with a deterministic synthetic corpus for
+perf testing.
+
+Philosophy
+----------
+Perf runs need to be **reproducible across runs**. That means the
+corpus seeded before Gate 2 (load) must be bit-identical to the corpus
+seeded before Gate 4 (reliability), so latency deltas between runs
+reflect code/hardware changes, not corpus drift. We drive everything
+from a single ``--seed`` argument — the random selection, the length
+distribution, the topic tagging, the timestamp spread. Same seed =
+same corpus.
+
+Philosophy (the other part)
+---------------------------
+We deliberately do **not** hit an external LLM (Ollama, OASST) for
+generation. That keeps the seed step self-contained and deterministic
+— no "but the model version changed" variance. The pool of seed
+fragments is intentionally mundane household-conversation-shaped text;
+the point is exercising dense/sparse embedding + rerank latency, not
+producing human-realistic corpora.
+
+Targets
+-------
+Seeds all five planes via Musubi's canonical API:
+
+  * episodic   — ``POST /v1/memories``
+  * curated    — ``POST /v1/curated-knowledge`` (via operator token)
+  * concept    — ``POST /v1/concepts`` (operator-scoped)
+  * artifact   — ``POST /v1/artifacts`` (multipart)
+  * thought    — ``POST /v1/thoughts/send``
+
+Namespaces are pinned under ``perf-test/<plane>`` so live data at
+``eric/*`` is never touched.
+
+Usage
+-----
+  MUSUBI_V2_BASE_URL=https://musubi.mey.house/v1 \\
+  MUSUBI_V2_TOKEN=mbi_perf_... \\
+  python3 scripts/perf/seed_corpus.py \\
+      --size 10000 --seed 42 --namespace-prefix perf-test
+
+Size is per-plane; ``--size 10000`` creates 10k episodic + 10k curated
++ 10k concept + 10k artifact + 10k thought. Use ``--planes`` to limit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import logging
+import os
+import random
+import sys
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+try:
+    import httpx
+except ImportError:
+    sys.stderr.write("seed_corpus.py requires httpx. Install: pip install httpx\n")
+    sys.exit(2)
+
+log = logging.getLogger("musubi.perf.seed")
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+
+PLANES = ("episodic", "curated", "concept", "artifact", "thought")
+
+# Intentionally mundane fragments — household + ops + meta mix. The
+# pool is small on purpose: seeded random sampling over a small pool
+# gives realistic duplication + reinforcement patterns (the same fact
+# mentioned in two episodic captures) which exercises dedup + scoring.
+_FRAGMENTS: tuple[str, ...] = (
+    "Remember the dentist appointment on Tuesday afternoon.",
+    "Eric prefers coffee black, no sugar.",
+    "Aoi mentioned the deploy finished cleanly.",
+    "Nyla is running a background sweep on household memory.",
+    "Party agent handles delegation to the other voice agents.",
+    "OpenClaw sidecar is responsible for capture mirroring.",
+    "The LiveKit stack routes SIP into voice tools.",
+    "Kong is the gateway that fronts musubi.mey.house for external traffic.",
+    "Qdrant holds every plane's vector embeddings behind named collections.",
+    "TEI serves BGE-M3 dense + SPLADE sparse embeddings on the RTX 3080.",
+    "BGE-reranker-v2-m3 does the cross-encoder rerank pass on hybrid retrieve.",
+    "Ollama runs Qwen2.5-7B Q4 for importance scoring and fact extraction.",
+    "Musubi's lifecycle engine sweeps maturation every five minutes.",
+    "Concept synthesis kicks off when episodic cluster size crosses threshold.",
+    "Promotion moves a concept into the curated plane after reinforcement.",
+    "Demotion archives episodic rows past the provisional TTL.",
+    "Reflection runs weekly and looks for contradiction patterns.",
+    "The auto-digest-bump workflow opens a PR on every release:published.",
+    "cosign keyless signs the core image via GitHub OIDC.",
+    "CycloneDX SBOM is attached to the image via anchore/sbom-action.",
+    "Trivy scans each published image and uploads SARIF to Code Scanning.",
+    "Slice-adapter-livekit shipped end-to-end tests against docker-compose Musubi.",
+    "The thought stream SSE consumer honors six consumer-expectation rules.",
+    "Presence resolution maps OpenClaw agent ids to Musubi presences.",
+    "Bearer tokens scope per-namespace read/write on the canonical API.",
+    "The curated plane is read-mostly; vault sync is the writer.",
+    "Episodic memories land provisional and mature to a stable state.",
+    "Retrieve fast-mode returns in under 200ms on reference hardware.",
+    "Retrieve deep-mode budgets five seconds for the full hybrid path.",
+    "Thoughts flow presence-to-presence with optional channel routing.",
+    "A vault sync pulls curated markdown into the episodic/concept chunker.",
+    "The observability stack emits structured JSON one field per concept.",
+    "Hybrid retrieve blends dense + sparse + lexical + recency + importance.",
+    "Namespace scope errors surface as 403 with a typed error envelope.",
+    "Rate limits follow the token-bucket pattern with operator multiplier.",
+    "Idempotency keys dedupe retried writes so the same capture is one row.",
+    "Artifact plane stores content-addressed blobs plus chunk embeddings.",
+    "Migration slice ETLs the alpha POC into the new canonical layout.",
+    "The release-please workflow cuts semver releases from conventional commits.",
+    "Every plane carries bitemporal event_at plus ingested_at timestamps.",
+    "Lineage fields supersedes and superseded_by chain mutations explicitly.",
+    "KSUID object ids live in payload; Qdrant point ids stay UUID.",
+    "Schema version is stamped on every payload for forward-read compatibility.",
+    "Operator notes flag anything sensitive that shouldn't land in git.",
+    "The scheduler channel carries time-boxed reminders between agents.",
+    "musubi_recall hits deep-mode retrieve across every plane by default.",
+    "musubi_remember captures at importance seven, above the passive baseline.",
+    "musubi_think delivers a presence-to-presence thought inline from voice.",
+    "A voice call triggers bursty retrieve+capture for a couple minutes.",
+    "Soak tests catch leaks that 15-minute load runs miss entirely.",
+    "Spike tests mimic a LiveKit session landing on top of background load.",
+)
+
+_TOPICS: tuple[str, ...] = (
+    "household",
+    "deploy",
+    "ops",
+    "voice",
+    "memory",
+    "retrieval",
+    "lifecycle",
+    "security",
+    "observability",
+    "migration",
+    "scheduler",
+    "presence",
+)
+
+
+@dataclass(frozen=True)
+class SeedConfig:
+    base_url: str
+    token: str
+    size: int
+    seed: int
+    namespace_prefix: str
+    planes: tuple[str, ...]
+    # How far back to spread timestamps. 90 days gives maturation a
+    # realistic age distribution (some provisional, some matured).
+    timespan_days: int = 90
+    # Per-request timeout. Generous — the seed runs once per corpus,
+    # we care about completing, not latency.
+    request_timeout_s: float = 30.0
+
+
+def parse_args() -> SeedConfig:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--size", type=int, required=True, help="rows per plane")
+    p.add_argument("--seed", type=int, default=42, help="deterministic RNG seed")
+    p.add_argument(
+        "--namespace-prefix",
+        default="perf-test",
+        help="namespace root for all seeded data; kept off 'eric/*' on purpose",
+    )
+    p.add_argument(
+        "--planes",
+        default=",".join(PLANES),
+        help=f"comma-separated subset of {PLANES}",
+    )
+    p.add_argument("--timespan-days", type=int, default=90)
+    args = p.parse_args()
+
+    base_url = os.environ.get("MUSUBI_V2_BASE_URL")
+    token = os.environ.get("MUSUBI_V2_TOKEN")
+    if not base_url or not token:
+        sys.stderr.write(
+            "error: MUSUBI_V2_BASE_URL and MUSUBI_V2_TOKEN must be set.\n"
+            "       The token must scope write access on "
+            f"{args.namespace_prefix}/* — never on eric/*.\n"
+        )
+        sys.exit(2)
+
+    planes = tuple(p.strip() for p in args.planes.split(",") if p.strip())
+    bad = [p for p in planes if p not in PLANES]
+    if bad:
+        sys.stderr.write(f"error: unknown plane(s): {bad}\n")
+        sys.exit(2)
+
+    return SeedConfig(
+        base_url=base_url.rstrip("/"),
+        token=token,
+        size=args.size,
+        seed=args.seed,
+        namespace_prefix=args.namespace_prefix.rstrip("/"),
+        planes=planes,
+        timespan_days=args.timespan_days,
+    )
+
+
+def make_content(rng: random.Random) -> str:
+    """Pick 1-4 fragments and join them. Seeded sampling from a small
+    pool produces realistic duplication and reinforcement patterns."""
+    k = rng.randint(1, 4)
+    return " ".join(rng.sample(_FRAGMENTS, k=k))
+
+
+def make_timestamp(rng: random.Random, timespan_days: int) -> datetime:
+    """Uniform spread across ``timespan_days`` ending at now. Late-
+    skew would be more realistic but makes maturation test results
+    uniform (all rows mature/not-mature together); uniform spread
+    keeps the mix deterministic and testable."""
+    seconds = rng.randint(0, timespan_days * 86400)
+    return datetime.now(UTC) - timedelta(seconds=seconds)
+
+
+def make_idempotency_key(namespace: str, content: str, timestamp: datetime) -> str:
+    """Deterministic idempotency key. Re-running the seed against the
+    same Musubi should NOT create duplicates — Musubi's capture pipeline
+    dedups on this key."""
+    h = hashlib.sha256()
+    h.update(namespace.encode())
+    h.update(content.encode())
+    h.update(timestamp.isoformat().encode())
+    return f"perf-seed:{h.hexdigest()[:24]}"
+
+
+def seed_episodic(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> int:
+    """POST /v1/memories. Repeated calls with the same idempotency key
+    fold into a single row, so the seed is safe to retry."""
+    ns = f"{cfg.namespace_prefix}/episodic"
+    ok = 0
+    for i in range(cfg.size):
+        content = make_content(rng)
+        ts = make_timestamp(rng, cfg.timespan_days)
+        body = {
+            "namespace": ns,
+            "content": content,
+            "tags": rng.sample(_TOPICS, k=rng.randint(1, 3)),
+            "topics": rng.sample(_TOPICS, k=rng.randint(0, 2)),
+            "importance": rng.randint(1, 9),
+        }
+        try:
+            r = client.post(
+                "/memories",
+                json=body,
+                headers={"Idempotency-Key": make_idempotency_key(ns, content, ts)},
+            )
+            r.raise_for_status()
+            ok += 1
+        except httpx.HTTPError as exc:
+            log.warning("episodic %d failed: %s", i, exc)
+        if i and i % 500 == 0:
+            log.info("episodic: %d / %d", i, cfg.size)
+    return ok
+
+
+def seed_thought(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> int:
+    ns = f"{cfg.namespace_prefix}/thought"
+    ok = 0
+    for i in range(cfg.size):
+        body = {
+            "namespace": ns,
+            "from_presence": f"{cfg.namespace_prefix}/seeder",
+            "to_presence": f"{cfg.namespace_prefix}/receiver-{i % 4}",
+            "content": make_content(rng),
+            "channel": rng.choice(("default", "scheduler", "ops")),
+            "importance": rng.randint(1, 9),
+        }
+        try:
+            r = client.post("/thoughts/send", json=body)
+            r.raise_for_status()
+            ok += 1
+        except httpx.HTTPError as exc:
+            log.warning("thought %d failed: %s", i, exc)
+        if i and i % 500 == 0:
+            log.info("thought: %d / %d", i, cfg.size)
+    return ok
+
+
+def seed_curated(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> int:
+    """POST /v1/curated-knowledge. Requires operator scope + body_hash.
+    Vault sync is the normal writer — seeding here is a deliberate
+    bypass for perf-testing corpus construction only."""
+    ns = f"{cfg.namespace_prefix}/curated"
+    ok = 0
+    for i in range(cfg.size):
+        content = make_content(rng)
+        body_hash = hashlib.sha256(content.encode()).hexdigest()
+        body = {
+            "namespace": ns,
+            "title": f"perf-seeded-{i:06d}",
+            "content": content,
+            "vault_path": f"{cfg.namespace_prefix}/curated/{i:06d}.md",
+            "body_hash": body_hash,
+            "tags": rng.sample(_TOPICS, k=rng.randint(1, 3)),
+        }
+        try:
+            r = client.post("/curated-knowledge", json=body)
+            r.raise_for_status()
+            ok += 1
+        except httpx.HTTPError as exc:
+            log.warning("curated %d failed: %s", i, exc)
+        if i and i % 500 == 0:
+            log.info("curated: %d / %d", i, cfg.size)
+    return ok
+
+
+def seed_concept(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> int:
+    """POST /v1/concepts. Concepts are normally emitted by the
+    synthesis lifecycle job; seeding bypasses it to give retrieve
+    something to rerank against."""
+    ns = f"{cfg.namespace_prefix}/concept"
+    ok = 0
+    for i in range(cfg.size):
+        body = {
+            "namespace": ns,
+            "content": make_content(rng),
+            "tags": rng.sample(_TOPICS, k=rng.randint(1, 3)),
+            "importance": rng.randint(1, 9),
+        }
+        try:
+            r = client.post("/concepts", json=body)
+            r.raise_for_status()
+            ok += 1
+        except httpx.HTTPError as exc:
+            log.warning("concept %d failed: %s", i, exc)
+        if i and i % 500 == 0:
+            log.info("concept: %d / %d", i, cfg.size)
+    return ok
+
+
+def seed_artifact(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> int:
+    """POST /v1/artifacts — multipart. Smaller volume by default would
+    be sensible; artifacts are heavier. Kept at --size for symmetry;
+    tune via --planes if you want to skip."""
+    ns = f"{cfg.namespace_prefix}/artifact"
+    ok = 0
+    for i in range(cfg.size):
+        # Multi-section markdown so the chunker has work to do.
+        content = (
+            f"# perf-seeded-{i:06d}\n\n"
+            f"## Section A\n\n{make_content(rng)}\n\n"
+            f"## Section B\n\n{make_content(rng)}\n\n"
+            f"## Section C\n\n{make_content(rng)}\n"
+        ).encode()
+        data = {
+            "namespace": ns,
+            "title": f"perf-seeded-{i:06d}.md",
+            "content_type": "text/markdown",
+            "source_system": "perf-seed",
+            "chunker": "markdown-headings-v1",
+        }
+        files = {"file": (f"perf-seeded-{i:06d}.md", content, "text/markdown")}
+        try:
+            r = client.post("/artifacts", data=data, files=files)
+            r.raise_for_status()
+            ok += 1
+        except httpx.HTTPError as exc:
+            log.warning("artifact %d failed: %s", i, exc)
+        if i and i % 250 == 0:
+            log.info("artifact: %d / %d", i, cfg.size)
+    return ok
+
+
+_SEEDERS = {
+    "episodic": seed_episodic,
+    "curated": seed_curated,
+    "concept": seed_concept,
+    "artifact": seed_artifact,
+    "thought": seed_thought,
+}
+
+
+def main() -> int:
+    cfg = parse_args()
+    log.info(
+        "seeding: size=%d seed=%d planes=%s namespace_prefix=%s target=%s",
+        cfg.size,
+        cfg.seed,
+        cfg.planes,
+        cfg.namespace_prefix,
+        cfg.base_url,
+    )
+
+    started = time.monotonic()
+    totals: dict[str, int] = {}
+
+    with httpx.Client(
+        base_url=cfg.base_url,
+        headers={
+            "Authorization": f"Bearer {cfg.token}",
+            "User-Agent": "musubi-perf-seed/1",
+        },
+        timeout=cfg.request_timeout_s,
+    ) as client:
+        for plane in cfg.planes:
+            # Per-plane RNG fork so runs with --planes=episodic,thought
+            # produce the same episodic+thought content as a full run.
+            rng = random.Random(f"{cfg.seed}:{plane}")
+            log.info("=== plane=%s ===", plane)
+            totals[plane] = _SEEDERS[plane](client, cfg, rng)
+
+    elapsed = time.monotonic() - started
+    log.info("done in %.1fs. totals: %s", elapsed, totals)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/perf/telemetry.sh
+++ b/scripts/perf/telemetry.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Telemetry sidecar — runs alongside a k6 scenario and captures
+# host-side resource data at 5s cadence. The k6 run itself produces
+# API-side latency + error metrics; this script covers the pieces k6
+# can't see (container RSS, GPU utilization, Qdrant index growth).
+#
+# Usage:
+#
+#   scripts/perf/telemetry.sh start <run-label>
+#   # ... k6 run in parallel ...
+#   scripts/perf/telemetry.sh stop
+#   scripts/perf/telemetry.sh summarize <run-label>
+#
+# Or, for convenience, `make perf-load` wraps this with the k6 run.
+#
+# Outputs:
+#
+#   ~/perf-runs/<label>/
+#     docker-stats.jsonl     — docker stats sample every 5s
+#     nvidia-smi.jsonl       — GPU sample every 5s (if present)
+#     musubi-access.log      — tail of musubi-core access logs
+#     summary.md             — post-run rollup (run `summarize`)
+
+set -euo pipefail
+
+# -------- config --------------------------------------------------
+
+RUN_ROOT="${PERF_RUN_ROOT:-$HOME/perf-runs}"
+SAMPLE_INTERVAL_S="${SAMPLE_INTERVAL_S:-5}"
+PID_FILE="/tmp/musubi-perf-telemetry.pid"
+
+# -------- helpers -------------------------------------------------
+
+log() { printf '[telemetry %s] %s\n' "$(date -u +%H:%M:%SZ)" "$*" >&2; }
+
+die() { log "ERROR: $*"; exit 1; }
+
+usage() {
+  sed -n '2,20p' "$0"
+  exit 1
+}
+
+# -------- commands ------------------------------------------------
+
+cmd_start() {
+  local label="${1:?missing run label}"
+  local dir="$RUN_ROOT/$label"
+  mkdir -p "$dir"
+
+  if [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+    die "telemetry already running as pid $(cat "$PID_FILE"). 'stop' it first."
+  fi
+
+  log "starting telemetry → $dir (sample every ${SAMPLE_INTERVAL_S}s)"
+
+  # Launch the sampler subshell. It traps SIGTERM so `stop` can
+  # flush cleanly. `exec` replaces shell, keeping PID stable for
+  # the stop command.
+  (
+    trap 'log "telemetry sampler stopping"; exit 0' TERM INT
+    while :; do
+      ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+      # Docker stats — JSON per container, one line per container per sample.
+      if command -v docker >/dev/null 2>&1; then
+        docker stats --no-stream --format '{{json .}}' 2>/dev/null \
+          | jq -c --arg ts "$ts" '. + {ts: $ts}' \
+          >> "$dir/docker-stats.jsonl" || true
+      fi
+
+      # GPU — skip silently if nvidia-smi isn't installed (dev machines).
+      if command -v nvidia-smi >/dev/null 2>&1; then
+        nvidia-smi --query-gpu=timestamp,name,utilization.gpu,utilization.memory,memory.used,memory.free,temperature.gpu \
+                   --format=csv,noheader,nounits 2>/dev/null \
+          | awk -v ts="$ts" 'BEGIN{FS=", "}{
+              printf "{\"ts\":\"%s\",\"name\":\"%s\",\"gpu_util\":%s,\"mem_util\":%s,\"mem_used_mib\":%s,\"mem_free_mib\":%s,\"temp_c\":%s}\n",
+                ts, $2, $3, $4, $5, $6, $7
+            }' \
+          >> "$dir/nvidia-smi.jsonl" || true
+      fi
+
+      sleep "$SAMPLE_INTERVAL_S"
+    done
+  ) &
+
+  echo $! > "$PID_FILE"
+  log "started as pid $(cat "$PID_FILE")"
+}
+
+cmd_stop() {
+  if [[ ! -f "$PID_FILE" ]]; then
+    log "not running (no pidfile)"
+    return 0
+  fi
+  local pid
+  pid="$(cat "$PID_FILE")"
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -TERM "$pid"
+    wait "$pid" 2>/dev/null || true
+    log "stopped pid $pid"
+  else
+    log "pid $pid not running"
+  fi
+  rm -f "$PID_FILE"
+}
+
+cmd_summarize() {
+  local label="${1:?missing run label}"
+  local dir="$RUN_ROOT/$label"
+  [[ -d "$dir" ]] || die "no run dir: $dir"
+
+  local summary="$dir/summary.md"
+
+  {
+    printf '# perf run: %s\n\n' "$label"
+    printf 'generated: %s\n\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+    printf '## Docker stats rollup\n\n'
+    if [[ -s "$dir/docker-stats.jsonl" ]]; then
+      jq -rn --slurpfile d "$dir/docker-stats.jsonl" '
+        [$d[] | {
+          name: .Name,
+          cpu: (.CPUPerc | rtrimstr("%") | tonumber? // 0),
+          mem_pct: (.MemPerc | rtrimstr("%") | tonumber? // 0)
+        }]
+        | group_by(.name)
+        | map({
+            name: .[0].name,
+            samples: length,
+            cpu_p50: (map(.cpu) | sort | .[(length/2 | floor)]),
+            cpu_p95: (map(.cpu) | sort | .[(length*0.95 | floor)]),
+            cpu_max: (map(.cpu) | max),
+            mem_p50: (map(.mem_pct) | sort | .[(length/2 | floor)]),
+            mem_p95: (map(.mem_pct) | sort | .[(length*0.95 | floor)]),
+            mem_max: (map(.mem_pct) | max)
+          })
+        | .[]
+        | "- **\(.name)** (samples=\(.samples)): cpu p50=\(.cpu_p50)% p95=\(.cpu_p95)% max=\(.cpu_max)% | mem p50=\(.mem_p50)% p95=\(.mem_p95)% max=\(.mem_max)%"
+      '
+    else
+      printf '_no docker-stats.jsonl captured_\n'
+    fi
+    printf '\n'
+
+    printf '## GPU rollup\n\n'
+    if [[ -s "$dir/nvidia-smi.jsonl" ]]; then
+      jq -rn --slurpfile g "$dir/nvidia-smi.jsonl" '
+        [$g[]]
+        | {
+            samples: length,
+            gpu_util_p50: (map(.gpu_util) | sort | .[(length/2 | floor)]),
+            gpu_util_p95: (map(.gpu_util) | sort | .[(length*0.95 | floor)]),
+            gpu_util_max: (map(.gpu_util) | max),
+            mem_used_p50: (map(.mem_used_mib) | sort | .[(length/2 | floor)]),
+            mem_used_p95: (map(.mem_used_mib) | sort | .[(length*0.95 | floor)]),
+            mem_used_max: (map(.mem_used_mib) | max),
+            mem_free_min: (map(.mem_free_mib) | min),
+            temp_max: (map(.temp_c) | max)
+          }
+        | "- samples=\(.samples)",
+          "- gpu_util: p50=\(.gpu_util_p50)% p95=\(.gpu_util_p95)% max=\(.gpu_util_max)%",
+          "- mem_used: p50=\(.mem_used_p50)MiB p95=\(.mem_used_p95)MiB max=\(.mem_used_max)MiB",
+          "- mem_free_min: \(.mem_free_min)MiB  ← must stay ≥ 1024 per perf gate",
+          "- temp_max: \(.temp_max)°C"
+      '
+    else
+      printf '_no nvidia-smi.jsonl — telemetry ran on a host without NVIDIA_\n'
+    fi
+    printf '\n'
+
+    printf '## Files\n\n'
+    ls -lh "$dir" | awk 'NR>1 {printf "- `%s` (%s)\n", $NF, $5}'
+  } > "$summary"
+
+  log "summary written: $summary"
+  cat "$summary"
+}
+
+# -------- dispatch ------------------------------------------------
+
+case "${1:-}" in
+  start) shift; cmd_start "$@" ;;
+  stop) cmd_stop ;;
+  summarize) shift; cmd_summarize "$@" ;;
+  *) usage ;;
+esac


### PR DESCRIPTION
No tracking Issue: Gate 0 of the load+perf testing plan discussed earlier today. Scripts only; zero live-system contact in this PR.

## Summary

Lands the harness we need to execute Gates 1–4 (rebaseline → load → spike → soak + reliability). Also lands an interim manual-recovery runbook since \`deploy/backup/restore.yml\` has rot (#190).

## What this PR adds

### \`scripts/perf/\`

| File | Purpose |
|---|---|
| \`seed_corpus.py\` | Deterministic synthetic corpus generator. Seeds all 5 planes via canonical API. Idempotent on retry. Defaults to \`perf-test/*\` namespace so \`eric/*\` is safe. |
| \`k6/baseline.js\` | Single-VU sequential happy-path floor measurement |
| \`k6/load.js\` | 10 VU, 2m ramp + 13m steady, weighted workload mix |
| \`k6/spike.js\` | 2 RPS baseline → 15 RPS burst for 20s → recovery window (mimics a voice call landing on background load) |
| \`k6/_shared.js\` | Auth headers + endpoint helpers shared across scenarios |
| \`telemetry.sh\` | Host-side sidecar. Samples docker stats + nvidia-smi every 5s. \`summarize\` rolls up p50/p95/max for CPU, RSS, GPU util, VRAM headroom. |
| \`README.md\` | How it all composes, prerequisites, env vars, safety rails. |

### \`deploy/runbooks/manual-recovery.md\`

7-step operator runbook for recovery from a backup snapshot without Ansible — stop stack → Qdrant snapshot-upload via HTTP API → SQLite copy → artifact-blobs rsync → restart → verify. Standard Command/Expected/Destructive/Rollback section format.

### \`Makefile\`

New targets:
- \`make perf-seed SIZE=10000 SEED=42\`
- \`make perf-baseline LABEL=<tag>\`
- \`make perf-load LABEL=<tag>\`
- \`make perf-spike LABEL=<tag>\`

All gate on \`MUSUBI_V2_BASE_URL\` + \`MUSUBI_V2_TOKEN\` being set. Outputs land under \`~/perf-runs/<LABEL>/\`.

## Operator pre-flight already done

- Labeled snapshot \`/var/lib/musubi/backups/pre-perf-baseline-2026-04-22/\` on musubi.mey.house — rollback point for the whole perf cycle.
- Backup timer confirmed active; 7 recent 6h-cadence snapshots present.
- Zero ansible drift against the running deployment (running digest exactly matches \`group_vars/all.yml\` pin).
- Alpha (Mac-side \`house-brain-qdrant\`) isolation confirmed — new Musubi's deps are all sibling containers.

## Not in this PR

- Running anything against a live stack. That's Gate 1+ and each proceeds on explicit approval after per-gate prep (labeled snapshot, scoped token, env-var staging).
- \`deploy/backup/restore.yml\` repair — #190. The manual runbook in this PR is the interim cover.

## Gates

- [x] \`make check\` → 1144 passed, 231 skipped (pre-existing), 17 deselected
- [x] \`make agent-check\` → 0 errors, 8 pre-existing warnings
- [x] Python + bash syntax checks clean
- [ ] PR-event Vault hygiene green
- [ ] post-merge Vault check green