### PR TITLE
fix(ops): perf-harness round 3 — three harness fixes found during live Gate 1

### DIFF
--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -19,9 +19,12 @@ scripts/perf/
 
 ## Prerequisites
 
-1. **Operator token scoped to `perf-test/*`** — *never* use `eric/*`.
-   See [.agent-context.local.md](../../.agent-context.local.md) for
-   how to mint a scoped token.
+1. **Operator token scoped to `perf-test/harness/*`** (or whichever
+   two-segment prefix you override to) — *never* use `eric/*`. The
+   scope list must include `operator`, per-plane `<prefix>/<plane>:rw`,
+   and `thoughts:send`. See [.agent-context.local.md](../../.agent-context.local.md)
+   for how to mint a scoped token against the running stack's
+   `JWT_SIGNING_KEY`.
 2. **k6 installed** on whatever host runs the scenarios
    (`brew install k6` on macOS, apt package on Ubuntu).
 3. **jq** (telemetry summarizer uses it).
@@ -33,10 +36,16 @@ scripts/perf/
 ## Env vars every scenario reads
 
 ```bash
-export MUSUBI_V2_BASE_URL=https://musubi.mey.house/v1
-export MUSUBI_V2_TOKEN=mbi_perf_...                # scoped to perf-test/*
-export MUSUBI_V2_NAMESPACE_PREFIX=perf-test        # default; override if isolating
+export MUSUBI_V2_BASE_URL=http://musubi.mey.house:8100/v1
+export MUSUBI_V2_TOKEN=mbi_perf_...                        # scoped to the prefix below
+export MUSUBI_V2_NAMESPACE_PREFIX=perf-test/harness        # tenant/presence — plane is appended
 ```
+
+The prefix must be exactly two segments — the server's namespace
+regex requires `tenant/presence/plane` (three segments total), and
+the seed script + k6 scenarios append the plane automatically. A
+one-segment prefix like `perf-test` will produce invalid namespaces
+and the server rejects them with a 500.
 
 ## Typical run sequence (per the plan)
 
@@ -84,6 +93,12 @@ K6_STAGES_OVERRIDE="2m,12h,30s" make perf-load LABEL=soak-overnight
   recovery window.
 - **`telemetry.sh`** — sidecar sampler. Runs alongside k6 and
   captures container CPU/RSS + GPU utilization + memory at 5s cadence.
+  When the driver runs on a different host than Musubi (common), set
+  `REMOTE_HOST=<user>@<musubi-host>` to sample over SSH. If the SSH
+  user isn't in the host's `docker` group but has passwordless sudo,
+  set `REMOTE_DOCKER_PREFIX="sudo -n"` — without it the remote
+  `docker stats` call fails silently and you end up with an empty
+  jsonl after the run.
 
 ## Output
 

--- a/scripts/perf/k6/_shared.js
+++ b/scripts/perf/k6/_shared.js
@@ -11,12 +11,28 @@ import { check } from 'k6';
 // consistent with production.
 const BASE_URL = __ENV.MUSUBI_V2_BASE_URL;
 const TOKEN = __ENV.MUSUBI_V2_TOKEN;
-const NS_PREFIX = __ENV.MUSUBI_V2_NAMESPACE_PREFIX || 'perf-test';
+// Canonical namespace format is `<tenant>/<presence>/<plane>` — the
+// prefix supplied here MUST be exactly two segments (tenant/presence);
+// the plane is appended by the call sites below. Default matches what
+// `scripts/perf/seed_corpus.py` writes with its default prefix.
+const NS_PREFIX = __ENV.MUSUBI_V2_NAMESPACE_PREFIX || 'perf-test/harness';
 
 if (!BASE_URL || !TOKEN) {
   throw new Error(
     'MUSUBI_V2_BASE_URL and MUSUBI_V2_TOKEN must be set. The token ' +
     'must scope to ' + NS_PREFIX + '/* — never to eric/*.'
+  );
+}
+
+// Fail fast at module load if the prefix is malformed. The server
+// rejects anything other than exactly three segments with an opaque
+// 500, which would otherwise mask the real problem (bad env var)
+// behind a wall of failed requests mid-run.
+const _nsParts = NS_PREFIX.split('/').filter(Boolean);
+if (_nsParts.length !== 2) {
+  throw new Error(
+    'MUSUBI_V2_NAMESPACE_PREFIX must be exactly "tenant/presence" ' +
+    '(two non-empty segments). Got: ' + JSON.stringify(NS_PREFIX)
   );
 }
 

--- a/scripts/perf/seed_corpus.py
+++ b/scripts/perf/seed_corpus.py
@@ -23,13 +23,19 @@ producing human-realistic corpora.
 
 Targets
 -------
