### PR TITLE
fix(embedding): pool httpx.AsyncClient in TEI clients

### DIFF
--- a/src/musubi/api/bootstrap.py
+++ b/src/musubi/api/bootstrap.py
@@ -237,6 +237,20 @@ def bootstrap_production_app(
         "embedder": embedder,
     }
 
+    # Close the TEI clients' pooled httpx.AsyncClient at shutdown so
+    # docker-compose stop / k8s termination drains cleanly (and tests
+    # that use the bootstrap path don't leak ResourceWarnings). Each
+    # aclose is idempotent so re-running bootstrap in the same app
+    # doesn't matter. FastAPI removed add_event_handler at the app
+    # level in favour of lifespan contexts; the same handler on
+    # app.router still works and is how Starlette always exposed it.
+    async def _shutdown_tei_clients() -> None:
+        await dense.aclose()
+        await sparse.aclose()
+        await reranker.aclose()
+
+    app.router.add_event_handler("shutdown", _shutdown_tei_clients)
+
 
 def _should_bootstrap(app: FastAPI, settings: Settings) -> bool:
     """Decide whether ``create_app()`` should call

--- a/src/musubi/embedding/tei.py
+++ b/src/musubi/embedding/tei.py
@@ -11,6 +11,16 @@ Each client is independent — they talk to separate base URLs and are composed
 by the caller. None of them cache embeddings; batching is the caller's
 concern (see [[06-ingestion/embedding-strategy]]).
 
+Connection reuse contract:
+
+- Each client owns a single long-lived ``httpx.AsyncClient`` with HTTP/1.1
+  keepalive. Bootstrap constructs the TEI clients once per process, so this
+  gives us a warm pool for the lifetime of the worker. Without it, every
+  request pays the full TCP connect + HTTP handshake cost — which shows up
+  as a ~10x slowdown under concurrency because the pool never warms up.
+- :meth:`aclose` must be called at process shutdown for clean teardown.
+  Bootstrap wires this to the FastAPI ``shutdown`` event.
+
 Error handling contract:
 
 - 5xx responses raise :class:`EmbeddingError` with ``status_code`` set.
@@ -34,6 +44,13 @@ _DEFAULT_TIMEOUT = 30.0
 _DEFAULT_MAX_BATCH_SIZE = 64
 _DEFAULT_MAX_INPUT_CHARS = 2048
 _DEFAULT_RETRY_BACKOFF = 0.05
+
+# Per-client connection pool. 100 max inflight is generous — Musubi's worst
+# realistic concurrency (voice call + 2 browser agents, each with a few
+# parallel plane queries) tops out around ~15. 20 keepalives is what httpx
+# recommends for a long-lived service-to-service client; it's the size of
+# the idle pool we hold open between bursts.
+_DEFAULT_LIMITS = httpx.Limits(max_connections=100, max_keepalive_connections=20)
 
 
 def _raise_for_httpx(exc: httpx.HTTPError) -> None:
@@ -61,19 +78,25 @@ def _raise_for_status(response: httpx.Response) -> None:
 
 
 async def _post_json(
+    client: httpx.AsyncClient,
     base_url: str,
     path: str,
     payload: dict[str, Any],
     *,
-    timeout: float,
     retry_backoff: float,
 ) -> Any:
-    """POST ``payload`` as JSON; raise :class:`EmbeddingError` on failure."""
+    """POST ``payload`` as JSON through ``client``; raise :class:`EmbeddingError`
+    on failure.
+
+    The caller owns ``client`` — we reuse it across calls so keepalive +
+    connection pooling actually kick in. Creating a fresh ``AsyncClient``
+    per call (the previous pattern) costs ~50-100ms in TCP handshake under
+    contention; reusing the pooled client is where the speedup lives.
+    """
     url = f"{base_url.rstrip('/')}{path}"
     for attempt in range(2):
         try:
-            async with httpx.AsyncClient(timeout=timeout) as client:
-                response = await client.post(url, json=payload)
+            response = await client.post(url, json=payload)
         except httpx.HTTPError as exc:
             _raise_for_httpx(exc)
             raise  # pragma: no cover — _raise_for_httpx always raises
@@ -107,6 +130,16 @@ def _truncate(text: str, max_input_chars: int) -> str:
     return text[:max_input_chars]
 
 
+def _build_client(timeout: float, limits: httpx.Limits) -> httpx.AsyncClient:
+    """Factory for the per-instance pooled HTTP client.
+
+    Constructing ``AsyncClient`` does no I/O — the pool is lazy until the
+    first request. So building it in ``__init__`` is safe even when the
+    event loop hasn't started yet (e.g. during FastAPI app bootstrap).
+    """
+    return httpx.AsyncClient(timeout=timeout, limits=limits)
+
+
 class TEIDenseClient:
     """Client for a TEI dense encoder endpoint.
 
