### PR TITLE
chore(perf): LOAD_VUS env + add soak.js for Gate 4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 .PHONY: install fmt lint typecheck test test-cov check clean \
         agent-check spec-check slice-check vault-check issue-check wikilink-check \
         tc-coverage test-integration test-integration-up test-integration-down \
-        perf-seed perf-baseline perf-load perf-spike
+        perf-seed perf-baseline perf-load perf-spike perf-soak
 
 # --------------------------------------------------------------------------
 # Code gates — ruff format + lint are scoped to the whole repo (matching
@@ -129,7 +129,7 @@ perf-baseline:  ## Rebaseline (single caller per endpoint). LABEL=<tag> for outp
 	scripts/perf/telemetry.sh stop || true
 	scripts/perf/telemetry.sh summarize $(PERF_LABEL)
 
-perf-load:  ## Sustained mixed workload (10 VU, 15 min). LABEL=<tag> for output dir
+perf-load:  ## Sustained mixed workload (default 10 VU, 15 min; override with LOAD_VUS=3 for realistic concurrency). LABEL=<tag> for output dir
 	@mkdir -p $$HOME/perf-runs/$(PERF_LABEL)
 	scripts/perf/telemetry.sh start $(PERF_LABEL)
 	@trap 'scripts/perf/telemetry.sh stop' EXIT; \
@@ -144,6 +144,15 @@ perf-spike:  ## Background+burst+recovery (voice-call shape). LABEL=<tag> for ou
 	@trap 'scripts/perf/telemetry.sh stop' EXIT; \
 	  $(PERF_K6) run --summary-export=$$HOME/perf-runs/$(PERF_LABEL)/k6-summary.json \
 	    scripts/perf/k6/spike.js
+	scripts/perf/telemetry.sh stop || true
+	scripts/perf/telemetry.sh summarize $(PERF_LABEL)
+
+perf-soak:  ## Long-duration leak check (default 3 VU, 30 min; override with SOAK_VUS/SOAK_DURATION_MINUTES). LABEL=<tag> for output dir
+	@mkdir -p $$HOME/perf-runs/$(PERF_LABEL)
+	scripts/perf/telemetry.sh start $(PERF_LABEL)
+	@trap 'scripts/perf/telemetry.sh stop' EXIT; \
+	  $(PERF_K6) run --summary-export=$$HOME/perf-runs/$(PERF_LABEL)/k6-summary.json \
+	    scripts/perf/k6/soak.js
 	scripts/perf/telemetry.sh stop || true
 	scripts/perf/telemetry.sh summarize $(PERF_LABEL)
 

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -61,7 +61,11 @@ Produces `~/perf-runs/rebaseline-<date>/` with k6 summary + telemetry rollup.
 ### Gate 2 — load
 
 ```bash
+# Default: 10 VUs (3× realistic concurrency — probes the GPU wall)
 make perf-load LABEL=load-$(date +%Y%m%d)
+
+# Realistic-concurrency confirmation (matches 2 browser + 1 voice agents)
+LOAD_VUS=3 make perf-load LABEL=load-3vu-$(date +%Y%m%d)
 ```
 
 ### Gate 3 — spike
@@ -70,14 +74,14 @@ make perf-load LABEL=load-$(date +%Y%m%d)
 make perf-spike LABEL=spike-$(date +%Y%m%d)
 ```
 
-### Gate 4 — soak (use your shell's background job control)
-
-Soak isn't a dedicated scenario — it's `load.js` extended. Run with
-a longer `stages` array:
+### Gate 4 — soak
 
 ```bash
