### PR TITLE
fix(api): map pydantic ValidationError to 422 (closes #192)

### DIFF
--- a/src/musubi/api/app.py
+++ b/src/musubi/api/app.py
@@ -33,7 +33,6 @@ from collections.abc import Awaitable, Callable
 
 from fastapi import FastAPI, Request, Response
 from fastapi.exceptions import RequestValidationError
-from pydantic import ValidationError
 
 from musubi.api.errors import APIError, api_error_handler, error_response
 from musubi.api.idempotency import IdempotencyCache, get_idempotency_cache
@@ -305,20 +304,16 @@ def create_app(*, settings: Settings | None = None) -> FastAPI:
             hint="check the request body / query parameters against the OpenAPI spec",
         )
 
-    @app.exception_handler(ValidationError)
-    async def _pydantic_validation_handler(_request: Request, exc: ValidationError) -> Response:
-        # Handles pydantic ValidationErrors raised *inside* handlers,
-        # typically when we construct a typed model (e.g. EpisodicMemory)
-        # from a body whose nested field fails a pydantic AfterValidator —
-        # most commonly the namespace regex. Without this, such errors
-        # bubble up as 500 INTERNAL, which is misleading: the client
-        # sent invalid data, not the server a bug.
-        return error_response(
-            status_code=422,
-            detail=str(exc),
-            code="BAD_REQUEST",
-            hint="check the field values against the OpenAPI spec / type constraints",
-        )
+    # NOTE: no global `ValidationError` handler.
+    #
+    # A naked `pydantic.ValidationError` can be raised anywhere — e.g.
+    # when a plane rehydrates a model from Qdrant payload and the
+    # stored data is corrupt. That's a 5xx, not a 422. A global
+    # handler would silently map every such bug to BAD_REQUEST and
+    # hide real server-side breakage. Translation is done at the
+    # specific call sites where we KNOW the input is request-driven
+    # (see `src/musubi/api/routers/writes_episodic.py` for the
+    # capture path).
 
     # Read routers (from slice-api-v0-read)
     app.include_router(ops.router)

--- a/src/musubi/api/app.py
+++ b/src/musubi/api/app.py
@@ -33,6 +33,7 @@ from collections.abc import Awaitable, Callable
 
 from fastapi import FastAPI, Request, Response
 from fastapi.exceptions import RequestValidationError
+from pydantic import ValidationError
 
 from musubi.api.errors import APIError, api_error_handler, error_response
 from musubi.api.idempotency import IdempotencyCache, get_idempotency_cache
@@ -293,11 +294,30 @@ def create_app(*, settings: Settings | None = None) -> FastAPI:
 
     @app.exception_handler(RequestValidationError)
     async def _validation_handler(_request: Request, exc: RequestValidationError) -> Response:
+        # 422 Unprocessable Entity is the correct status for a
+        # well-formed request whose body fails semantic validation
+        # (RFC 9110 §15.5.21). We were emitting 400 here originally,
+        # which conflated "malformed" with "semantically invalid".
         return error_response(
-            status_code=400,
+            status_code=422,
             detail=str(exc),
             code="BAD_REQUEST",
             hint="check the request body / query parameters against the OpenAPI spec",
+        )
+
+    @app.exception_handler(ValidationError)
+    async def _pydantic_validation_handler(_request: Request, exc: ValidationError) -> Response:
+        # Handles pydantic ValidationErrors raised *inside* handlers,
+        # typically when we construct a typed model (e.g. EpisodicMemory)
+        # from a body whose nested field fails a pydantic AfterValidator —
+        # most commonly the namespace regex. Without this, such errors
+        # bubble up as 500 INTERNAL, which is misleading: the client
+        # sent invalid data, not the server a bug.
+        return error_response(
+            status_code=422,
+            detail=str(exc),
+            code="BAD_REQUEST",
+            hint="check the field values against the OpenAPI spec / type constraints",
         )
 
     # Read routers (from slice-api-v0-read)

--- a/src/musubi/api/routers/writes_episodic.py
+++ b/src/musubi/api/routers/writes_episodic.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Body, Depends, Query, Request, Response
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from qdrant_client import QdrantClient, models
 
 from musubi.api.auth import require_auth
@@ -15,6 +15,26 @@ from musubi.planes.episodic import EpisodicPlane
 from musubi.settings import Settings
 from musubi.types.common import Err, Ok
 from musubi.types.episodic import EpisodicMemory
+
+
+def _build_episodic(**kwargs: object) -> EpisodicMemory:
+    """Construct an :class:`EpisodicMemory` from request-supplied values.
+
+    A direct ``EpisodicMemory(**kwargs)`` call raises
+    :class:`pydantic.ValidationError` on a bad namespace / importance /
+    tags value. Since this is request-driven data we translate that to
+    a 422 BAD_REQUEST — the same status FastAPI emits when the body
+    itself fails schema validation. See the note in ``app.py`` about why
+    we don't install a global handler for ``ValidationError``."""
+    try:
+        return EpisodicMemory(**kwargs)  # type: ignore[arg-type]
+    except ValidationError as exc:
+        raise APIError(
+            status_code=422,
+            code="BAD_REQUEST",
+            detail=str(exc),
+            hint="check the request body against the OpenAPI spec",
+        ) from exc
 
 
 def _check_body_scope(request: Request, namespace: str, settings: Settings) -> None:
@@ -96,15 +116,14 @@ async def capture(
     settings: Settings = Depends(get_settings_dep),
 ) -> CaptureResponse:
     _check_body_scope(request, body.namespace, settings)
-    saved = await plane.create(
-        EpisodicMemory(
-            namespace=body.namespace,
-            content=body.content,
-            summary=body.summary,
-            tags=body.tags,
-            importance=body.importance,
-        )
+    memory = _build_episodic(
+        namespace=body.namespace,
+        content=body.content,
+        summary=body.summary,
+        tags=body.tags,
+        importance=body.importance,
     )
+    saved = await plane.create(memory)
     response = CaptureResponse(object_id=saved.object_id, state=saved.state)
     request.state.idempotency_response = response.model_dump()
     return response
@@ -125,15 +144,14 @@ async def batch_capture(
     _check_body_scope(request, body.namespace, settings)
     out: list[str] = []
     for item in body.items:
-        saved = await plane.create(
-            EpisodicMemory(
-                namespace=body.namespace,
-                content=item.content,
-                summary=item.summary,
-                tags=item.tags,
-                importance=item.importance,
-            )
+        memory = _build_episodic(
+            namespace=body.namespace,
+            content=item.content,
+            summary=item.summary,
+            tags=item.tags,
+            importance=item.importance,
         )
+        saved = await plane.create(memory)
         out.append(saved.object_id)
     return BatchCaptureResponse(object_ids=out)
 

--- a/tests/api/test_api_v0_write.py
+++ b/tests/api/test_api_v0_write.py
@@ -683,19 +683,62 @@ def test_committed_openapi_yaml_includes_write_paths() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_capture_validation_error_returns_400(
+def test_capture_validation_error_returns_422(
     client: TestClient,
     valid_token: str,
 ) -> None:
-    """A validation error (e.g. missing required content) returns the
-    typed BAD_REQUEST envelope."""
+    """A well-formed request whose body fails validation at the
+    FastAPI boundary (e.g. missing required content) returns 422
+    Unprocessable Entity per RFC 9110 §15.5.21, carrying the typed
+    BAD_REQUEST envelope."""
     r = client.post(
         "/v1/memories",
         headers={"Authorization": f"Bearer {valid_token}"},
         json={"namespace": "eric/claude-code/episodic"},  # content missing
     )
-    assert r.status_code == 400
+    assert r.status_code == 422
     assert r.json()["error"]["code"] == "BAD_REQUEST"
+
+
+def test_capture_malformed_namespace_returns_422_not_500(
+    client: TestClient,
+    api_settings: object,
+) -> None:
+    """Regression guard for #192 — a malformed namespace (two segments
+    instead of the required tenant/presence/plane) fails the pydantic
+    AfterValidator that the plane's typed model applies when the
+    handler constructs an ``EpisodicMemory``. That pydantic
+    ``ValidationError`` used to bubble up unhandled as 500 INTERNAL,
+    which was misleading: the client sent invalid data, not the server
+    a bug. Must be 422 with the typed BAD_REQUEST envelope.
+
+    To reach the typed-model construction we need a token whose scope
+    matches the malformed namespace (otherwise the auth scope check
+    fires first, producing 403). The scope matcher accepts any N-part
+    glob, so a 2-segment scope pattern grants a 2-segment namespace —
+    and we land at the plane's AfterValidator, which is what we're
+    actually testing."""
+    from tests.api.conftest import mint_token
+
+    # Scope grants the exact malformed namespace so scope check passes.
+    token = mint_token(
+        api_settings,  # type: ignore[arg-type]
+        scopes=["perf-test/episodic:rw"],
+        presence="perf-test/ephemeral",
+    )
+    r = client.post(
+        "/v1/memories",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "namespace": "perf-test/episodic",  # two segments — invalid
+            "content": "whatever",
+        },
+    )
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "BAD_REQUEST"
+    # The detail should mention the namespace field so callers can
+    # localise the problem.
+    assert "namespace" in r.json()["error"]["detail"].lower()
 
 
 def test_idempotency_key_different_body_returns_conflict(


### PR DESCRIPTION
Closes #192.

## Summary

Two related behaviours changed, both bringing the API in line with RFC 9110 §15.5.21 (422 Unprocessable Entity = well-formed request but semantically invalid content):

1. **`RequestValidationError` (FastAPI boundary)** was emitting 400. Now 422. Same typed envelope (`code` stays `BAD_REQUEST`), correct status.

2. **Raw `pydantic.ValidationError` raised inside a handler** had no handler registered, so it bubbled up as 500 INTERNAL — a lie about who was at fault. Now handled → 422.

The specific #192 repro: `POST /v1/memories` with a 2-segment namespace (\`perf-test/episodic\`) passes the scope check on a 2-segment scope pattern, then fails `EpisodicMemory`'s `Namespace` AfterValidator when the handler constructs the typed model. Previously 500, now 422.

## Test plan

- [x] New `test_capture_malformed_namespace_returns_422_not_500` — regression guard for the exact #192 case (mid-handler pydantic path).
- [x] Renamed `test_capture_validation_error_returns_400` → `_returns_422` with updated assertions; covers the FastAPI boundary path.
- [x] `make check` — 1171 passed, 231 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)