@@ -122,12 +155,14 @@ class TEIDenseClient:
         max_batch_size: int = _DEFAULT_MAX_BATCH_SIZE,
         max_input_chars: int = _DEFAULT_MAX_INPUT_CHARS,
         retry_backoff: float = _DEFAULT_RETRY_BACKOFF,
+        limits: httpx.Limits = _DEFAULT_LIMITS,
     ) -> None:
         self._base_url = base_url
         self._timeout = timeout
         self._max_batch_size = max_batch_size
         self._max_input_chars = max_input_chars
         self._retry_backoff = retry_backoff
+        self._client = _build_client(timeout, limits)
 
     async def embed_dense(self, texts: list[str]) -> list[list[float]]:
         if not texts:
@@ -135,15 +170,19 @@ class TEIDenseClient:
         out: list[list[float]] = []
         for batch in _chunks(texts, self._max_batch_size):
             data = await _post_json(
+                self._client,
                 self._base_url,
                 "/embed",
                 {"inputs": [_truncate(text, self._max_input_chars) for text in batch]},
-                timeout=self._timeout,
                 retry_backoff=self._retry_backoff,
             )
             # TEI returns list[list[float]] in input order.
             out.extend([[float(x) for x in vec] for vec in data])
         return out
+
+    async def aclose(self) -> None:
+        """Close the underlying httpx connection pool. Idempotent."""
+        await self._client.aclose()
 
 
 class TEISparseClient:
@@ -162,12 +201,14 @@ class TEISparseClient:
         max_batch_size: int = _DEFAULT_MAX_BATCH_SIZE,
         max_input_chars: int = _DEFAULT_MAX_INPUT_CHARS,
         retry_backoff: float = _DEFAULT_RETRY_BACKOFF,
+        limits: httpx.Limits = _DEFAULT_LIMITS,
     ) -> None:
         self._base_url = base_url
         self._timeout = timeout
         self._max_batch_size = max_batch_size
         self._max_input_chars = max_input_chars
         self._retry_backoff = retry_backoff
+        self._client = _build_client(timeout, limits)
 
     async def embed_sparse(self, texts: list[str]) -> list[dict[int, float]]:
         if not texts:
@@ -175,10 +216,10 @@ class TEISparseClient:
         out: list[dict[int, float]] = []
         for batch in _chunks(texts, self._max_batch_size):
             data = await _post_json(
+                self._client,
                 self._base_url,
                 "/embed_sparse",
                 {"inputs": [_truncate(text, self._max_input_chars) for text in batch]},
-                timeout=self._timeout,
                 retry_backoff=self._retry_backoff,
             )
             # data: list[list[{"index": int, "value": float}]]
@@ -186,6 +227,10 @@ class TEISparseClient:
                 [{int(entry["index"]): float(entry["value"]) for entry in row} for row in data]
             )
         return out
+
+    async def aclose(self) -> None:
+        """Close the underlying httpx connection pool. Idempotent."""
+        await self._client.aclose()
 
 
 class TEIRerankerClient:
@@ -205,23 +250,25 @@ class TEIRerankerClient:
         timeout: float = _DEFAULT_TIMEOUT,
         max_input_chars: int = _DEFAULT_MAX_INPUT_CHARS,
         retry_backoff: float = _DEFAULT_RETRY_BACKOFF,
+        limits: httpx.Limits = _DEFAULT_LIMITS,
     ) -> None:
         self._base_url = base_url
         self._timeout = timeout
         self._max_input_chars = max_input_chars
         self._retry_backoff = retry_backoff
+        self._client = _build_client(timeout, limits)
 
     async def rerank(self, query: str, candidates: list[str]) -> list[float]:
         if not candidates:
             return []
         data = await _post_json(
+            self._client,
             self._base_url,
             "/rerank",
             {
                 "query": _truncate(query, self._max_input_chars),
                 "texts": [_truncate(candidate, self._max_input_chars) for candidate in candidates],
             },
-            timeout=self._timeout,
             retry_backoff=self._retry_backoff,
         )
         # data: list[{"index": int, "score": float}] — possibly out of order.
@@ -239,6 +286,10 @@ class TEIRerankerClient:
                 status_code=None,
             )
         return scores