-Seeds all five planes via Musubi's canonical API:
+Seeds four of the five planes via Musubi's canonical API:
 
   * episodic   — ``POST /v1/memories``
   * curated    — ``POST /v1/curated-knowledge`` (via operator token)
-  * concept    — ``POST /v1/concepts`` (operator-scoped)
   * artifact   — ``POST /v1/artifacts`` (multipart)
   * thought    — ``POST /v1/thoughts/send``
+
+The **concept** plane is intentionally omitted: there is no
+``POST /v1/concepts`` endpoint — concepts are produced only by the
+lifecycle synthesis job against episodic clusters. If you need the
+concept plane populated for a retrieval test, either run the real
+synthesis sweep after seeding episodic, or call the
+debug-synthesis trigger.
 
 Namespaces are pinned under ``<tenant>/<presence>/<plane>`` (the
 canonical three-segment format), defaulting to
@@ -80,7 +86,12 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)s %(message)s",
 )
 
-PLANES = ("episodic", "curated", "concept", "artifact", "thought")
+# Note: concept is intentionally absent. Concepts are produced by the
+# lifecycle synthesis job against episodic clusters — there is no
+# direct POST /v1/concepts endpoint (it returns 405), so seeding them
+# via the HTTP API is impossible. Either run the real synthesis job
+# after seeding episodic, or hit the debug-synthesis trigger.
+PLANES = ("episodic", "curated", "artifact", "thought")
 
 # Intentionally mundane fragments — household + ops + meta mix. The
 # pool is small on purpose: seeded random sampling over a small pool
