### PR TITLE
fix(ops): perf harness — idempotent seed + remote telemetry + 429 backoff

### DIFF
--- a/scripts/perf/seed_corpus.py
+++ b/scripts/perf/seed_corpus.py
@@ -31,15 +31,18 @@ Seeds all five planes via Musubi's canonical API:
   * artifact   — ``POST /v1/artifacts`` (multipart)
   * thought    — ``POST /v1/thoughts/send``
 
-Namespaces are pinned under ``perf-test/<plane>`` so live data at
-``eric/*`` is never touched.
+Namespaces are pinned under ``<tenant>/<presence>/<plane>`` (the
+canonical three-segment format), defaulting to
+``perf-test/harness/<plane>`` so live data at ``eric/*`` is never
+touched. The tenant + presence are taken from ``--namespace-prefix``
+which must be exactly two segments.
 
 Usage
 -----
-  MUSUBI_V2_BASE_URL=https://musubi.mey.house/v1 \\
+  MUSUBI_V2_BASE_URL=http://musubi.mey.house:8100/v1 \\
   MUSUBI_V2_TOKEN=mbi_perf_... \\
   python3 scripts/perf/seed_corpus.py \\
-      --size 10000 --seed 42 --namespace-prefix perf-test
+      --size 10000 --seed 42 --namespace-prefix perf-test/harness
 
 Size is per-plane; ``--size 10000`` creates 10k episodic + 10k curated
 + 10k concept + 10k artifact + 10k thought. Use ``--planes`` to limit.
@@ -175,8 +178,12 @@ def parse_args() -> SeedConfig:
     p.add_argument("--seed", type=int, default=42, help="deterministic RNG seed")
     p.add_argument(
         "--namespace-prefix",
-        default="perf-test",
-        help="namespace root for all seeded data; kept off 'eric/*' on purpose",
+        default="perf-test/harness",
+        help=(
+            "tenant/presence prefix for all seeded data; the plane is "
+            "appended automatically to produce the canonical three-segment "
+            "namespace. Kept off 'eric/*' on purpose."
+        ),
     )
     p.add_argument(
         "--planes",
@@ -202,12 +209,22 @@ def parse_args() -> SeedConfig:
         sys.stderr.write(f"error: unknown plane(s): {bad}\n")
         sys.exit(2)
 
+    # Server rejects anything other than exactly `<tenant>/<presence>/<plane>`
+    # — fail loudly here instead of eating 500s mid-run.
+    prefix = args.namespace_prefix.strip("/")
+    if prefix.count("/") != 1 or not all(prefix.split("/")):
+        sys.stderr.write(
+            f"error: --namespace-prefix must be 'tenant/presence' (got {prefix!r}).\n"
+            "       The plane is appended automatically.\n"
+        )
+        sys.exit(2)
+
     return SeedConfig(
         base_url=base_url.rstrip("/"),
         token=token,
         size=args.size,
         seed=args.seed,
-        namespace_prefix=args.namespace_prefix.rstrip("/"),
+        namespace_prefix=prefix,
         planes=planes,
         timespan_days=args.timespan_days,
     )
@@ -267,7 +284,9 @@ def _sleep_for_429(resp: httpx.Response, attempt: int, rng: random.Random) -> fl
         # 0.25s, 0.5s, 1s, 2s, 4s, 8s + 0-25% jitter.
         wait_s = BASE_BACKOFF_S * (2**attempt)
         wait_s += wait_s * rng.random() * 0.25
-    wait_s = min(wait_s, MAX_BACKOFF_S)
+    # Clamp below too — a misbehaving proxy returning a negative
+    # Retry-After would otherwise crash time.sleep().
+    wait_s = max(0.0, min(wait_s, MAX_BACKOFF_S))
     time.sleep(wait_s)
     return wait_s
 
@@ -337,6 +356,8 @@ def seed_episodic(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> 
             ok += 1
         elif r is not None:
             log.warning("episodic %d: %d %s", i, r.status_code, r.text[:160])
+        else:
+            log.warning("episodic %d: skipped (transport error or 429 exhaustion)", i)
         if i and i % 500 == 0:
             log.info("episodic: %d / %d (ok=%d)", i, cfg.size, ok)
     return ok
@@ -360,6 +381,8 @@ def seed_thought(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> i
             ok += 1
         elif r is not None:
             log.warning("thought %d: %d %s", i, r.status_code, r.text[:160])
+        else:
+            log.warning("thought %d: skipped (transport error or 429 exhaustion)", i)
         if i and i % 500 == 0:
             log.info("thought: %d / %d (ok=%d)", i, cfg.size, ok)
     return ok
@@ -392,6 +415,8 @@ def seed_curated(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> i
             ok += 1
         elif r is not None:
             log.warning("curated %d: %d %s", i, r.status_code, r.text[:160])
+        else:
+            log.warning("curated %d: skipped (transport error or 429 exhaustion)", i)
         if i and i % 500 == 0:
             log.info("curated: %d / %d (ok=%d)", i, cfg.size, ok)
     return ok
@@ -427,6 +452,8 @@ def seed_concept(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> i
             ok += 1
         elif r is not None:
             log.warning("concept %d: %d %s", i, r.status_code, r.text[:160])
+        else:
+            log.warning("concept %d: skipped (transport error or 429 exhaustion)", i)
         if i and i % 500 == 0:
             log.info("concept: %d / %d (ok=%d)", i, cfg.size, ok)
     return ok
@@ -464,6 +491,8 @@ def seed_artifact(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> 
             ok += 1
         elif r is not None:
             log.warning("artifact %d: %d %s", i, r.status_code, r.text[:160])
+        else:
+            log.warning("artifact %d: skipped (transport error or 429 exhaustion)", i)
         if i and i % 250 == 0:
             log.info("artifact: %d / %d (ok=%d)", i, cfg.size, ok)
     return ok

--- a/scripts/perf/seed_corpus.py
+++ b/scripts/perf/seed_corpus.py
@@ -63,6 +63,14 @@ except ImportError:
     sys.stderr.write("seed_corpus.py requires httpx. Install: pip install httpx\n")
     sys.exit(2)
 
+# Fixed anchor — timestamps derive as `TIMESTAMP_ANCHOR - offset_seconds`
+# where offset comes from the seeded RNG. Pinning this to a constant
+# epoch makes the entire corpus — content + timestamps + idempotency
+# keys — bit-identical across runs of the same --seed. That's what
+# makes the seed genuinely idempotent on retry: the server sees the
+# same idempotency key and dedupes into the pre-existing row.
+TIMESTAMP_ANCHOR = datetime(2026, 4, 1, 0, 0, 0, tzinfo=UTC)
+
 log = logging.getLogger("musubi.perf.seed")
 logging.basicConfig(
     level=logging.INFO,
@@ -213,12 +221,14 @@ def make_content(rng: random.Random) -> str:
 
 
 def make_timestamp(rng: random.Random, timespan_days: int) -> datetime:
-    """Uniform spread across ``timespan_days`` ending at now. Late-
-    skew would be more realistic but makes maturation test results
-    uniform (all rows mature/not-mature together); uniform spread
-    keeps the mix deterministic and testable."""
+    """Uniform spread across ``timespan_days`` ending at the fixed
+    ``TIMESTAMP_ANCHOR``. Using a fixed anchor (not ``datetime.now()``)
+    is what lets the seed script be genuinely idempotent on retry:
+    same --seed produces the same timestamps, hence the same
+    idempotency keys, hence the server dedupes retried writes into
+    the existing rows instead of creating duplicates."""
     seconds = rng.randint(0, timespan_days * 86400)
-    return datetime.now(UTC) - timedelta(seconds=seconds)
+    return TIMESTAMP_ANCHOR - timedelta(seconds=seconds)
 
 
 def make_idempotency_key(namespace: str, content: str, timestamp: datetime) -> str:
@@ -232,11 +242,80 @@ def make_idempotency_key(namespace: str, content: str, timestamp: datetime) -> s
     return f"perf-seed:{h.hexdigest()[:24]}"
 
 
+# Backoff tuning. Musubi's rate-limit middleware returns 429 with a
+# Retry-After header (in seconds) — honor it first. If the header
+# is missing, fall back to exponential backoff anchored at 250ms with
+# jitter, capped at MAX_BACKOFF_S. After MAX_429_RETRIES attempts we
+# give up on the row and move on — a dropped seed row is recoverable
+# by re-running (idempotency keys dedupe against what's already there).
+MAX_429_RETRIES = 6
+BASE_BACKOFF_S = 0.25
+MAX_BACKOFF_S = 30.0
+
+
+def _sleep_for_429(resp: httpx.Response, attempt: int, rng: random.Random) -> float:
+    """Return how long we slept, for observability + tests."""
+    retry_after = resp.headers.get("Retry-After") or resp.headers.get("retry-after")
+    if retry_after:
+        try:
+            wait_s = float(retry_after)
+        except ValueError:
+            # Retry-After can be an HTTP date; we don't need that
+            # branch for Musubi (middleware emits integer seconds).
+            wait_s = BASE_BACKOFF_S * (2**attempt)
+    else:
+        # 0.25s, 0.5s, 1s, 2s, 4s, 8s + 0-25% jitter.
+        wait_s = BASE_BACKOFF_S * (2**attempt)
+        wait_s += wait_s * rng.random() * 0.25
+    wait_s = min(wait_s, MAX_BACKOFF_S)
+    time.sleep(wait_s)
+    return wait_s
+
+
+def post_with_backoff(
+    client: httpx.Client,
+    path: str,
+    *,
+    rng: random.Random,
+    json_body: dict | None = None,
+    data: dict | None = None,
+    files: dict | None = None,
+    extra_headers: dict[str, str] | None = None,
+) -> httpx.Response | None:
+    """POST wrapper that retries 429s with Retry-After / exp-backoff.
+
+    Returns the final ``httpx.Response`` on 2xx/4xx-other, or None if
+    we hit ``MAX_429_RETRIES`` consecutive 429s (caller logs + moves
+    on). Non-429 4xx and 5xx are NOT retried — those are either client
+    bugs or transient server errors that the outer loop's per-row
+    warning surfaces. Keeps the seed simple: dedup makes re-runs
+    the retry mechanism for flaky rows."""
+    for attempt in range(MAX_429_RETRIES):
+        try:
+            r = client.post(
+                path,
+                json=json_body,
+                data=data,
+                files=files,
+                headers=extra_headers,
+            )
+        except httpx.HTTPError as exc:
+            log.warning("POST %s transport error (attempt %d): %s", path, attempt, exc)
+            return None
+        if r.status_code != 429:
+            return r
+        slept = _sleep_for_429(r, attempt, rng)
+        log.info("429 on %s (attempt %d); slept %.2fs", path, attempt, slept)
+    log.warning("POST %s gave up after %d consecutive 429s", path, MAX_429_RETRIES)
+    return None
+
+
 def seed_episodic(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> int:
     """POST /v1/memories. Repeated calls with the same idempotency key
     fold into a single row, so the seed is safe to retry."""
     ns = f"{cfg.namespace_prefix}/episodic"
     ok = 0
+    progress_rng = random.Random(cfg.seed ^ 0xBEEF)  # separate stream for sleeps
     for i in range(cfg.size):
         content = make_content(rng)
         ts = make_timestamp(rng, cfg.timespan_days)
@@ -247,24 +326,26 @@ def seed_episodic(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> 
             "topics": rng.sample(_TOPICS, k=rng.randint(0, 2)),
             "importance": rng.randint(1, 9),
         }
-        try:
-            r = client.post(
-                "/memories",
-                json=body,
-                headers={"Idempotency-Key": make_idempotency_key(ns, content, ts)},
-            )
-            r.raise_for_status()
+        r = post_with_backoff(
+            client,
+            "/memories",
+            rng=progress_rng,
+            json_body=body,
+            extra_headers={"Idempotency-Key": make_idempotency_key(ns, content, ts)},
+        )
+        if r is not None and r.is_success:
             ok += 1
-        except httpx.HTTPError as exc:
-            log.warning("episodic %d failed: %s", i, exc)
+        elif r is not None:
+            log.warning("episodic %d: %d %s", i, r.status_code, r.text[:160])
         if i and i % 500 == 0:
-            log.info("episodic: %d / %d", i, cfg.size)
+            log.info("episodic: %d / %d (ok=%d)", i, cfg.size, ok)
     return ok
 
 
 def seed_thought(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> int:
     ns = f"{cfg.namespace_prefix}/thought"
     ok = 0
+    backoff_rng = random.Random(cfg.seed ^ 0xF00D)
     for i in range(cfg.size):
         body = {
             "namespace": ns,
@@ -274,23 +355,27 @@ def seed_thought(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> i
             "channel": rng.choice(("default", "scheduler", "ops")),
             "importance": rng.randint(1, 9),
         }
-        try:
-            r = client.post("/thoughts/send", json=body)
-            r.raise_for_status()
+        r = post_with_backoff(client, "/thoughts/send", rng=backoff_rng, json_body=body)
+        if r is not None and r.is_success:
             ok += 1
-        except httpx.HTTPError as exc:
-            log.warning("thought %d failed: %s", i, exc)
+        elif r is not None:
+            log.warning("thought %d: %d %s", i, r.status_code, r.text[:160])
         if i and i % 500 == 0:
-            log.info("thought: %d / %d", i, cfg.size)
+            log.info("thought: %d / %d (ok=%d)", i, cfg.size, ok)
     return ok
 
 
 def seed_curated(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> int:
     """POST /v1/curated-knowledge. Requires operator scope + body_hash.
     Vault sync is the normal writer — seeding here is a deliberate
-    bypass for perf-testing corpus construction only."""
+    bypass for perf-testing corpus construction only.
+
+    Idempotency-on-retry: the ``body_hash`` is a pure function of
+    ``content``, so re-running the same --seed produces the same hashes
+    and the server dedupes into existing rows."""
     ns = f"{cfg.namespace_prefix}/curated"
     ok = 0
+    backoff_rng = random.Random(cfg.seed ^ 0xCAFE)
     for i in range(cfg.size):
         content = make_content(rng)
         body_hash = hashlib.sha256(content.encode()).hexdigest()
@@ -302,14 +387,13 @@ def seed_curated(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> i
             "body_hash": body_hash,
             "tags": rng.sample(_TOPICS, k=rng.randint(1, 3)),
         }
-        try:
-            r = client.post("/curated-knowledge", json=body)
-            r.raise_for_status()
+        r = post_with_backoff(client, "/curated-knowledge", rng=backoff_rng, json_body=body)
+        if r is not None and r.is_success:
             ok += 1
-        except httpx.HTTPError as exc:
-            log.warning("curated %d failed: %s", i, exc)
+        elif r is not None:
+            log.warning("curated %d: %d %s", i, r.status_code, r.text[:160])
         if i and i % 500 == 0:
-            log.info("curated: %d / %d", i, cfg.size)
+            log.info("curated: %d / %d (ok=%d)", i, cfg.size, ok)
     return ok
 
 
@@ -319,30 +403,46 @@ def seed_concept(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> i
     something to rerank against."""
     ns = f"{cfg.namespace_prefix}/concept"
     ok = 0
+    backoff_rng = random.Random(cfg.seed ^ 0xC0DE)
     for i in range(cfg.size):
+        content = make_content(rng)
+        # Concept ingest has no intrinsic content hash; we compute one
+        # from (namespace, content, deterministic index) so the
+        # Idempotency-Key is stable across re-runs of the same --seed.
+        ts_proxy = TIMESTAMP_ANCHOR - timedelta(seconds=i)
         body = {
             "namespace": ns,
-            "content": make_content(rng),
+            "content": content,
             "tags": rng.sample(_TOPICS, k=rng.randint(1, 3)),
             "importance": rng.randint(1, 9),
         }
-        try:
-            r = client.post("/concepts", json=body)
-            r.raise_for_status()
+        r = post_with_backoff(
+            client,
+            "/concepts",
+            rng=backoff_rng,
+            json_body=body,
+            extra_headers={"Idempotency-Key": make_idempotency_key(ns, content, ts_proxy)},
+        )
+        if r is not None and r.is_success:
             ok += 1
-        except httpx.HTTPError as exc:
-            log.warning("concept %d failed: %s", i, exc)
+        elif r is not None:
+            log.warning("concept %d: %d %s", i, r.status_code, r.text[:160])
         if i and i % 500 == 0:
-            log.info("concept: %d / %d", i, cfg.size)
+            log.info("concept: %d / %d (ok=%d)", i, cfg.size, ok)
     return ok
 
 
 def seed_artifact(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> int:
     """POST /v1/artifacts — multipart. Smaller volume by default would
     be sensible; artifacts are heavier. Kept at --size for symmetry;
-    tune via --planes if you want to skip."""
+    tune via --planes if you want to skip.
+
+    Idempotency-on-retry: artifact storage is content-addressed by
+    SHA256 of the blob; same --seed produces the same bytes so the
+    server dedupes on re-run."""
     ns = f"{cfg.namespace_prefix}/artifact"
     ok = 0
+    backoff_rng = random.Random(cfg.seed ^ 0xA57)
     for i in range(cfg.size):
         # Multi-section markdown so the chunker has work to do.
         content = (
@@ -359,14 +459,13 @@ def seed_artifact(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> 
             "chunker": "markdown-headings-v1",
         }
         files = {"file": (f"perf-seeded-{i:06d}.md", content, "text/markdown")}
-        try:
-            r = client.post("/artifacts", data=data, files=files)
-            r.raise_for_status()
+        r = post_with_backoff(client, "/artifacts", rng=backoff_rng, data=data, files=files)
+        if r is not None and r.is_success:
             ok += 1
-        except httpx.HTTPError as exc:
-            log.warning("artifact %d failed: %s", i, exc)
+        elif r is not None:
+            log.warning("artifact %d: %d %s", i, r.status_code, r.text[:160])
         if i and i % 250 == 0:
-            log.info("artifact: %d / %d", i, cfg.size)
+            log.info("artifact: %d / %d (ok=%d)", i, cfg.size, ok)
     return ok
 
 

--- a/scripts/perf/telemetry.sh
+++ b/scripts/perf/telemetry.sh
@@ -29,6 +29,21 @@ RUN_ROOT="${PERF_RUN_ROOT:-$HOME/perf-runs}"
 SAMPLE_INTERVAL_S="${SAMPLE_INTERVAL_S:-5}"
 PID_FILE="/tmp/musubi-perf-telemetry.pid"
 
+# If REMOTE_HOST is set, docker stats + nvidia-smi are collected over
+# SSH on that host — the common case when the perf driver (k6, seed
+# script) runs on a workstation but Musubi's containers + GPU live on
+# a different machine. Without REMOTE_HOST the sampler degrades to
+# local-only sampling (useful on a single-box dev setup).
+#
+# Usage:
+#   REMOTE_HOST=eric@musubi.mey.house scripts/perf/telemetry.sh start <label>
+#
+# SSH is expected to be key-based and non-interactive. We fail fast
+# on connection errors during `start` so you notice at setup-time
+# instead of discovering an empty jsonl after the run.
+REMOTE_HOST="${REMOTE_HOST:-}"
+SSH_OPTS="${SSH_OPTS:--o BatchMode=yes -o ConnectTimeout=5}"
+
 # -------- helpers -------------------------------------------------
 
 log() { printf '[telemetry %s] %s\n' "$(date -u +%H:%M:%SZ)" "$*" >&2; }
@@ -51,32 +66,31 @@ cmd_start() {
     die "telemetry already running as pid $(cat "$PID_FILE"). 'stop' it first."
   fi
 
-  log "starting telemetry → $dir (sample every ${SAMPLE_INTERVAL_S}s)"
+  if [[ -n "$REMOTE_HOST" ]]; then
+    # Fail fast if SSH isn't set up — a silent failure here turns
+    # into an empty jsonl file three hours later.
+    # shellcheck disable=SC2086
+    if ! ssh $SSH_OPTS "$REMOTE_HOST" "echo ok" >/dev/null 2>&1; then
+      die "REMOTE_HOST=$REMOTE_HOST is unreachable via ssh (check keys / BatchMode)."
+    fi
+    log "starting telemetry → $dir (remote=$REMOTE_HOST, every ${SAMPLE_INTERVAL_S}s)"
+  else
+    log "starting telemetry → $dir (local, every ${SAMPLE_INTERVAL_S}s)"
+    log "WARNING: REMOTE_HOST is unset — sampling THIS host. Set REMOTE_HOST=user@musubi-host"
+    log "         if Musubi's containers + GPU live on a different machine."
+  fi
 
   # Launch the sampler subshell. It traps SIGTERM so `stop` can
-  # flush cleanly. `exec` replaces shell, keeping PID stable for
-  # the stop command.
+  # flush cleanly.
   (
     trap 'log "telemetry sampler stopping"; exit 0' TERM INT
     while :; do
       ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
-      # Docker stats — JSON per container, one line per container per sample.
-      if command -v docker >/dev/null 2>&1; then
-        docker stats --no-stream --format '{{json .}}' 2>/dev/null \
-          | jq -c --arg ts "$ts" '. + {ts: $ts}' \
-          >> "$dir/docker-stats.jsonl" || true
-      fi
-
-      # GPU — skip silently if nvidia-smi isn't installed (dev machines).
-      if command -v nvidia-smi >/dev/null 2>&1; then
-        nvidia-smi --query-gpu=timestamp,name,utilization.gpu,utilization.memory,memory.used,memory.free,temperature.gpu \
-                   --format=csv,noheader,nounits 2>/dev/null \
-          | awk -v ts="$ts" 'BEGIN{FS=", "}{
-              printf "{\"ts\":\"%s\",\"name\":\"%s\",\"gpu_util\":%s,\"mem_util\":%s,\"mem_used_mib\":%s,\"mem_free_mib\":%s,\"temp_c\":%s}\n",
-                ts, $2, $3, $4, $5, $6, $7
-            }' \
-          >> "$dir/nvidia-smi.jsonl" || true
+      if [[ -n "$REMOTE_HOST" ]]; then
+        _sample_remote "$ts" "$dir"
+      else
+        _sample_local "$ts" "$dir"
       fi
 
       sleep "$SAMPLE_INTERVAL_S"
@@ -85,6 +99,55 @@ cmd_start() {
 
   echo $! > "$PID_FILE"
   log "started as pid $(cat "$PID_FILE")"
+}
+
+# -------- samplers ------------------------------------------------
+
+_sample_local() {
+  local ts="$1" dir="$2"
+
+  if command -v docker >/dev/null 2>&1; then
+    docker stats --no-stream --format '{{json .}}' 2>/dev/null \
+      | jq -c --arg ts "$ts" '. + {ts: $ts}' \
+      >> "$dir/docker-stats.jsonl" || true
+  fi
+
+  if command -v nvidia-smi >/dev/null 2>&1; then
+    nvidia-smi --query-gpu=timestamp,name,utilization.gpu,utilization.memory,memory.used,memory.free,temperature.gpu \
+               --format=csv,noheader,nounits 2>/dev/null \
+      | awk -v ts="$ts" 'BEGIN{FS=", "}{
+          printf "{\"ts\":\"%s\",\"name\":\"%s\",\"gpu_util\":%s,\"mem_util\":%s,\"mem_used_mib\":%s,\"mem_free_mib\":%s,\"temp_c\":%s}\n",
+            ts, $2, $3, $4, $5, $6, $7
+        }' \
+      >> "$dir/nvidia-smi.jsonl" || true
+  fi
+}
+
+_sample_remote() {
+  local ts="$1" dir="$2"
+
+  # Docker stats over SSH. `--format` curlies would need escaping
+  # through two shells; we use the template directly and trust that
+  # our SSH target isn't interpolating it (no jinja here, plain ssh).
+  # shellcheck disable=SC2086
+  ssh $SSH_OPTS "$REMOTE_HOST" \
+    "docker stats --no-stream --format '{{json .}}' 2>/dev/null" 2>/dev/null \
+    | jq -c --arg ts "$ts" '. + {ts: $ts}' \
+    >> "$dir/docker-stats.jsonl" || true
+
+  # GPU — server-side `command -v nvidia-smi` gate so a non-GPU
+  # host doesn't fail noisily; we just end up with an empty jsonl.
+  # shellcheck disable=SC2086
+  ssh $SSH_OPTS "$REMOTE_HOST" '
+    command -v nvidia-smi >/dev/null 2>&1 && \
+    nvidia-smi --query-gpu=timestamp,name,utilization.gpu,utilization.memory,memory.used,memory.free,temperature.gpu \
+               --format=csv,noheader,nounits 2>/dev/null
+  ' 2>/dev/null \
+    | awk -v ts="$ts" 'BEGIN{FS=", "}NF>=7{
+        printf "{\"ts\":\"%s\",\"name\":\"%s\",\"gpu_util\":%s,\"mem_util\":%s,\"mem_used_mib\":%s,\"mem_free_mib\":%s,\"temp_c\":%s}\n",
+          ts, $2, $3, $4, $5, $6, $7
+      }' \
+    >> "$dir/nvidia-smi.jsonl" || true
 }
 
 cmd_stop() {

--- a/scripts/perf/telemetry.sh
+++ b/scripts/perf/telemetry.sh
@@ -42,7 +42,12 @@ PID_FILE="/tmp/musubi-perf-telemetry.pid"
 # on connection errors during `start` so you notice at setup-time
 # instead of discovering an empty jsonl after the run.
 REMOTE_HOST="${REMOTE_HOST:-}"
-SSH_OPTS="${SSH_OPTS:--o BatchMode=yes -o ConnectTimeout=5}"
+# Use an array so arguments with spaces (e.g. identity paths) survive
+# expansion. If the caller wants to override, they can set SSH_OPTS
+# as a string of additional flags — we append those safely via
+# word-splitting on $SSH_OPTS only, never on SSH_OPTS_DEFAULT[@].
+SSH_OPTS_DEFAULT=(-o BatchMode=yes -o ConnectTimeout=5)
+SSH_OPTS="${SSH_OPTS:-}"
 
 # -------- helpers -------------------------------------------------
 
@@ -70,7 +75,7 @@ cmd_start() {
     # Fail fast if SSH isn't set up — a silent failure here turns
     # into an empty jsonl file three hours later.
     # shellcheck disable=SC2086
-    if ! ssh $SSH_OPTS "$REMOTE_HOST" "echo ok" >/dev/null 2>&1; then
+    if ! ssh "${SSH_OPTS_DEFAULT[@]}" $SSH_OPTS "$REMOTE_HOST" "echo ok" >/dev/null 2>&1; then
       die "REMOTE_HOST=$REMOTE_HOST is unreachable via ssh (check keys / BatchMode)."
     fi
     log "starting telemetry → $dir (remote=$REMOTE_HOST, every ${SAMPLE_INTERVAL_S}s)"
@@ -130,7 +135,7 @@ _sample_remote() {
   # through two shells; we use the template directly and trust that
   # our SSH target isn't interpolating it (no jinja here, plain ssh).
   # shellcheck disable=SC2086
-  ssh $SSH_OPTS "$REMOTE_HOST" \
+  ssh "${SSH_OPTS_DEFAULT[@]}" $SSH_OPTS "$REMOTE_HOST" \
     "docker stats --no-stream --format '{{json .}}' 2>/dev/null" 2>/dev/null \
     | jq -c --arg ts "$ts" '. + {ts: $ts}' \
     >> "$dir/docker-stats.jsonl" || true
@@ -138,7 +143,7 @@ _sample_remote() {
   # GPU — server-side `command -v nvidia-smi` gate so a non-GPU
   # host doesn't fail noisily; we just end up with an empty jsonl.
   # shellcheck disable=SC2086
-  ssh $SSH_OPTS "$REMOTE_HOST" '
+  ssh "${SSH_OPTS_DEFAULT[@]}" $SSH_OPTS "$REMOTE_HOST" '
     command -v nvidia-smi >/dev/null 2>&1 && \
     nvidia-smi --query-gpu=timestamp,name,utilization.gpu,utilization.memory,memory.used,memory.free,temperature.gpu \
                --format=csv,noheader,nounits 2>/dev/null

--- a/tests/ops/test_perf_seed.py
+++ b/tests/ops/test_perf_seed.py
@@ -69,7 +69,10 @@ def test_make_timestamp_never_exceeds_anchor() -> None:
 
 def test_idempotency_key_is_stable() -> None:
     seed = _load()
-    ns = "perf-test/episodic"
+    # Canonical namespace format is tenant/presence/plane — use a valid
+    # shape even in a hashing-only test so the fixture matches what
+    # real requests will carry.
+    ns = "perf-test/harness/episodic"
     content = "Eric prefers coffee black, no sugar."
     ts = datetime(2026, 3, 1, 12, 0, 0, tzinfo=UTC)
     k1 = seed.make_idempotency_key(ns, content, ts)
@@ -81,11 +84,11 @@ def test_idempotency_key_is_stable() -> None:
 def test_idempotency_key_changes_with_any_input() -> None:
     seed = _load()
     ts = datetime(2026, 3, 1, 12, 0, 0, tzinfo=UTC)
-    k_base = seed.make_idempotency_key("ns/a", "content", ts)
-    assert k_base != seed.make_idempotency_key("ns/b", "content", ts)
-    assert k_base != seed.make_idempotency_key("ns/a", "other content", ts)
+    k_base = seed.make_idempotency_key("t/p/a", "content", ts)
+    assert k_base != seed.make_idempotency_key("t/p/b", "content", ts)
+    assert k_base != seed.make_idempotency_key("t/p/a", "other content", ts)
     assert k_base != seed.make_idempotency_key(
-        "ns/a", "content", datetime(2026, 3, 2, 12, 0, 0, tzinfo=UTC)
+        "t/p/a", "content", datetime(2026, 3, 2, 12, 0, 0, tzinfo=UTC)
     )
 
 
@@ -188,3 +191,48 @@ def test_post_with_backoff_returns_none_on_transport_error(monkeypatch: Any) -> 
 
     got = seed.post_with_backoff(client, "/memories", rng=random.Random(0), json_body={})
     assert got is None
+
+
+def test_sleep_for_429_clamps_negative_retry_after(monkeypatch: Any) -> None:
+    """A misbehaving proxy could return a negative Retry-After. We must
+    clamp to 0.0 before sleeping — time.sleep(-1) raises ValueError."""
+    seed = _load()
+    sleeps: list[float] = []
+    monkeypatch.setattr(seed.time, "sleep", lambda s: sleeps.append(s))
+    resp = MagicMock()
+    resp.headers = {"Retry-After": "-5"}
+    slept = seed._sleep_for_429(resp, attempt=0, rng=random.Random(0))
+    assert slept == 0.0
+    assert sleeps == [0.0]
+
+
+def test_parse_args_rejects_wrong_segment_prefix(monkeypatch: Any) -> None:
+    """--namespace-prefix must be exactly tenant/presence — a 1-segment
+    or 3-segment value will produce invalid server-side namespaces, so
+    we fail fast at parse time."""
+    seed = _load()
+    monkeypatch.setenv("MUSUBI_V2_BASE_URL", "http://localhost:8100/v1")
+    monkeypatch.setenv("MUSUBI_V2_TOKEN", "x")
+
+    for bad in ("perf-test", "perf-test/harness/extra", "//", ""):
+        monkeypatch.setattr(
+            "sys.argv", ["seed_corpus.py", "--size", "1", "--namespace-prefix", bad]
+        )
+        try:
+            seed.parse_args()
+        except SystemExit as exc:
+            assert exc.code == 2
+        else:
+            raise AssertionError(f"expected SystemExit for prefix {bad!r}")
+
+
+def test_parse_args_accepts_valid_two_segment_prefix(monkeypatch: Any) -> None:
+    seed = _load()
+    monkeypatch.setenv("MUSUBI_V2_BASE_URL", "http://localhost:8100/v1")
+    monkeypatch.setenv("MUSUBI_V2_TOKEN", "x")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["seed_corpus.py", "--size", "1", "--namespace-prefix", "perf-test/harness"],
+    )
+    cfg = seed.parse_args()
+    assert cfg.namespace_prefix == "perf-test/harness"

--- a/tests/ops/test_perf_seed.py
+++ b/tests/ops/test_perf_seed.py
@@ -1,0 +1,190 @@
+"""Tests for scripts/perf/seed_corpus.py helpers.
+
+Covers three behaviours the seed script promises the caller:
+
+1. **Timestamp determinism** — same --seed produces same timestamps,
+   across runs and across restarts. This is the property that makes
+   the seed idempotent-on-retry.
+
+2. **Idempotency-key stability** — the SHA-derived Idempotency-Key is
+   purely a function of (namespace, content, timestamp). Re-running
+   the same seed against a Musubi that already has the corpus must
+   produce the same keys so the server dedupes.
+
+3. **429 / Retry-After backoff** — honors Retry-After when present,
+   falls back to exponential backoff with jitter otherwise, gives up
+   after MAX_429_RETRIES consecutive 429s.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import random
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+ROOT = Path(__file__).resolve().parents[2]
+SEED_PATH = ROOT / "scripts" / "perf" / "seed_corpus.py"
+
+
+def _load() -> Any:
+    # Register in sys.modules before exec so dataclass ClassVar
+    # resolution can find the module via cls.__module__ lookup.
+    if "musubi_perf_seed" in sys.modules:
+        return sys.modules["musubi_perf_seed"]
+    spec = importlib.util.spec_from_file_location("musubi_perf_seed", SEED_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["musubi_perf_seed"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_timestamp_anchor_is_fixed_epoch() -> None:
+    seed = _load()
+    anchor: datetime = seed.TIMESTAMP_ANCHOR
+    assert anchor == datetime(2026, 4, 1, 0, 0, 0, tzinfo=UTC)
+
+
+def test_make_timestamp_is_deterministic_for_same_seed() -> None:
+    seed = _load()
+    r1 = random.Random(42)
+    r2 = random.Random(42)
+    a = [seed.make_timestamp(r1, 90) for _ in range(25)]
+    b = [seed.make_timestamp(r2, 90) for _ in range(25)]
+    assert a == b
+
+
+def test_make_timestamp_never_exceeds_anchor() -> None:
+    seed = _load()
+    rng = random.Random(1)
+    for _ in range(200):
+        ts = seed.make_timestamp(rng, 90)
+        assert ts <= seed.TIMESTAMP_ANCHOR
+
+
+def test_idempotency_key_is_stable() -> None:
+    seed = _load()
+    ns = "perf-test/episodic"
+    content = "Eric prefers coffee black, no sugar."
+    ts = datetime(2026, 3, 1, 12, 0, 0, tzinfo=UTC)
+    k1 = seed.make_idempotency_key(ns, content, ts)
+    k2 = seed.make_idempotency_key(ns, content, ts)
+    assert k1 == k2
+    assert k1.startswith("perf-seed:")
+
+
+def test_idempotency_key_changes_with_any_input() -> None:
+    seed = _load()
+    ts = datetime(2026, 3, 1, 12, 0, 0, tzinfo=UTC)
+    k_base = seed.make_idempotency_key("ns/a", "content", ts)
+    assert k_base != seed.make_idempotency_key("ns/b", "content", ts)
+    assert k_base != seed.make_idempotency_key("ns/a", "other content", ts)
+    assert k_base != seed.make_idempotency_key(
+        "ns/a", "content", datetime(2026, 3, 2, 12, 0, 0, tzinfo=UTC)
+    )
+
+
+def test_sleep_for_429_honors_retry_after_header(monkeypatch: Any) -> None:
+    seed = _load()
+    monkeypatch.setattr(seed.time, "sleep", lambda _s: None)
+    resp = MagicMock()
+    resp.headers = {"Retry-After": "0.1"}
+    slept = seed._sleep_for_429(resp, attempt=0, rng=random.Random(0))
+    assert slept == 0.1
+
+
+def test_sleep_for_429_retry_after_is_capped(monkeypatch: Any) -> None:
+    seed = _load()
+    monkeypatch.setattr(seed.time, "sleep", lambda _s: None)
+    resp = MagicMock()
+    resp.headers = {"Retry-After": "9999"}
+    slept = seed._sleep_for_429(resp, attempt=0, rng=random.Random(0))
+    assert slept == seed.MAX_BACKOFF_S
+
+
+def test_sleep_for_429_falls_back_to_exponential_backoff(monkeypatch: Any) -> None:
+    seed = _load()
+    monkeypatch.setattr(seed.time, "sleep", lambda _s: None)
+    resp = MagicMock()
+    resp.headers = {}
+    # attempt=2 → 0.25 * 4 = 1.0s + up to 25% jitter → [1.0, 1.25]
+    slept = seed._sleep_for_429(resp, attempt=2, rng=random.Random(0))
+    assert 1.0 <= slept <= 1.25
+
+
+def test_post_with_backoff_returns_success_on_2xx(monkeypatch: Any) -> None:
+    seed = _load()
+    # Skip real sleeps entirely so the test is fast.
+    monkeypatch.setattr(seed.time, "sleep", lambda _s: None)
+
+    success = MagicMock()
+    success.status_code = 201
+    client = MagicMock()
+    client.post.return_value = success
+
+    got = seed.post_with_backoff(client, "/memories", rng=random.Random(0), json_body={})
+    assert got is success
+    assert client.post.call_count == 1
+
+
+def test_post_with_backoff_retries_429_then_succeeds(monkeypatch: Any) -> None:
+    seed = _load()
+    monkeypatch.setattr(seed.time, "sleep", lambda _s: None)
+
+    r429 = MagicMock()
+    r429.status_code = 429
+    r429.headers = {"Retry-After": "0"}
+    r200 = MagicMock()
+    r200.status_code = 200
+
+    client = MagicMock()
+    client.post.side_effect = [r429, r429, r200]
+
+    got = seed.post_with_backoff(client, "/memories", rng=random.Random(0), json_body={})
+    assert got is r200
+    assert client.post.call_count == 3
+
+
+def test_post_with_backoff_gives_up_after_max_retries(monkeypatch: Any) -> None:
+    seed = _load()
+    monkeypatch.setattr(seed.time, "sleep", lambda _s: None)
+
+    r429 = MagicMock()
+    r429.status_code = 429
+    r429.headers = {"Retry-After": "0"}
+    client = MagicMock()
+    client.post.return_value = r429
+
+    got = seed.post_with_backoff(client, "/memories", rng=random.Random(0), json_body={})
+    assert got is None
+    assert client.post.call_count == seed.MAX_429_RETRIES
+
+
+def test_post_with_backoff_does_not_retry_non_429(monkeypatch: Any) -> None:
+    seed = _load()
+    monkeypatch.setattr(seed.time, "sleep", lambda _s: None)
+
+    r500 = MagicMock()
+    r500.status_code = 500
+    client = MagicMock()
+    client.post.return_value = r500
+
+    got = seed.post_with_backoff(client, "/memories", rng=random.Random(0), json_body={})
+    assert got is r500
+    assert client.post.call_count == 1
+
+
+def test_post_with_backoff_returns_none_on_transport_error(monkeypatch: Any) -> None:
+    seed = _load()
+    monkeypatch.setattr(seed.time, "sleep", lambda _s: None)
+
+    client = MagicMock()
+    client.post.side_effect = seed.httpx.ConnectError("boom")
+
+    got = seed.post_with_backoff(client, "/memories", rng=random.Random(0), json_body={})
+    assert got is None


### PR DESCRIPTION
No tracking Issue: Gate 1 harness-fix chore — builds on #191.

## Summary

Three concrete issues surfaced while running Gate 1 (rebaseline) against the real server. Each is a harness bug, not a Musubi-server bug — but each silently polluted the numbers we're about to use as migration budgets.

### 1. Seed was not idempotent on retry
`make_timestamp` derived from `datetime.now(UTC)`, so re-running `seed_corpus.py` produced different timestamps → different `Idempotency-Key`s → fresh rows instead of dedup-into-existing. Pinning to a fixed `TIMESTAMP_ANCHOR` (2026-04-01T00:00Z) makes the entire corpus — content, timestamps, keys — bit-identical across runs of the same `--seed`.

### 2. Seed silently dropped rows on 429
One POST at a time from a workstation hit rate limits at roughly row 1,600 on episodic. The old code `raise_for_status()`'d and moved on, so the corpus had holes. New `post_with_backoff` wrapper honors `Retry-After`, falls back to exp-backoff + jitter (0.25s → 30s cap), gives up after `MAX_429_RETRIES=6` consecutive 429s. Every seeder (episodic, curated, concept, artifact, thought) now uses it. Dropped rows are still recoverable by re-running, which is safe because of fix #1.

### 3. Telemetry sampled the wrong host
`telemetry.sh` called `docker stats` + `nvidia-smi` on whatever host it ran on. When the perf driver runs on a workstation and Musubi's containers + GPU are on `musubi.mey.house`, we captured laptop noise and no GPU. Added `REMOTE_HOST=` mode that samples over SSH (BatchMode, 5s timeout, fails fast at `start` time so you notice before the run, not after). Local mode now emits a loud warning.

### Follow-ups opened during Gate 1 (separate from this PR)
- #192 — API: pydantic `ValidationError` should be 422 not 500
- #193 — Ops: audit operator multiplier + per-plane rate-limit budgets

## Test plan

- [x] 13 new unit tests in `tests/ops/test_perf_seed.py` covering:
  - `TIMESTAMP_ANCHOR` is a fixed epoch
  - Same `--seed` produces identical timestamps across `Random()` instances
  - Timestamps never exceed anchor
  - `make_idempotency_key` is pure and changes with any input change
  - `Retry-After` header honored (and capped)
  - Exp-backoff math with deterministic RNG
  - `post_with_backoff` retries 429 → success
  - Gives up after `MAX_429_RETRIES`
  - Does not retry non-429
  - Transport errors return `None`
- [x] `make fmt` clean, `make lint` clean, `make typecheck` clean
- [x] Full `make test` — 1157 passed, 231 skipped, 17 deselected
- [x] `make agent-check` — only pre-existing DAG drift warnings (unrelated)

Functional re-seed + rebaseline happens on the next turn after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)