+
+    async def aclose(self) -> None:
+        """Close the underlying httpx connection pool. Idempotent."""
+        await self._client.aclose()
 
 
 __all__ = ["TEIDenseClient", "TEIRerankerClient", "TEISparseClient"]

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -586,3 +586,81 @@ async def test_tei_dense_client_handles_httpx_connect_error(
     client = TEIDenseClient(base_url="http://tei-dense")
     with pytest.raises(EmbeddingError):
         await client.embed_dense(["x"])
+
+
+# ---------------------------------------------------------------------------
+# Connection pooling — regression guard for the "fresh AsyncClient per call"
+# anti-pattern that showed up as 10.94% failure rate under Gate 2 load.
+# Each client must own one long-lived httpx.AsyncClient and reuse it across
+# calls so HTTP/1.1 keepalive actually kicks in.
+# ---------------------------------------------------------------------------
+
+
+async def test_tei_dense_client_reuses_single_async_client(
+    httpx_mock: HTTPXMock,
+) -> None:
+    for _ in range(3):
+        httpx_mock.add_response(
+            url="http://tei-dense/embed",
+            method="POST",
+            json=[[0.0] * DENSE_SIZE],
+        )
+    client = TEIDenseClient(base_url="http://tei-dense")
+    first = client._client
+    for _ in range(3):
+        await client.embed_dense(["x"])
+    # Same AsyncClient instance across calls → keepalive + pooling in play.
+    assert client._client is first
+
+
+async def test_tei_sparse_client_reuses_single_async_client(
+    httpx_mock: HTTPXMock,
+) -> None:
+    for _ in range(3):
+        httpx_mock.add_response(
+            url="http://tei-sparse/embed_sparse",
+            method="POST",
+            json=[[{"index": 0, "value": 1.0}]],
+        )
+    client = TEISparseClient(base_url="http://tei-sparse")
+    first = client._client
+    for _ in range(3):
+        await client.embed_sparse(["x"])
+    assert client._client is first
+
+
+async def test_tei_reranker_client_reuses_single_async_client(
+    httpx_mock: HTTPXMock,
+) -> None:
+    for _ in range(3):
+        httpx_mock.add_response(
+            url="http://tei-reranker/rerank",
+            method="POST",
+            json=[{"index": 0, "score": 0.9}],
+        )
+    client = TEIRerankerClient(base_url="http://tei-reranker")
+    first = client._client
+    for _ in range(3):
+        await client.rerank("q", ["c"])
+    assert client._client is first
+
+
+async def test_tei_dense_client_aclose_closes_pool() -> None:
+    """aclose() must actually close the underlying httpx pool so process
+    shutdown drains cleanly + tests don't leak ResourceWarnings."""
+    client = TEIDenseClient(base_url="http://tei-dense")
+    assert not client._client.is_closed
+    await client.aclose()
+    assert client._client.is_closed
+
+
+async def test_tei_sparse_client_aclose_closes_pool() -> None:
+    client = TEISparseClient(base_url="http://tei-sparse")
+    await client.aclose()
+    assert client._client.is_closed
+
+
+async def test_tei_reranker_client_aclose_closes_pool() -> None:
+    client = TEIRerankerClient(base_url="http://tei-reranker")
+    await client.aclose()
+    assert client._client.is_closed


### PR DESCRIPTION
No tracking Issue: Gate 2 root-cause fix found during live load testing.

## Summary

Each `TEI{Dense,Sparse,Reranker}Client` was constructing a fresh `httpx.AsyncClient` on every request. No connection pool, no HTTP/1.1 keepalive — every call paid the full TCP connect + HTTP handshake cost.

This showed up as 10.94% failure rate on Gate 2 load (10 VUs, weighted mix, 15 min), with all 671 failures being 503 BACKEND_UNAVAILABLE on `/v1/retrieve` from the fast-path 400 ms `asyncio.wait_for` firing. Host was not saturated (GPU p95 31%, Qdrant CPU p95 9%, TEI CPU p95 7%) — the bottleneck was strictly per-request HTTP setup, amplified by concurrent retrieves each firing 2-3 TEI calls.

## Changes

- **`src/musubi/embedding/tei.py`** — each client owns a long-lived `httpx.AsyncClient` with explicit `Limits(max_connections=100, max_keepalive_connections=20)`. `_post_json` takes the client as a parameter instead of building one per call. Added `aclose()` to each class.
- **`src/musubi/api/bootstrap.py`** — register a shutdown handler on `app.router` that awaits all three `aclose()` calls. FastAPI removed the app-level `add_event_handler` in favour of lifespan; the router-level method still works and is how Starlette always exposed it.
- **`tests/test_embedding.py`** — 6 new tests:
  - `test_tei_{dense,sparse,reranker}_client_reuses_single_async_client` — regression guard. Asserts `client._client` is the same instance across multiple calls.
  - `test_tei_{dense,sparse,reranker}_client_aclose_closes_pool` — asserts pool is closed after `aclose()`.

## Expected impact

TEI round-trip latency drops from ~100 ms under contention back toward the ~10-20 ms reference-hardware envelope under which the 400 ms fast-path budget was originally calibrated. That should move Gate 2's retrieve p95 from 1.21 s back under 500 ms and drop the failure rate from 10.94% toward 0%.

Will re-run Gate 2 after this merges + deploys, and report before touching Gate 3 / Gate 4.

## Test plan

- [x] `make check` — 1170 passed, 231 skipped (+6 new)
- [x] All 10 existing TEI unit tests still pass
- [ ] Live Gate 2 re-run against `musubi.mey.house` post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)