@@ -422,43 +433,6 @@ def seed_curated(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> i
     return ok
 
 
-def seed_concept(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> int:
-    """POST /v1/concepts. Concepts are normally emitted by the
-    synthesis lifecycle job; seeding bypasses it to give retrieve
-    something to rerank against."""
-    ns = f"{cfg.namespace_prefix}/concept"
-    ok = 0
-    backoff_rng = random.Random(cfg.seed ^ 0xC0DE)
-    for i in range(cfg.size):
-        content = make_content(rng)
-        # Concept ingest has no intrinsic content hash; we compute one
-        # from (namespace, content, deterministic index) so the
-        # Idempotency-Key is stable across re-runs of the same --seed.
-        ts_proxy = TIMESTAMP_ANCHOR - timedelta(seconds=i)
-        body = {
-            "namespace": ns,
-            "content": content,
-            "tags": rng.sample(_TOPICS, k=rng.randint(1, 3)),
-            "importance": rng.randint(1, 9),
-        }
-        r = post_with_backoff(
-            client,
-            "/concepts",
-            rng=backoff_rng,
-            json_body=body,
-            extra_headers={"Idempotency-Key": make_idempotency_key(ns, content, ts_proxy)},
-        )
-        if r is not None and r.is_success:
-            ok += 1
-        elif r is not None:
-            log.warning("concept %d: %d %s", i, r.status_code, r.text[:160])
-        else:
-            log.warning("concept %d: skipped (transport error or 429 exhaustion)", i)
-        if i and i % 500 == 0:
-            log.info("concept: %d / %d (ok=%d)", i, cfg.size, ok)
-    return ok
-
-
 def seed_artifact(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> int:
     """POST /v1/artifacts — multipart. Smaller volume by default would
     be sensible; artifacts are heavier. Kept at --size for symmetry;
@@ -501,7 +475,6 @@ def seed_artifact(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> 
 _SEEDERS = {
     "episodic": seed_episodic,
     "curated": seed_curated,
-    "concept": seed_concept,
     "artifact": seed_artifact,
     "thought": seed_thought,
 }

--- a/scripts/perf/telemetry.sh
+++ b/scripts/perf/telemetry.sh
@@ -48,6 +48,10 @@ REMOTE_HOST="${REMOTE_HOST:-}"
 # word-splitting on $SSH_OPTS only, never on SSH_OPTS_DEFAULT[@].
 SSH_OPTS_DEFAULT=(-o BatchMode=yes -o ConnectTimeout=5)
 SSH_OPTS="${SSH_OPTS:-}"
+# Optional prefix for remote docker invocation (e.g. "sudo -n" when
+# the SSH user isn't in the docker group but has passwordless sudo).
+# Empty by default — no-op when the user can run docker directly.
+REMOTE_DOCKER_PREFIX="${REMOTE_DOCKER_PREFIX:-}"
 
 # -------- helpers -------------------------------------------------
 
@@ -136,7 +140,7 @@ _sample_remote() {
   # our SSH target isn't interpolating it (no jinja here, plain ssh).
   # shellcheck disable=SC2086
   ssh "${SSH_OPTS_DEFAULT[@]}" $SSH_OPTS "$REMOTE_HOST" \
-    "docker stats --no-stream --format '{{json .}}' 2>/dev/null" 2>/dev/null \
+    "${REMOTE_DOCKER_PREFIX} docker stats --no-stream --format '{{json .}}' 2>/dev/null" 2>/dev/null \
     | jq -c --arg ts "$ts" '. + {ts: $ts}' \
     >> "$dir/docker-stats.jsonl" || true
 

--- a/tests/ops/test_perf_seed.py
+++ b/tests/ops/test_perf_seed.py
@@ -226,6 +226,17 @@ def test_parse_args_rejects_wrong_segment_prefix(monkeypatch: Any) -> None:
             raise AssertionError(f"expected SystemExit for prefix {bad!r}")
 
 
+def test_planes_excludes_concept() -> None:
+    """Concept ingest has no HTTP endpoint (synthesis-only); the seeder
+    must not advertise it as a plane so --planes validation stays honest
+    and callers aren't tempted to pass --planes=concept."""
+    seed = _load()
+    assert "concept" not in seed.PLANES
+    assert "concept" not in seed._SEEDERS
+    # Sanity: the four writeable planes are still there.
+    assert set(seed.PLANES) == {"episodic", "curated", "artifact", "thought"}
+
+
 def test_parse_args_accepts_valid_two_segment_prefix(monkeypatch: Any) -> None:
     seed = _load()
     monkeypatch.setenv("MUSUBI_V2_BASE_URL", "http://localhost:8100/v1")


### PR DESCRIPTION
No tracking Issue: harness-fixes-found-during-run chore — builds on #194.

## Summary

Took the harness out for a live run against real Musubi. Three real harness issues plus **one major Musubi-core finding** (filed separately as **#195** because the fix belongs to a slice-api-* author).

### 1. Drop concept plane from the seeder
`POST /v1/concepts` does **not exist** — the endpoint returns 405. Concepts are produced only by the lifecycle synthesis job against episodic clusters. The old seeder burned ~15s hammering the dead URL on every run and logged \"concept N: 405 Method Not Allowed\" 10,000 times. Removed entirely; docstring now points callers at the debug-synthesis trigger if they need concepts populated.

### 2. Default k6 namespace prefix is broken
`MUSUBI_V2_NAMESPACE_PREFIX` defaulted to `perf-test` (1 segment). The k6 scenarios build `\${NS_PREFIX}/\${plane}` → `perf-test/episodic` (2 segments). The server requires exactly 3 — `tenant/presence/plane` — so every request would 500. New default is `perf-test/harness`; module-load validation fails fast with a clear message on a bad override.

### 3. Telemetry's `docker stats` silently failed on the musubi host
SSH user isn't in `docker` group but has passwordless sudo. The new remote-mode sampler called `docker stats` without sudo, so `docker-stats.jsonl` was empty after a live run. New `REMOTE_DOCKER_PREFIX` env var lets callers prepend `sudo -n` — empty by default, no-op for hosts where the user can run docker directly. README updated.

### 4. **Major finding — filed as #195**

During the baseline run I got retrieve_fast p95 = 38ms and retrieve_deep p95 = 42ms against a 20k-row corpus. Should differ by an order of magnitude. Root cause: [`src/musubi/api/routers/retrieve.py`](src/musubi/api/routers/retrieve.py) is a first-cut stub that:
- Ignores the \`mode\` parameter
- Hardcodes \`score=1.0\`
- Never calls \`musubi.retrieve.orchestration\`, \`rerank()\`, or \`rank_hits()\`

The whole `src/musubi/retrieve/` pipeline is dead code at the HTTP boundary. All subsequent perf gates would measure the wrong thing until this is wired. **Not fixed in this PR** — canonical API is frozen per slice-api-* and this needs a dedicated slice. See #195 for the full triage + suggested fix path.

## Test plan

- [x] `make check` — 1161 passed, 231 skipped
- [x] `make agent-check` — clean (pre-existing DAG warnings only)
- [x] 17 unit tests in `tests/ops/test_perf_seed.py` including new `test_planes_excludes_concept`
- [x] Re-ran the seed locally post-fix: episodic + curated at 10k, artifact + thought at 2k, no 405s, no silent holes
- [x] Re-ran k6 baseline with the fixed _shared.js; all four scenarios ✓ at thresholds
- [x] Re-ran telemetry with REMOTE_DOCKER_PREFIX=\"sudo -n\"; docker-stats.jsonl captured 78 samples across 8 containers + 77 GPU samples

🤖 Generated with [Claude Code](https://claude.com/claude-code)