### PR TITLE
chore(deploy): pin musubi_core_image to post-#198 pooled-client digest

### DIFF
--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -22,12 +22,18 @@ musubi_data_dirs:
   - /var/lib/musubi/backups
 
 musubi_core_port: 8100
-# Musubi Core image. Pinned by immutable digest from the v0.3.0 signed
-# publish run (2026-04-21). Produced by `.github/workflows/publish-core-image.yml`;
-# verified cosign-signed + SBOM-attested + Trivy-CRITICAL-scanned.
-# Bump this after every release — the release note on the GitHub tag carries
-# the new digest line ready to paste.
-musubi_core_image: "ghcr.io/ericmey/musubi-core@sha256:8e3554303d948406d79cd39c7c1b1edc1f5497894eeb2466307a83a38336f015"
+# Musubi Core image. Pinned by immutable digest.
+#
+# Current pin: post-#198 (TEI connection pooling fix). This is the digest
+# validated end-to-end through Gates 1-4 on 2026-04-23 against the live
+# musubi.mey.house box — baseline + load at 3 VUs + spike + 30-minute soak
+# all clean, no memory drift.
+#
+# Produced by `.github/workflows/publish-core-image.yml`; verified
+# cosign-signed + SBOM-attested + Trivy-CRITICAL-scanned. Bump this after
+# every release — the release note on the GitHub tag carries the new
+# digest line ready to paste.
+musubi_core_image: "ghcr.io/ericmey/musubi-core@sha256:4c51335e27e4bae2afb5645e4ac20df35708dbed5b62126818a7efa00450602f"
 musubi_qdrant_image: "qdrant/qdrant:v1.17.1"
 # TEI image tag = <compute-capability>-<version>. RTX 3080 is Ampere,
 # compute 8.6 → `86-*`. Other GPUs: `turing-*` (RTX 20xx), `89-*` (RTX 40xx),


### PR DESCRIPTION
No tracking Issue: config-as-code sync after tonight's gate sweep.

## Summary

Bumps \`deploy/ansible/group_vars/all.yml::musubi_core_image\` from the v0.3.0 baseline digest (\`sha256:8e3554…\`) to \`sha256:4c51335e…\` — the digest the live box at \`musubi.mey.house\` is actually running and that was validated end-to-end through Gates 1-4 tonight:

- **Gate 1 baseline** — passed after #197 wired retrieve to orchestration
- **Gate 2 load** at 3 VUs (realistic) — 5/5 thresholds, 0.30% failure rate
- **Gate 3 spike** — recovered cleanly from 15 RPS burst
- **Gate 4 soak** — 30 min, 6639 requests, 0.43% failures, zero memory drift

## Why this matters

Before this bump, group_vars lagged live state by **four releases' worth of src/musubi/ changes** (#194, #196, #197, #198). Running \`ansible-playbook deploy.yml\` with the old pin would have reverted the live core container to the pre-#195 stub retrieve — not a fun surprise the next time anyone deploys.

The normal auto-digest-bump workflow fires on \`release:published\`, not on merge to main. Since tonight's work landed as a sequence of merges without cutting a release, the pin drifted.

## Test plan

- [x] Live verified: \`sudo docker inspect musubi-core-1 --format '{{.Image}}'\` on \`musubi.mey.house\` matches the new digest exactly.
- [x] Gate sweep recorded in \`~/perf-runs/{rebaseline,load-3vu,spike,soak}-20260423\` against this image.
- [ ] Next \`ansible-playbook deploy.yml\` or \`update.yml\` will no-op on the core container (pin already matches running digest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)