### PR TITLE
fix(api): wire /v1/retrieve to orchestration (closes #195)

### DIFF
--- a/src/musubi/api/bootstrap.py
+++ b/src/musubi/api/bootstrap.py
@@ -43,6 +43,7 @@ from musubi.api.dependencies import (
     get_episodic_plane,
     get_lifecycle_service,
     get_qdrant_client,
+    get_reranker,
     get_thoughts_plane,
 )
 from musubi.embedding import Embedder, TEIDenseClient, TEIRerankerClient, TEISparseClient
@@ -206,6 +207,10 @@ def bootstrap_production_app(
     # bootstrap a second time replaces the dict entries cleanly (idempotent).
     app.dependency_overrides[get_qdrant_client] = lambda: qdrant
     app.dependency_overrides[get_embedder] = lambda: embedder
+    # Orchestration takes a rerank client as its own arg (the composite
+    # embedder also carries one, but passing it separately keeps the
+    # retrieve pipeline's signature honest + tests easier).
+    app.dependency_overrides[get_reranker] = lambda: reranker
     app.dependency_overrides[get_episodic_plane] = lambda: EpisodicPlane(
         client=qdrant, embedder=embedder
     )

--- a/src/musubi/api/dependencies.py
+++ b/src/musubi/api/dependencies.py
@@ -21,7 +21,7 @@ from functools import lru_cache
 from qdrant_client import QdrantClient
 
 from musubi.config import get_settings
-from musubi.embedding import Embedder
+from musubi.embedding import Embedder, TEIRerankerClient
 from musubi.planes.artifact import ArtifactPlane
 from musubi.planes.concept import ConceptPlane
 from musubi.planes.curated import CuratedPlane
@@ -92,6 +92,20 @@ def get_embedder() -> Embedder:
     )
 
 
+def get_reranker() -> TEIRerankerClient:
+    """Cross-encoder reranker used by deep-path retrieval.
+
+    Separate from the composite embedder on purpose: the retrieval
+    orchestration signature takes ``reranker`` as its own argument,
+    and tests need to be able to swap the reranker in isolation
+    (e.g. to assert that deep mode actually called ``.rerank()``).
+    """
+    raise NotImplementedError(
+        "Reranker is not configured. Override via app.dependency_overrides in tests, "
+        "or wire production deps via slice-api-app-bootstrap."
+    )
+
+
 def get_lifecycle_service() -> object:
     """Per-process lifecycle handle for the /v1/lifecycle/* endpoints.
 
@@ -114,6 +128,7 @@ __all__ = [
     "get_episodic_plane",
     "get_lifecycle_service",
     "get_qdrant_client",
+    "get_reranker",
     "get_settings_dep",
     "get_thoughts_plane",
 ]

--- a/src/musubi/api/routers/retrieve.py
+++ b/src/musubi/api/routers/retrieve.py
@@ -2,34 +2,33 @@
 
 POST /v1/retrieve is a read in disguise — body carries the query
 parameters; no state mutation. NDJSON streaming variant
-(POST /v1/retrieve/stream) is deferred to slice-api-v0-write.
+(POST /v1/retrieve/stream) lives in ``writes_retrieve_stream.py``.
 
-The retrieval implementation lives in ``src/musubi/retrieve/`` and is
-owned by the retrieval slices. This router does the minimum: parses the
-query body, gates scope, and routes to either the per-plane ``query``
-methods (first cut) or to the future blended retriever once
-slice-retrieval-orchestration wires it through. The single-plane fast
-path uses ``EpisodicPlane.query`` today; cross-plane blended retrieval
-arrives via slice-retrieval-blended.
+Dispatches to :func:`musubi.retrieve.orchestration.retrieve`, which
+runs the per-mode pipeline (``fast`` → vector + recency + reinforcement
+scoring; ``deep`` → full hybrid + cross-encoder rerank + lineage
+hydration; ``blended`` → hybrid without the reranker). The router
+itself does auth + body validation + error mapping; everything
+interesting happens behind the orchestration boundary.
 """
 
 from __future__ import annotations
 
 from fastapi import APIRouter, Body, Depends, Request
 from pydantic import BaseModel
+from qdrant_client import QdrantClient
 
 from musubi.api.dependencies import (
-    get_concept_plane,
-    get_curated_plane,
-    get_episodic_plane,
+    get_embedder,
+    get_qdrant_client,
+    get_reranker,
     get_settings_dep,
 )
 from musubi.api.errors import APIError, ErrorCode
 from musubi.api.responses import RetrieveResponse, RetrieveResultRow
 from musubi.auth import AuthRequirement, authenticate_request
-from musubi.planes.concept import ConceptPlane
-from musubi.planes.curated import CuratedPlane
-from musubi.planes.episodic import EpisodicPlane
+from musubi.embedding import Embedder, TEIRerankerClient
+from musubi.retrieve.orchestration import retrieve as run_orchestration_retrieve
 from musubi.settings import Settings
 from musubi.types.common import Err
 
@@ -45,14 +44,26 @@ class RetrieveQuery(BaseModel):
     include_archived: bool = False
 
 
+# orchestration.RetrievalError.kind → (HTTP status, typed error code).
+# `timeout` maps to BACKEND_UNAVAILABLE because a timeout in orchestration
+# means Qdrant or TEI didn't respond within budget — same shape as any
+# upstream outage from the caller's perspective.
+_KIND_STATUS_MAP: dict[str, tuple[int, ErrorCode]] = {
+    "bad_query": (400, "BAD_REQUEST"),
+    "forbidden": (403, "FORBIDDEN"),
+    "timeout": (503, "BACKEND_UNAVAILABLE"),
+    "internal": (500, "INTERNAL"),
+}
+
+
 @router.post("", response_model=RetrieveResponse)
 async def retrieve(
     request: Request,
     body: RetrieveQuery = Body(...),
     settings: Settings = Depends(get_settings_dep),
-    episodic: EpisodicPlane = Depends(get_episodic_plane),
-    curated: CuratedPlane = Depends(get_curated_plane),
-    concept: ConceptPlane = Depends(get_concept_plane),
+    qdrant: QdrantClient = Depends(get_qdrant_client),
+    embedder: Embedder = Depends(get_embedder),
+    reranker: TEIRerankerClient = Depends(get_reranker),
 ) -> RetrieveResponse:
     requirement = AuthRequirement(namespace=body.namespace, access="r")
     result = authenticate_request(
@@ -69,61 +80,50 @@ async def retrieve(
             detail=err.detail,
         )
 
-    requested_planes = set(body.planes or ["episodic"])
-    rows: list[RetrieveResultRow] = []
-
-    # First cut: dispatch to each requested plane's query() in turn and
-    # interleave the results. Cross-plane scoring/dedup lives in
-    # slice-retrieval-orchestration; this router carries the API surface.
-    plane_namespace_map = {
-        "episodic": ("episodic", body.namespace),
-        "curated": ("curated", body.namespace.rsplit("/", 1)[0] + "/curated"),
-        "concept": ("concept", body.namespace.rsplit("/", 1)[0] + "/concept"),
+    # Build the orchestration query dict. Defaulting `planes` server-side
+    # matches the pre-wiring router behaviour (single-plane episodic by
+    # default) so callers that didn't know about cross-plane retrieval
+    # don't suddenly start pulling from curated/concept too.
+    query_body: dict[str, object] = {
+        "namespace": body.namespace,
+        "query_text": body.query_text,
+        "mode": body.mode,
+        "limit": body.limit,
+        "planes": body.planes or ["episodic"],
+        "include_archived": body.include_archived,
     }
 
-    if "episodic" in requested_planes:
-        for mem in await episodic.query(
-            namespace=body.namespace, query=body.query_text, limit=body.limit
-        ):
-            rows.append(
-                RetrieveResultRow(
-                    object_id=mem.object_id,
-                    score=1.0,
-                    plane="episodic",
-                    content=mem.content,
-                    namespace=mem.namespace,
-                )
+    orchestration_result = await run_orchestration_retrieve(
+        client=qdrant,
+        embedder=embedder,
+        reranker=reranker,
+        query=query_body,
+    )
+
+    if isinstance(orchestration_result, Err):
+        retrieval_err = orchestration_result.error
+        status, error_code = _KIND_STATUS_MAP.get(retrieval_err.kind, (500, "INTERNAL"))
+        raise APIError(status_code=status, code=error_code, detail=retrieval_err.detail)
+
+    rows: list[RetrieveResultRow] = []
+    for hit in orchestration_result.value:
+        rows.append(
+            RetrieveResultRow(
+                object_id=hit.object_id,
+                score=hit.score,
+                plane=hit.plane,
+                content=hit.snippet,
+                namespace=hit.namespace,
+                # Rich context stays in `extra` so the top-level response
+                # shape (RetrieveResultRow) doesn't break for callers that
+                # only want object_id / score / content.
+                extra={
+                    "score_components": hit.score_components,
+                    "lineage": hit.lineage,
+                    "title": hit.title,
+                },
             )
-    if "curated" in requested_planes:
-        for cur in await curated.query(
-            namespace=plane_namespace_map["curated"][1],
-            query=body.query_text,
-            limit=body.limit,
-        ):
-            rows.append(
-                RetrieveResultRow(
-                    object_id=cur.object_id,
-                    score=1.0,
-                    plane="curated",
-                    content=cur.content,
-                    namespace=cur.namespace,
-                )
-            )
-    if "concept" in requested_planes:
-        for con in await concept.query(
-            namespace=plane_namespace_map["concept"][1],
-            query=body.query_text,
-            limit=body.limit,
-        ):
-            rows.append(
-                RetrieveResultRow(
-                    object_id=con.object_id,
-                    score=1.0,
-                    plane="concept",
-                    content=con.content,
-                    namespace=con.namespace,
-                )
-            )
+        )
 
     return RetrieveResponse(
         results=rows[: body.limit],

--- a/src/musubi/retrieve/orchestration.py
+++ b/src/musubi/retrieve/orchestration.py
@@ -238,9 +238,9 @@ def _pack_scored_hits(
                 snippet=_snippet(hit.payload, max_chars=300),
                 score=hit.score,
                 score_components={
-                    "relevance": hit.components.relevance,
-                    "recency": hit.components.recency,
-                    "reinforcement": hit.components.reinforce,
+                    "relevance": hit.score_components.relevance,
+                    "recency": hit.score_components.recency,
+                    "reinforcement": hit.score_components.reinforce,
                 },
                 lineage=_summarize_lineage(hit.payload),
                 payload=hit.payload if include_payload else None,

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -25,8 +25,10 @@ from musubi.api.dependencies import (
     get_artifact_plane,
     get_concept_plane,
     get_curated_plane,
+    get_embedder,
     get_episodic_plane,
     get_qdrant_client,
+    get_reranker,
     get_settings_dep,
 )
 from musubi.embedding import FakeEmbedder
@@ -121,8 +123,15 @@ def app_factory(
     """Returns the FastAPI app with all DI overrides wired to the
     in-memory test instances."""
     app = create_app(settings=api_settings)
+    # Shared FakeEmbedder — the retrieve router threads it through
+    # orchestration as both embedder and reranker (FakeEmbedder.rerank
+    # satisfies the TEIRerankerClient duck-type). Tests that care about
+    # rerank specifically override get_reranker with a spy.
+    fake = FakeEmbedder()
     app.dependency_overrides[get_settings_dep] = lambda: api_settings
     app.dependency_overrides[get_qdrant_client] = lambda: qdrant
+    app.dependency_overrides[get_embedder] = lambda: fake
+    app.dependency_overrides[get_reranker] = lambda: fake
     app.dependency_overrides[get_episodic_plane] = lambda: episodic
     app.dependency_overrides[get_curated_plane] = lambda: curated
     app.dependency_overrides[get_concept_plane] = lambda: concept

--- a/tests/api/test_api_v0_read.py
+++ b/tests/api/test_api_v0_read.py
@@ -749,6 +749,156 @@ def test_retrieve_endpoint_routes_to_plane(
     assert "results" in body
 
 
+def _seed_episodic_batch(episodic: EpisodicPlane, namespace: str, fragments: list[str]) -> None:
+    """Seed + mature a batch of episodic memories so retrieval has
+    enough candidates to exercise rerank."""
+
+    async def _seed() -> None:
+        for content in fragments:
+            saved = await episodic.create(EpisodicMemory(namespace=namespace, content=content))
+            await episodic.transition(
+                namespace=namespace,
+                object_id=saved.object_id,
+                to_state="matured",
+                actor="seed",
+                reason="seed",
+            )
+
+    asyncio.run(_seed())
+
+
+def test_retrieve_fast_returns_real_scores_not_hardcoded_one(
+    client: TestClient,
+    auth: dict[str, str],
+    episodic: EpisodicPlane,
+) -> None:
+    """Regression guard for #195 — the pre-wiring router hardcoded
+    score=1.0 on every row. The real scoring model combines relevance
+    + recency + importance + provenance + reinforcement; scores must
+    vary across hits (and at least one must differ from 1.0) or the
+    orchestration wire-up has regressed to the stub."""
+    namespace = "eric/claude-code/episodic"
+    _seed_episodic_batch(
+        episodic,
+        namespace,
+        [
+            "Remember the dentist appointment Tuesday afternoon.",
+            "Eric prefers coffee black, no sugar.",
+            "Aoi mentioned the deploy finished cleanly.",
+            "Qdrant holds the vector embeddings behind named collections.",
+            "The LiveKit stack routes SIP into voice tools.",
+            "TEI serves BGE-M3 dense and SPLADE sparse embeddings.",
+            "Promotion moves a concept into the curated plane.",
+            "Kong fronts musubi.mey.house for external traffic.",
+        ],
+    )
+
+    r = client.post(
+        "/v1/retrieve",
+        headers=auth,
+        json={
+            "namespace": namespace,
+            "query_text": "dentist appointment tuesday",
+            "mode": "fast",
+            "limit": 5,
+        },
+    )
+    assert r.status_code == 200
+    results = r.json()["results"]
+    assert results, "fast-mode retrieve returned no results"
+
+    scores = [row["score"] for row in results]
+    assert any(s != 1.0 for s in scores), (
+        f"every result had score=1.0 — router is likely still the stub. saw scores={scores!r}"
+    )
+
+
+def test_retrieve_deep_mode_invokes_reranker(
+    client: TestClient,
+    auth: dict[str, str],
+    episodic: EpisodicPlane,
+    app_factory: object,
+) -> None:
+    """Deep-mode retrieval must actually call the cross-encoder
+    reranker — that's the only behaviour that distinguishes deep from
+    fast at the orchestration layer. Spy on the reranker dep; after
+    a deep-mode call its counter must be > 0."""
+    from musubi.api.dependencies import get_reranker
+    from musubi.embedding import FakeEmbedder
+
+    class _SpyReranker:
+        def __init__(self) -> None:
+            self.call_count = 0
+            self._inner = FakeEmbedder()
+
+        async def rerank(self, query: str, candidates: list[str]) -> list[float]:
+            self.call_count += 1
+            return await self._inner.rerank(query, candidates)
+
+    spy = _SpyReranker()
+    app_factory.dependency_overrides[get_reranker] = lambda: spy  # type: ignore[attr-defined]
+
+    namespace = "eric/claude-code/episodic"
+    # Rerank is only invoked when hybrid returns >5 candidates (see
+    # musubi.retrieve.rerank.rerank's short-circuit). Seed enough
+    # distinct rows that hybrid returns more than that bar.
+    _seed_episodic_batch(
+        episodic,
+        namespace,
+        [f"voice pipeline document {i}: LiveKit routes SIP calls" for i in range(12)],
+    )
+
+    r = client.post(
+        "/v1/retrieve",
+        headers=auth,
+        json={
+            "namespace": namespace,
+            "query_text": "voice pipeline LiveKit",
+            "mode": "deep",
+            "limit": 10,
+        },
+    )
+    assert r.status_code == 200, r.text
+    assert spy.call_count >= 1, "deep-mode retrieve did not call the reranker"
+
+
+def test_retrieve_result_carries_score_components_in_extra(
+    client: TestClient,
+    auth: dict[str, str],
+    episodic: EpisodicPlane,
+) -> None:
+    """The scoring model is explainable; callers (eval tools, voice
+    agents debugging recall) need the component breakdown. The
+    response extra dict must carry score_components keyed by the
+    component names the scoring model exports."""
+    namespace = "eric/claude-code/episodic"
+    _seed_episodic_batch(
+        episodic,
+        namespace,
+        ["Remember the dentist appointment Tuesday.", "Eric prefers coffee black."],
+    )
+
+    r = client.post(
+        "/v1/retrieve",
+        headers=auth,
+        json={
+            "namespace": namespace,
+            "query_text": "dentist appointment",
+            "mode": "fast",
+            "limit": 5,
+        },
+    )
+    assert r.status_code == 200
+    results = r.json()["results"]
+    assert results
+    extra = results[0]["extra"]
+    assert "score_components" in extra
+    components = extra["score_components"]
+    # At minimum the three components the scoring-model tests assert.
+    for key in ("relevance", "recency", "reinforcement"):
+        assert key in components, f"score_components missing {key!r}: {components!r}"
+
+
 def test_thoughts_check_endpoint_responds(
     client: TestClient,
     api_settings: object,


### PR DESCRIPTION
Closes #195.

## Summary

The retrieve router was a first-cut stub — ignored `mode`, hardcoded `score=1.0`, per-plane `EpisodicPlane.query()` loop, zero touch on the `src/musubi/retrieve/` pipeline. This PR swaps it for a real call into `musubi.retrieve.orchestration.retrieve()`.

Found during Gate 1 perf rebaseline: retrieve_fast p95 = **38 ms** and retrieve_deep p95 = **42 ms** against a 20 k-row corpus. They should differ by an order of magnitude — deep runs hybrid + cross-encoder rerank + lineage hydration. They were identical because the same code ran in both paths. A live `deep` request came back with all 10 hits scored exactly `1.0`, confirming the stub.

## Changes

- **`src/musubi/api/dependencies.py`** — new `get_reranker()` stub mirroring `get_embedder()`. Orchestration takes `reranker` as its own argument separate from the composite embedder, so DI needs to surface it on its own.
- **`src/musubi/api/bootstrap.py`** — override `get_reranker` with the `TEIRerankerClient` the bootstrap already constructs on startup.
- **`src/musubi/api/routers/retrieve.py`** — replace the per-plane dispatch with a single call to `orchestration.retrieve()`. Map `RetrievalError.kind` → HTTP status (bad_query→400, forbidden→403, timeout→503 BACKEND_UNAVAILABLE, internal→500). `score_components` + `lineage` + `title` go into the response row's `extra` dict so the top-level response shape stays stable for existing consumers.
- **`src/musubi/retrieve/orchestration.py`** — fix a latent typo in `_pack_scored_hits` (`hit.components` → `hit.score_components`) that blocked the wire-up. The deep path had never been exercised end-to-end through the API, so this attribute error had never surfaced.
- **`tests/api/conftest.py`** — override `get_embedder` + `get_reranker` with a shared `FakeEmbedder` (its `.rerank()` satisfies the TEI client duck-type).
- **`tests/api/test_api_v0_read.py`** — three new tests that pin the behaviour #195 regressed from:
  - `test_retrieve_fast_returns_real_scores_not_hardcoded_one` — regression guard. Asserts at least one result has `score != 1.0`.
  - `test_retrieve_deep_mode_invokes_reranker` — spies on `get_reranker`, asserts it was called ≥ 1 time after a deep-mode request. Seeds 12 rows to clear rerank's `len(candidates) <= 5` short-circuit.
  - `test_retrieve_result_carries_score_components_in_extra` — asserts the `extra` dict exposes `relevance`, `recency`, `reinforcement`.

## Guardrails

This PR touches `src/musubi/api/` which is normally frozen per CLAUDE.md rule #2 (\"canonical API is frozen per version\"). The change is **corrective**, not additive — the router response shape is unchanged (rich fields are in `extra`), no new paths, no new top-level body fields. Explicitly authorised by the operator as a follow-up to issue #195 filed during Gate 1.

## Test plan

- [x] `make check` — 1164 passed, 231 skipped (+3 new retrieve tests)
- [x] `make agent-check` — clean (pre-existing DAG warnings only)
- [ ] Live verify against musubi.mey.house after image ship: same 20k-row corpus, retrieve_deep p95 should be visibly > retrieve_fast p95 + response scores should not all equal 1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)