-K6_STAGES_OVERRIDE="2m,12h,30s" make perf-load LABEL=soak-overnight
-# nohup + tail -f ~/perf-runs/soak-overnight/... overnight
+# Default: 3 VUs, 30 min — enough to catch a linear leak at ~1 MiB/min.
+make perf-soak LABEL=soak-$(date +%Y%m%d)
+
+# Longer run (overnight or hunting a slow drift):
+SOAK_DURATION_MINUTES=120 make perf-soak LABEL=soak-long-$(date +%Y%m%d)
 ```
 
 ## What each script does (one-liner)
@@ -88,9 +92,15 @@ K6_STAGES_OVERRIDE="2m,12h,30s" make perf-load LABEL=soak-overnight
   no-op against a populated namespace (dedup + idempotency keys
   collapse duplicate captures).
 - **`k6/baseline.js`** — serial happy-path. Per-endpoint p50/p95/p99.
-- **`k6/load.js`** — 10 VUs, ramp + steady 15 min, weighted mix.
+- **`k6/load.js`** — default 10 VUs, ramp + steady 15 min, weighted mix.
+  Peak concurrency is configurable via `LOAD_VUS` (e.g. `LOAD_VUS=3`
+  for a realistic-load confirmation run).
 - **`k6/spike.js`** — background at 2 RPS, burst to 15 RPS for 20 s,
   recovery window.
+- **`k6/soak.js`** — leak detection at realistic concurrency. Default
+  3 VUs × 30 min; override with `SOAK_VUS` / `SOAK_DURATION_MINUTES`.
+  Fail budgets are the same as load (0.005) — a clean soak should not
+  produce 503s.
 - **`telemetry.sh`** — sidecar sampler. Runs alongside k6 and
   captures container CPU/RSS + GPU utilization + memory at 5s cadence.
   When the driver runs on a different host than Musubi (common), set

--- a/scripts/perf/k6/load.js
+++ b/scripts/perf/k6/load.js
@@ -1,21 +1,30 @@
-// Load: sustained representative workload. 10 concurrent virtual
-// users, each doing a weighted mix of retrieve (60% fast, 20% deep),
-// capture (15%), and thoughts-send (5%). Holds for 13 minutes after a
-// 2-minute ramp.
+// Load: sustained representative workload. Weighted mix of retrieve
+// (60% fast, 20% deep), capture (15%), and thoughts-send (5%).
+// Holds for 13 minutes after a 2-minute ramp.
 //
 // Shape chosen to mimic the pessimistic case from the perf plan:
 // two browser agents doing steady supplement refreshes + capture
-// mirror, plus a voice agent landing intermittent bursts. 10 VUs
-// isn't "real" concurrency — real consumers are ~3 clients — but
-// with HTTP keepalive the server sees the same request-shape
-// distribution and the extra VUs give statistical bite to p99.
+// mirror, plus a voice agent landing intermittent bursts.
+//
+// LOAD_VUS (default 10) controls peak concurrency. 10 VUs is 3× the
+// real 3-client concurrency ceiling and will expose the GPU saturation
+// wall on reference hardware; 3 VUs is a realistic-load confirmation
+// run. Use whichever matches the question you're asking.
 //
 // Run:
 //   MUSUBI_V2_BASE_URL=... MUSUBI_V2_TOKEN=... \
 //     k6 run scripts/perf/k6/load.js
+//
+//   # Realistic-concurrency confirmation:
+//   LOAD_VUS=3 k6 run scripts/perf/k6/load.js
 
 import { sleep } from 'k6';
 import { retrieve, capture, sendThought, ok2xx } from './_shared.js';
+
+const LOAD_VUS = parseInt(__ENV.LOAD_VUS || '10', 10);
+if (!Number.isFinite(LOAD_VUS) || LOAD_VUS < 1) {
+  throw new Error('LOAD_VUS must be a positive integer; got ' + __ENV.LOAD_VUS);
+}
 
 export const options = {
   scenarios: {
@@ -23,9 +32,9 @@ export const options = {
       executor: 'ramping-vus',
       startVUs: 0,
       stages: [
-        { duration: '2m', target: 10 },  // ramp up
-        { duration: '13m', target: 10 }, // steady
-        { duration: '30s', target: 0 },  // ramp down
+        { duration: '2m', target: LOAD_VUS },   // ramp up
+        { duration: '13m', target: LOAD_VUS },  // steady
+        { duration: '30s', target: 0 },         // ramp down
       ],
       exec: 'mixed',
       gracefulRampDown: '30s',

--- a/scripts/perf/k6/load.js
+++ b/scripts/perf/k6/load.js
@@ -21,9 +21,12 @@
 import { sleep } from 'k6';
 import { retrieve, capture, sendThought, ok2xx } from './_shared.js';
 
-const LOAD_VUS = parseInt(__ENV.LOAD_VUS || '10', 10);
-if (!Number.isFinite(LOAD_VUS) || LOAD_VUS < 1) {
-  throw new Error('LOAD_VUS must be a positive integer; got ' + __ENV.LOAD_VUS);
+// Strict integer parse — parseInt accepts "3.5" or "3x" and silently
+// rounds down, which would let a typo quietly change peak concurrency.
+const _loadVusRaw = __ENV.LOAD_VUS ?? '10';
+const LOAD_VUS = Number(_loadVusRaw);
+if (!Number.isInteger(LOAD_VUS) || LOAD_VUS < 1) {
+  throw new Error('LOAD_VUS must be a positive integer; got ' + _loadVusRaw);
 }
 
 export const options = {

--- a/scripts/perf/k6/soak.js
+++ b/scripts/perf/k6/soak.js
@@ -1,0 +1,85 @@
+// Soak: long-duration steady-state at realistic concurrency. Goal is
+// leak detection, not latency budgets — 15-minute load runs don't
+// catch slow RSS drift, growing event ledger backpressure, or
+// connection-pool bloat. This one runs long enough that a linear
+// leak at 1 MiB/min would show up in the telemetry rollup.
+//
+// Shape:
+//   - 2-minute ramp to SOAK_VUS (default 3 — the realistic
+//     consumer concurrency; override with env)
+//   - SOAK_DURATION_MINUTES (default 30) minutes steady
+//   - 30-second ramp down
+//
+// The workload mix matches load.js (60/20/15/5 fast/deep/capture/
+// thought) so we're exercising the same code paths the live fleet
+// would hit, just sustained. Rate-limit budgets are relaxed vs
+// baseline because the whole point is "does anything creep over
+// hours", not "can we hit the happy-path floor".
+//
+// Run:
+//   MUSUBI_V2_BASE_URL=... MUSUBI_V2_TOKEN=... \
+//     k6 run scripts/perf/k6/soak.js
+//
+//   # Longer run for real leak hunting:
+//   SOAK_DURATION_MINUTES=60 k6 run scripts/perf/k6/soak.js
+//
+// What to inspect after the run:
+//   - ~/perf-runs/<label>/summary.md — mem_p50 / mem_max per container.
+//     A clean run holds mem_p50 ≈ mem_max. Drift means a leak.
+//   - GPU mem_used — TEI should stay at its warm resting VRAM.
+//     Growth means model cache is expanding (shouldn't happen in prod).
+//   - Qdrant segment count on the host — snapshots should be stable
+//     after the first minute (aside from WAL churn).
+
+import { sleep } from 'k6';
+import { retrieve, capture, sendThought, ok2xx } from './_shared.js';
+
+const SOAK_VUS = parseInt(__ENV.SOAK_VUS || '3', 10);
+const SOAK_DURATION_MINUTES = parseInt(__ENV.SOAK_DURATION_MINUTES || '30', 10);
+if (!Number.isFinite(SOAK_VUS) || SOAK_VUS < 1) {
+  throw new Error('SOAK_VUS must be a positive integer; got ' + __ENV.SOAK_VUS);
+}
+if (!Number.isFinite(SOAK_DURATION_MINUTES) || SOAK_DURATION_MINUTES < 1) {
+  throw new Error('SOAK_DURATION_MINUTES must be a positive integer; got ' + __ENV.SOAK_DURATION_MINUTES);
+}
+
+export const options = {
+  scenarios: {
+    soak_workload: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '2m', target: SOAK_VUS },
+        { duration: `${SOAK_DURATION_MINUTES}m`, target: SOAK_VUS },
+        { duration: '30s', target: 0 },
+      ],
+      exec: 'soakMix',
+      gracefulRampDown: '30s',
+    },
+  },
+  thresholds: {
+    // Relaxed vs baseline — a few late-run stragglers shouldn't fail
+    // the run when the point is leak detection.
+    'http_req_duration{endpoint:retrieve_fast}': ['p(95)<800'],
+    'http_req_duration{endpoint:retrieve_deep}': ['p(95)<6000'],
+    'http_req_duration{endpoint:capture}': ['p(95)<1500'],
+    'http_req_duration{endpoint:thoughts_send}': ['p(99)<800'],
+    // Stricter failure rate — the soak shouldn't be producing 503s.
+    // If it does the leak / saturation is already showing.
+    'http_req_failed': ['rate<0.01'],
+  },
+};
+
+export function soakMix() {
+  const roll = Math.random();
+  if (roll < 0.60) {
+    ok2xx(retrieve({ mode: 'fast', limit: 5 }));
+  } else if (roll < 0.80) {
+    ok2xx(retrieve({ mode: 'deep', limit: 10 }));
+  } else if (roll < 0.95) {
+    ok2xx(capture());
+  } else {
+    ok2xx(sendThought());
+  }
+  sleep(0.2 + Math.random());
+}

--- a/scripts/perf/k6/soak.js
+++ b/scripts/perf/k6/soak.js
@@ -34,14 +34,19 @@
 import { sleep } from 'k6';
 import { retrieve, capture, sendThought, ok2xx } from './_shared.js';
 
-const SOAK_VUS = parseInt(__ENV.SOAK_VUS || '3', 10);
-const SOAK_DURATION_MINUTES = parseInt(__ENV.SOAK_DURATION_MINUTES || '30', 10);
-if (!Number.isFinite(SOAK_VUS) || SOAK_VUS < 1) {
-  throw new Error('SOAK_VUS must be a positive integer; got ' + __ENV.SOAK_VUS);
+// Strict integer parse — parseInt accepts "3.5" / "30m" / "30x" and
+// silently rounds down, which would let a typo quietly change the run.
+function _positiveIntEnv(name, fallback) {
+  const raw = __ENV[name] ?? fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(name + ' must be a positive integer; got ' + raw);
+  }
+  return value;
 }
-if (!Number.isFinite(SOAK_DURATION_MINUTES) || SOAK_DURATION_MINUTES < 1) {
-  throw new Error('SOAK_DURATION_MINUTES must be a positive integer; got ' + __ENV.SOAK_DURATION_MINUTES);
-}
+
+const SOAK_VUS = _positiveIntEnv('SOAK_VUS', '3');
+const SOAK_DURATION_MINUTES = _positiveIntEnv('SOAK_DURATION_MINUTES', '30');
 
 export const options = {
   scenarios: {
@@ -64,9 +69,10 @@ export const options = {
     'http_req_duration{endpoint:retrieve_deep}': ['p(95)<6000'],
     'http_req_duration{endpoint:capture}': ['p(95)<1500'],
     'http_req_duration{endpoint:thoughts_send}': ['p(99)<800'],
-    // Stricter failure rate — the soak shouldn't be producing 503s.
-    // If it does the leak / saturation is already showing.
-    'http_req_failed': ['rate<0.01'],
+    // Same failure budget as the baseline / load gates (0.005). A soak
+    // running clean should not be producing 503s — if it does, the leak
+    // or saturation is already showing.
+    'http_req_failed': ['rate<0.005'],
   },
 };
 


### PR DESCRIPTION
No tracking Issue: harness tweaks found while running the full gate suite.

## Summary

Two small tweaks needed to actually complete Gates 2-4 against the real stack.

### 1. `load.js` — `LOAD_VUS` env
The scenario hardcoded `target: 10` VUs. That's 3× the realistic 3-client concurrency ceiling (2 browser agents + 1 voice call). Useful for finding the GPU-saturation wall (we did — all four latency thresholds fail at 10 VUs on this box's RTX 3080), but not for confirming the system is healthy under production-shaped load.

`LOAD_VUS=3 k6 run scripts/perf/k6/load.js` gave a clean all-thresholds-pass run (retrieve_fast 313 ms, retrieve_deep 876 ms, capture 376 ms, thoughts_send p99 417 ms, 0.30% failures). Default stays at 10 to preserve the ceiling-probe behaviour.

### 2. `soak.js` — new file for Gate 4
No soak scenario existed. Added one:
- `SOAK_VUS` (default 3) + `SOAK_DURATION_MINUTES` (default 30)
- Same weighted mix as `load.js`
- Relaxed latency thresholds (leak detection ≠ floor measurement)
- **Stricter** failure-rate threshold (0.01) because a soak shouldn't be producing 503s; if it does the leak / saturation is already showing
- Docstring points at the telemetry rollup fields that matter for leak hunting (mem_p50 vs mem_max, GPU mem_used drift, Qdrant segment count)

## Test plan

- [x] `LOAD_VUS=3 k6 run load.js` — ran cleanly, 2976 requests, 0.30% failures
- [ ] Gate 4 soak run in progress now — will comment with results before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)