### PR TITLE
fix(ops): repair backup/restore playbook (closes #190)

### DIFF
--- a/deploy/backup/drill.yml
+++ b/deploy/backup/drill.yml
@@ -1,26 +1,69 @@
 ---
-- name: Restore drill bootstrap
-  ansible.builtin.import_playbook: ../ansible/bootstrap.yml
+# Restore drill — exercises restore.yml end-to-end and verifies the
+# stack is serving afterwards.
+#
+# By DEFAULT this does NOT re-run bootstrap.yml. Bootstrap is
+# destructive (reinstalls system packages, creates the musubi user,
+# etc.) and running it against an already-bootstrapped host would
+# rebuild the host from scratch. That's the correct behaviour for a
+# scratch-VM drill but the wrong behaviour for a "does restore.yml
+# still work" drill run on the live box.
+#
+# Two modes:
+#
+#   # Safe mode (default). Runs only restore + validation on an
+#   # already-bootstrapped host. Use this against musubi.mey.house.
+#   ansible-playbook deploy/backup/drill.yml \
+#     -e backup_timestamp=20260422T180001Z
+#
+#   # Fresh-host mode. Runs bootstrap too. Intended for a scratch VM
+#   # where you want to prove the full bring-up + restore loop works.
+#   ansible-playbook deploy/backup/drill.yml \
+#     -e drill_fresh_host=true \
+#     -e backup_timestamp=20260422T180001Z
 
-- name: Restore drill data
+- name: Optional bootstrap (fresh-host drills only)
+  hosts: musubi
+  become: true
+  gather_facts: false
+  vars:
+    drill_fresh_host: false
+  tasks:
+    - name: Include bootstrap playbook when drill_fresh_host=true
+      ansible.builtin.import_playbook: ../ansible/bootstrap.yml
+      when: drill_fresh_host | bool
+
+- name: Restore drill — data
   ansible.builtin.import_playbook: restore.yml
 
 - name: Validate restored Musubi
   hosts: musubi
   become: true
+  vars:
+    musubi_config_dir: /etc/musubi
+    compose_file: "{{ musubi_config_dir }}/docker-compose.yml"
+    env_file: "{{ musubi_config_dir }}/.env.production"
   tasks:
-    - name: Rebuild curated index during drill
-      ansible.builtin.command:
-        cmd: musubi-cli index rebuild --collection musubi_curated --source /var/lib/musubi/vault
-      changed_when: true
+    - name: Probe core health
+      ansible.builtin.uri:
+        url: "http://{{ ansible_host }}:8100/v1/ops/health"
+        status_code: 200
 
-    - name: Rechunk artifacts during drill
+    - name: Sanity-check Qdrant collection count (must be non-zero after restore)
       ansible.builtin.command:
-        cmd: musubi-cli artifacts rechunk --all
-      changed_when: true
-
-    - name: Run restore smoke suite
-      ansible.builtin.command: musubi-contract-smoke --target http://127.0.0.1:8100
-      async: 300
-      poll: 10
+        cmd: >-
+          docker compose -f {{ compose_file }} --env-file {{ env_file }}
+          exec -T lifecycle-worker python -c
+          "import os, httpx, sys;
+          r = httpx.get('http://qdrant:6333/collections',
+                       headers={'api-key': os.environ['QDRANT_API_KEY']},
+                       timeout=15.0);
+          names = [c['name'] for c in r.json().get('result', {}).get('collections', [])];
+          print(' '.join(names));
+          sys.exit(0 if names else 1)"
+      register: qdrant_collections
       changed_when: false
+
+    - name: Surface which collections came back online
+      ansible.builtin.debug:
+        msg: "Restored collections: {{ qdrant_collections.stdout }}"

--- a/deploy/backup/drill.yml
+++ b/deploy/backup/drill.yml
@@ -22,16 +22,13 @@
 #     -e drill_fresh_host=true \
 #     -e backup_timestamp=20260422T180001Z
 
-- name: Optional bootstrap (fresh-host drills only)
-  hosts: musubi
-  become: true
-  gather_facts: false
-  vars:
-    drill_fresh_host: false
-  tasks:
-    - name: Include bootstrap playbook when drill_fresh_host=true
-      ansible.builtin.import_playbook: ../ansible/bootstrap.yml
-      when: drill_fresh_host | bool
+# `import_playbook` is a play-level directive, not a task action, so
+# the conditional bootstrap gate must sit at play scope. When
+# drill_fresh_host is false (the default) the import is skipped
+# entirely — no bootstrap play runs.
+- name: Bootstrap (fresh-host drills only)
+  ansible.builtin.import_playbook: ../ansible/bootstrap.yml
+  when: drill_fresh_host | default(false) | bool
 
 - name: Restore drill — data
   ansible.builtin.import_playbook: restore.yml
@@ -46,7 +43,7 @@
   tasks:
     - name: Probe core health
       ansible.builtin.uri:
-        url: "http://{{ ansible_host }}:8100/v1/ops/health"
+        url: "{{ musubi_health_urls.core }}"
         status_code: 200
 
     - name: Sanity-check Qdrant collection count (must be non-zero after restore)

--- a/deploy/backup/restore.yml
+++ b/deploy/backup/restore.yml
@@ -1,94 +1,198 @@
 ---
-- name: Restore Musubi canonical stores
+# Restore Musubi canonical state from a host-local backup.
+#
+# Paired with `musubi-backup.sh` (systemd timer, 6h cadence). That
+# script produces:
+#
+#   /var/lib/musubi/backups/<TIMESTAMP>/
+#     qdrant/<collection>.snapshot + SHA256SUMS
+#     sqlite/work.sqlite
+#     artifact-blobs/<blob hashes>
+#     manifest.json
+#
+# This playbook consumes that layout:
+#
+#   1. Stop the core + lifecycle-worker compose services so nothing
+#      writes to the volumes while we swap them.
+#   2. Copy Qdrant snapshot files into the per-collection directory
+#      Qdrant watches (/var/lib/musubi/qdrant-snapshots/<coll>/), then
+#      POST each one to /collections/<coll>/snapshots/recover via the
+#      Qdrant HTTP API. We shell the HTTP call through the
+#      lifecycle-worker container (same pattern the backup script uses)
+#      so we don't need curl on the host and stay inside the compose
+#      network.
+#   3. Copy the SQLite ledger back into place.
+#   4. Rsync artifact blobs back. Content-addressed so this is nearly
+#      idempotent.
+#   5. Re-start core + lifecycle-worker via docker-compose.
+#
+# Left out on purpose:
+#   - Vault git clone — vault sync is a separate concern (slice-vault-sync).
+#     If the vault needs restoring, the git remote that the vault-sync
+#     pushes to is the source of truth, not this backup tarball.
+#   - Index rebuilds / rechunking — Qdrant snapshots already contain
+#     the indexes, so they come back ready to serve. The old
+#     `musubi-cli index rebuild` step predated the snapshot-API flow.
+#
+# Invocation:
+#
+#   ansible-playbook -i deploy/ansible/inventory.yml \
+#     -e backup_timestamp=20260422T180001Z \
+#     deploy/backup/restore.yml
+#
+# Omitting `backup_timestamp` falls back to the most recent backup dir.
+
+- name: Restore Musubi canonical stores from a host-local backup
   hosts: musubi
   become: true
   vars:
-    restore_timestamp: "{{ backup_timestamp | default('latest') }}"
+    # Where the backup script wrote to and where this restore reads from.
+    backup_root: /var/lib/musubi/backups
+    # Per-host compose config the `musubi` systemd unit points at.
+    musubi_config_dir: /etc/musubi
+    compose_file: "{{ musubi_config_dir }}/docker-compose.yml"
+    env_file: "{{ musubi_config_dir }}/.env.production"
+    # Services whose containers must be stopped before we swap state.
+    # Qdrant itself keeps running — the snapshot-recover API is its
+    # supported live-restore path.
+    restored_services:
+      - core
+      - lifecycle-worker
+    # `latest` resolves to the most recent directory under backup_root
+    # at playbook time; override with `-e backup_timestamp=<id>` to pin.
+    backup_timestamp: latest
+
   tasks:
-    - name: Stop Musubi before restore
-      ansible.builtin.systemd_service:
-        name: musubi
+    - name: Resolve backup directory (latest or pinned)
+      ansible.builtin.shell: |
+        set -euo pipefail
+        if [ "{{ backup_timestamp }}" = "latest" ]; then
+          ls -1 {{ backup_root }} | sort | tail -n 1
+        else
+          echo "{{ backup_timestamp }}"
+        fi
+      register: resolved_backup
+      changed_when: false
+
+    - name: Set backup_dir fact
+      ansible.builtin.set_fact:
+        backup_dir: "{{ backup_root }}/{{ resolved_backup.stdout }}"
+
+    - name: Assert backup directory exists
+      ansible.builtin.stat:
+        path: "{{ backup_dir }}/manifest.json"
+      register: manifest_stat
+      failed_when: not manifest_stat.stat.exists
+
+    - name: Read backup manifest
+      ansible.builtin.slurp:
+        src: "{{ backup_dir }}/manifest.json"
+      register: manifest_blob
+
+    - name: Surface which backup we're restoring from
+      ansible.builtin.debug:
+        msg: "Restoring from {{ backup_dir }} manifest={{ (manifest_blob.content | b64decode) }}"
+
+    # ------------------------------------------------------------------
+    # 1. Stop core + lifecycle-worker (leave qdrant up for snapshot-recover).
+    # ------------------------------------------------------------------
+
+    - name: Stop core + lifecycle-worker before restoring state
+      community.docker.docker_compose_v2:
+        project_src: "{{ musubi_config_dir }}"
+        env_files:
+          - "{{ env_file }}"
+        services: "{{ restored_services }}"
         state: stopped
 
-    - name: Restore vault from git remote
+    # ------------------------------------------------------------------
+    # 2. Qdrant snapshot recovery.
+    # ------------------------------------------------------------------
+
+    - name: Enumerate snapshot files to restore
+      ansible.builtin.find:
+        paths: "{{ backup_dir }}/qdrant"
+        patterns: "*.snapshot"
+        file_type: file
+      register: snapshot_files
+
+    - name: Fail loudly if no snapshots found
+      ansible.builtin.fail:
+        msg: "no *.snapshot files under {{ backup_dir }}/qdrant — cowardly refusing to restore"
+      when: snapshot_files.files | length == 0
+
+    - name: Stage each snapshot into Qdrant's per-collection snapshots dir
+      ansible.builtin.copy:
+        src: "{{ item.path }}"
+        dest: "/var/lib/musubi/qdrant-snapshots/{{ item.path | basename | regex_replace('\\.snapshot$', '') }}/{{ item.path | basename }}"
+        remote_src: true
+        mode: "0640"
+      loop: "{{ snapshot_files.files }}"
+      loop_control:
+        label: "{{ item.path | basename }}"
+
+    - name: Recover each Qdrant collection from its staged snapshot
       ansible.builtin.command:
         cmd: >-
-          git clone {{ vault_musubi_vault_remote }}
-          /var/lib/musubi/vault.restore
+          docker compose -f {{ compose_file }} --env-file {{ env_file }}
+          exec -T lifecycle-worker python -c
+          "import os, sys, httpx;
+          coll = sys.argv[1];
+          snap = sys.argv[2];
+          r = httpx.put(f'http://qdrant:6333/collections/{coll}/snapshots/recover',
+                        headers={'api-key': os.environ['QDRANT_API_KEY']},
+                        json={'location': f'file:///qdrant/snapshots/{coll}/{snap}'},
+                        timeout=300.0);
+          sys.exit(0 if r.status_code == 200 else (print(r.status_code, r.text[:200]) or 1))"
+          {{ item.path | basename | regex_replace('\\.snapshot$', '') }}
+          {{ item.path | basename }}
+      loop: "{{ snapshot_files.files }}"
+      loop_control:
+        label: "{{ item.path | basename }}"
       changed_when: true
-      no_log: true
 
-    - name: Swap restored vault into place
-      ansible.builtin.command:
-        cmd: >-
-          rsync -a --delete-after /var/lib/musubi/vault.restore/
-          /var/lib/musubi/vault/
-      changed_when: true
-
-    - name: Restore artifact blobs
-      ansible.posix.synchronize:
-        src: /mnt/snapshots/artifact-blobs/
-        dest: /var/lib/musubi/artifact-blobs/
-        archive: true
-        delete: false
-      delegate_to: "{{ inventory_hostname }}"
+    # ------------------------------------------------------------------
+    # 3. SQLite ledger.
+    # ------------------------------------------------------------------
 
     - name: Restore sqlite lifecycle ledger
       ansible.builtin.copy:
-        src: /mnt/snapshots/sqlite/lifecycle-work-{{ restore_timestamp }}.sqlite
-        dest: /var/lib/musubi/lifecycle-work.sqlite
+        src: "{{ backup_dir }}/sqlite/work.sqlite"
+        dest: /var/lib/musubi/lifecycle/work.sqlite
         remote_src: true
         owner: musubi
         group: musubi
         mode: "0640"
 
-    - name: Restore lifecycle cursor files
+    # ------------------------------------------------------------------
+    # 4. Artifact blobs.
+    # ------------------------------------------------------------------
+
+    - name: Restore artifact blobs (content-addressed, idempotent)
       ansible.posix.synchronize:
-        src: /mnt/snapshots/cursors/
-        dest: /var/lib/musubi/
+        src: "{{ backup_dir }}/artifact-blobs/"
+        dest: /var/lib/musubi/artifact-blobs/
         archive: true
         delete: false
       delegate_to: "{{ inventory_hostname }}"
 
-    - name: Start Musubi with restored filesystem stores
-      ansible.builtin.systemd_service:
-        name: musubi
+    # ------------------------------------------------------------------
+    # 5. Bring core + lifecycle-worker back up.
+    # ------------------------------------------------------------------
+
+    - name: Restart core + lifecycle-worker with restored state
+      community.docker.docker_compose_v2:
+        project_src: "{{ musubi_config_dir }}"
+        env_files:
+          - "{{ env_file }}"
+        services: "{{ restored_services }}"
         state: started
 
-    - name: Recover Qdrant collections from snapshot files
-      ansible.builtin.command:
-        cmd: musubi-cli qdrant recover-from-snapshot --name {{ restore_timestamp }}
-      changed_when: true
-
-    - name: Rebuild curated Qdrant index from vault
-      ansible.builtin.command:
-        cmd: musubi-cli index rebuild --collection musubi_curated --source /var/lib/musubi/vault
-      changed_when: true
-
-    - name: Count curated Qdrant records after rebuild
-      ansible.builtin.command:
-        cmd: musubi-cli index count --collection musubi_curated
-      changed_when: false
-      register: curated_qdrant_count
-
-    - name: Rechunk artifact blobs after restore
-      ansible.builtin.command:
-        cmd: musubi-cli artifacts rechunk --all
-      changed_when: true
-
-    - name: Count artifact chunks in Qdrant
-      ansible.builtin.command:
-        cmd: musubi-cli artifacts chunk-count --source qdrant
-      changed_when: false
-      register: qdrant_chunk_count
-
-    - name: Count artifact chunks from filesystem source
-      ansible.builtin.command:
-        cmd: musubi-cli artifacts chunk-count --source filesystem
-      changed_when: false
-      register: filesystem_chunk_count
-
-    - name: Assert restored artifact chunks match source count
-      ansible.builtin.assert:
-        that:
-          - qdrant_chunk_count.stdout == filesystem_chunk_count.stdout
+    - name: Wait for core /v1/ops/health to return 200
+      ansible.builtin.uri:
+        url: "http://{{ ansible_host }}:8100/v1/ops/health"
+        status_code: 200
+      register: health
+      retries: 30
+      delay: 5
+      until: health.status == 200

--- a/deploy/backup/restore.yml
+++ b/deploy/backup/restore.yml
@@ -16,7 +16,7 @@
 #      writes to the volumes while we swap them.
 #   2. Copy Qdrant snapshot files into the per-collection directory
 #      Qdrant watches (/var/lib/musubi/qdrant-snapshots/<coll>/), then
-#      POST each one to /collections/<coll>/snapshots/recover via the
+#      PUT each one to /collections/<coll>/snapshots/recover via the
 #      Qdrant HTTP API. We shell the HTTP call through the
 #      lifecycle-worker container (same pattern the backup script uses)
 #      so we don't need curl on the host and stay inside the compose
@@ -118,8 +118,23 @@
 
     - name: Fail loudly if no snapshots found
       ansible.builtin.fail:
-        msg: "no *.snapshot files under {{ backup_dir }}/qdrant — cowardly refusing to restore"
+        msg: >-
+          No *.snapshot files found under {{ backup_dir }}/qdrant;
+          refusing to restore without Qdrant snapshots. Verify
+          backup_timestamp={{ backup_timestamp }} points at a directory
+          produced by musubi-backup.sh and check the timer status.
       when: snapshot_files.files | length == 0
+
+    - name: Ensure per-collection Qdrant snapshot directories exist
+      ansible.builtin.file:
+        path: "/var/lib/musubi/qdrant-snapshots/{{ item.path | basename | regex_replace('\\.snapshot$', '') }}"
+        state: directory
+        owner: musubi
+        group: musubi
+        mode: "0750"
+      loop: "{{ snapshot_files.files }}"
+      loop_control:
+        label: "{{ item.path | basename }}"
 
     - name: Stage each snapshot into Qdrant's per-collection snapshots dir
       ansible.builtin.copy:
@@ -190,7 +205,7 @@
 
     - name: Wait for core /v1/ops/health to return 200
       ansible.builtin.uri:
-        url: "http://{{ ansible_host }}:8100/v1/ops/health"
+        url: "{{ musubi_health_urls.core }}"
         status_code: 200
       register: health
       retries: 30

--- a/tests/ops/test_backup.py
+++ b/tests/ops/test_backup.py
@@ -73,27 +73,10 @@ def test_sqlite_backup_completes_under_5s_at_v1_scale(tmp_path: Path) -> None:
         assert conn.execute("select count(*) from lifecycle_events").fetchone() == (1,)
 
 
-def test_drill_playbook_restores_to_working_musubi() -> None:
-    drill_text = DRILL_PLAYBOOK.read_text()
-
-    assert "bootstrap.yml" in drill_text
-    assert "restore.yml" in drill_text
-    assert "musubi-cli index rebuild --collection musubi_curated --source" in drill_text
-    assert "musubi-cli artifacts rechunk --all" in drill_text
-
-
-def test_restore_drill_smoke_suite_passes_within_5min() -> None:
-    drill = _load_yaml(DRILL_PLAYBOOK)
-    smoke_tasks = [
-        task
-        for play in drill
-        for task in play.get("tasks", [])
-        if task.get("name") == "Run restore smoke suite"
-    ]
-
-    assert smoke_tasks
-    assert smoke_tasks[0]["async"] == 300
-    assert "musubi-contract-smoke" in smoke_tasks[0]["ansible.builtin.command"]
+# Drill-playbook structural assertions and restore.yml CLI/path
+# assertions moved to tests/ops/test_restore_playbook.py as part of
+# #190 — the old `musubi-cli` commands and `musubi-contract-smoke`
+# binary don't exist, so the assertions were locking in broken behaviour.
 
 
 def test_corruption_check_fails_on_tampered_snapshot(tmp_path: Path) -> None:
@@ -139,17 +122,7 @@ def test_restore_drills_run_quarterly() -> None:
     assert module.RESTORE_DRILL_CADENCE_DAYS <= 92
 
 
-def test_curated_rebuild_from_vault_produces_matching_qdrant_count() -> None:
-    restore_text = RESTORE_PLAYBOOK.read_text()
-
-    assert "musubi-cli index rebuild --collection musubi_curated --source" in restore_text
-    assert "musubi-cli index count --collection musubi_curated" in restore_text
-    assert "changed_when: false" in restore_text
-
-
-def test_artifact_rechunk_produces_same_chunk_count_as_snapshot() -> None:
-    restore_text = RESTORE_PLAYBOOK.read_text()
-
-    assert "musubi-cli artifacts rechunk --all" in restore_text
-    assert "musubi-cli artifacts chunk-count --source qdrant" in restore_text
-    assert "musubi-cli artifacts chunk-count --source filesystem" in restore_text
+# Curated rebuild / artifact rechunk assertions removed in #190 — those
+# paths called a non-existent `musubi-cli` binary. Qdrant snapshot
+# recovery restores the indexes directly, so no rebuild step is needed.
+# See tests/ops/test_restore_playbook.py for the new structural checks.

--- a/tests/ops/test_restore_playbook.py
+++ b/tests/ops/test_restore_playbook.py
@@ -1,0 +1,170 @@
+"""Structural tests for deploy/backup/restore.yml and drill.yml.
+
+Closes #190. The playbook rotted when the backup script switched to
+``/var/lib/musubi/backups/<TIMESTAMP>/`` and when systemd-native
+Musubi was replaced by docker-compose; restore.yml was still targeting
+``/mnt/snapshots/``, calling a non-existent ``musubi-cli``, and
+restarting a systemd unit that no longer exists.
+
+These tests lock in the acceptance criteria from the issue:
+
+- restore.yml sources from ``/var/lib/musubi/backups/``, never from
+  the old ``/mnt/snapshots/`` path.
+- restore.yml uses the Qdrant HTTP API to recover snapshots, not a
+  phantom CLI.
+- restore.yml uses ``community.docker.docker_compose_v2`` to restart
+  services, not ``ansible.builtin.systemd_service``.
+- drill.yml's bootstrap step is guarded by ``drill_fresh_host`` so
+  the default invocation is safe against an already-bootstrapped
+  host (e.g. the live musubi.mey.house box).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+RESTORE_YML = ROOT / "deploy" / "backup" / "restore.yml"
+DRILL_YML = ROOT / "deploy" / "backup" / "drill.yml"
+
+
+def _load_multi(path: Path) -> list[Any]:
+    """Ansible playbooks are lists of plays at top level; some (like
+    drill.yml) also use ``import_playbook`` which yaml parses as a
+    dict-in-list. safe_load returns whatever it finds — we only need
+    the raw text for assertions below, but this gives a shape check."""
+    return list(yaml.safe_load_all(path.read_text()))
+
+
+# ---------------------------------------------------------------------------
+# Parse coverage
+# ---------------------------------------------------------------------------
+
+
+def test_restore_yml_parses_as_yaml() -> None:
+    """Broken YAML = broken runtime, catch it at test-time."""
+    docs = _load_multi(RESTORE_YML)
+    assert docs, "restore.yml is empty"
+    plays = docs[0]
+    assert isinstance(plays, list) and plays, "restore.yml must be a list of plays"
+
+
+def test_drill_yml_parses_as_yaml() -> None:
+    docs = _load_multi(DRILL_YML)
+    assert docs, "drill.yml is empty"
+
+
+# ---------------------------------------------------------------------------
+# Path hygiene — sources must be /var/lib/musubi/backups, never /mnt/snapshots
+# ---------------------------------------------------------------------------
+
+
+def test_restore_yml_sources_from_var_lib_musubi_backups() -> None:
+    """The canonical backup layout (per `musubi-backup.sh`) writes
+    under ``/var/lib/musubi/backups/<TIMESTAMP>/``. restore.yml must
+    read from the same root, not the legacy ``/mnt/snapshots``."""
+    text = RESTORE_YML.read_text()
+    assert "/var/lib/musubi/backups" in text
+    assert "/mnt/snapshots" not in text, (
+        "restore.yml still references the legacy /mnt/snapshots path — "
+        "the live backup script writes under /var/lib/musubi/backups/"
+    )
+
+
+def test_restore_yml_does_not_rsync_cursor_subdir() -> None:
+    """The backup script does NOT create a ``cursors/`` subdirectory,
+    so restore.yml mustn't try to rsync one back. Either add it to
+    the backup script (separate design call) or leave it out."""
+    text = RESTORE_YML.read_text()
+    assert "/cursors/" not in text
+    assert "cursors/" not in text.replace("/mnt/snapshots/cursors/", "")
+
+
+# ---------------------------------------------------------------------------
+# No phantom CLIs
+# ---------------------------------------------------------------------------
+
+
+def test_restore_yml_does_not_invoke_musubi_cli() -> None:
+    """The core image is uvicorn-only — there is no ``musubi-cli``
+    binary. The old playbook invoked it for snapshot recovery, index
+    rebuild, and artifact rechunk. All of those paths are replaced
+    by direct Qdrant API calls / pipeline runs.
+
+    We only flag non-comment occurrences so the explanatory docstring
+    in the file is allowed to reference the historical shape."""
+    lines = [
+        line for line in RESTORE_YML.read_text().splitlines() if not line.lstrip().startswith("#")
+    ]
+    executable = "\n".join(lines)
+    assert "musubi-cli" not in executable, (
+        "restore.yml still shells out to `musubi-cli`, but no such "
+        "binary exists in the core image. Use Qdrant's HTTP API instead."
+    )
+
+
+def test_restore_yml_uses_qdrant_http_api_for_snapshot_recover() -> None:
+    """Qdrant's supported snapshot-restore path is
+    ``POST /collections/<name>/snapshots/upload`` or the companion
+    ``PUT /collections/<name>/snapshots/recover``. One of those must
+    appear in the playbook."""
+    text = RESTORE_YML.read_text()
+    assert "/snapshots/recover" in text or "/snapshots/upload" in text, (
+        "restore.yml must use Qdrant's snapshot-recover/upload HTTP API"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Service restart — docker-compose, not systemd
+# ---------------------------------------------------------------------------
+
+
+def test_restore_yml_restarts_via_docker_compose_not_systemd() -> None:
+    """Deployment is compose-based (services live as containers
+    under a compose project at ``/etc/musubi``). A ``systemd_service:
+    name=musubi`` call would fail with "unit not found" on the live
+    host."""
+    text = RESTORE_YML.read_text()
+    assert "community.docker.docker_compose_v2" in text
+    assert "systemd_service" not in text, (
+        "restore.yml still uses systemd_service to stop/start Musubi — "
+        "the stack runs under docker-compose, not a systemd unit."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Drill safety — bootstrap must be opt-in
+# ---------------------------------------------------------------------------
+
+
+def test_drill_yml_bootstrap_is_guarded_by_drill_fresh_host() -> None:
+    """bootstrap.yml reinstalls packages and creates users — running
+    it against an already-bootstrapped host is destructive. The
+    default drill invocation must skip bootstrap; fresh-host drills
+    must pass ``-e drill_fresh_host=true`` to opt in."""
+    text = DRILL_YML.read_text()
+    assert "drill_fresh_host" in text, (
+        "drill.yml must gate the bootstrap step behind a "
+        "`drill_fresh_host` flag (default false) so the default "
+        "invocation doesn't rebuild the host."
+    )
+    assert "import_playbook: ../ansible/bootstrap.yml" in text
+    # Whatever the task shape looks like, the bootstrap step must sit
+    # behind a conditional that references the flag.
+    bootstrap_idx = text.index("import_playbook: ../ansible/bootstrap.yml")
+    nearby = text[max(0, bootstrap_idx - 200) : bootstrap_idx + 300]
+    assert "drill_fresh_host" in nearby, (
+        "drill.yml imports bootstrap.yml without a visible drill_fresh_host "
+        "guard — the conditional must be on the same task / play as the import."
+    )
+
+
+def test_drill_yml_validates_after_restore() -> None:
+    """A drill without a post-restore health check doesn't actually
+    exercise anything — it just copies files around. The playbook
+    should hit /v1/ops/health after the restore completes."""
+    text = DRILL_YML.read_text()
+    assert "/v1/ops/health" in text

--- a/tests/ops/test_restore_playbook.py
+++ b/tests/ops/test_restore_playbook.py
@@ -165,6 +165,9 @@ def test_drill_yml_bootstrap_is_guarded_by_drill_fresh_host() -> None:
 def test_drill_yml_validates_after_restore() -> None:
     """A drill without a post-restore health check doesn't actually
     exercise anything — it just copies files around. The playbook
-    should hit /v1/ops/health after the restore completes."""
+    should hit core health after the restore completes. We accept
+    either the literal ``/v1/ops/health`` path or the centralised
+    ``musubi_health_urls.core`` variable the rest of the ops
+    playbooks use."""
     text = DRILL_YML.read_text()
-    assert "/v1/ops/health" in text
+    assert "/v1/ops/health" in text or "musubi_health_urls.core" in text


### PR DESCRIPTION
Closes #190.

## Summary

Backup side works; restore side had rotted. Five concrete failures in \`deploy/backup/restore.yml\` + \`drill.yml\`, all fixed here.

| # | Gap | Fix |
|---|---|---|
| 1 | Read from \`/mnt/snapshots/\` — live backup writes to \`/var/lib/musubi/backups/<TIMESTAMP>/\` | Source paths match the driver's layout; new \`backup_timestamp\` var (default \`latest\`) picks the dir at run time. |
| 2 | Rsynced a \`cursors/\` subdir the backup script doesn't produce | Dropped entirely. |
| 3 | Called a \`musubi-cli\` binary that doesn't exist in the core image (uvicorn-only) | Replaced with Qdrant's \`PUT /collections/<coll>/snapshots/recover\` over HTTP, tunnelled through \`lifecycle-worker\` exactly like the backup script does. Index rebuild / artifact rechunk steps drop — snapshots contain the indexes and the artifact blob store is content-addressed. |
| 4 | \`systemd_service: name=musubi\` — deployment is compose, not a systemd unit | Swapped for \`community.docker.docker_compose_v2\` targeting just \`core\` + \`lifecycle-worker\`. Qdrant keeps running through the restore (its live-snapshot-recover path is the supported one). |
| 5 | drill.yml imported bootstrap.yml unconditionally → running drill against the live host rebuilt it | Bootstrap is gated behind \`drill_fresh_host\` (default false). Safe-mode drill runs restore + health probe only. Fresh-VM drill opts in via \`-e drill_fresh_host=true\`. |

## New post-restore behaviour

1. Resolve \`backup_timestamp\` (latest or pinned).
2. Stop \`core\` + \`lifecycle-worker\` via docker-compose.
3. Stage snapshot files into \`/var/lib/musubi/qdrant-snapshots/<coll>/\`.
4. \`PUT /collections/<coll>/snapshots/recover\` per collection (Qdrant's supported live-restore path).
5. Copy \`sqlite/work.sqlite\` back, rsync artifact-blobs.
6. Start core + lifecycle-worker.
7. Poll \`GET /v1/ops/health\` until 200.

## Tests

- **New**: \`tests/ops/test_restore_playbook.py\` — 9 structural tests matching the issue's acceptance checklist (paths, no phantom CLI, Qdrant HTTP API present, docker-compose not systemd, drill bootstrap guard, post-restore health probe).
- **Removed**: 4 assertions in \`tests/ops/test_backup.py\` that locked in the old broken behaviour (the \`musubi-cli\` commands and \`musubi-contract-smoke\` task). Replaced with pointer comments.

## Test plan

- [x] \`make check\` — 1175 passed, 231 skipped
- [x] \`ansible-playbook --syntax-check\` on both playbooks — clean
- [ ] Live restore drill against a non-production snapshot before the next prod backup

🤖 Generated with [Claude Code](https://claude.com/claude-code)