### PR TITLE
feat(api,sdk): operator-gated created_at override on capture (closes #140)

### DIFF
--- a/src/musubi/api/routers/writes_episodic.py
+++ b/src/musubi/api/routers/writes_episodic.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 
 from fastapi import APIRouter, Body, Depends, Query, Request, Response
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from qdrant_client import QdrantClient, models
 
 from musubi.api.auth import require_auth
@@ -40,10 +40,12 @@ def _require_operator_for_created_at(request: Request) -> None:
     it lets the migration path preserve source-truth timestamps when
     ingesting historical data, but it must not be available to
     regular consumers because it would let a token rewrite when an
-    event "happened". The bearer's ``AuthContext`` is already
-    attached by the ``require_auth`` dependency on the route; if the
-    scope list doesn't include ``operator`` we 403 before touching
-    the plane."""
+    event "happened". The bearer's ``AuthContext`` is attached to
+    ``request.state.auth`` by ``_check_body_scope`` (which calls
+    ``authenticate_request``) — the capture handlers don't use the
+    ``require_auth`` dependency because scope is body-derived, not
+    static. If the scope list doesn't include ``operator`` we 403
+    before touching the plane."""
     ctx = getattr(request.state, "auth", None)
     if ctx is None or "operator" not in (ctx.scopes or ()):
         raise APIError(
@@ -59,6 +61,19 @@ def _require_operator_for_created_at(request: Request) -> None:
 router = APIRouter(prefix="/v1/memories", tags=["episodic-writes"])
 
 
+def _require_tz_aware(value: datetime | None) -> datetime | None:
+    """Reject naive datetimes at the request-model layer.
+
+    ``EpisodicMemory`` forbids ``tzinfo=None`` (``ensure_utc`` in
+    types.episodic) — without this validator a naive ISO-8601 string
+    would parse into the request model and then blow up at plane
+    construction as a pydantic ``ValidationError``. Catching it here
+    produces a clean 422 with a targeted message instead."""
+    if value is not None and value.tzinfo is None:
+        raise ValueError("created_at must be timezone-aware (ISO-8601 with offset or 'Z')")
+    return value
+
+
 class CaptureRequest(BaseModel):
     namespace: str
     content: str = Field(min_length=1)
@@ -70,6 +85,11 @@ class CaptureRequest(BaseModel):
     # and Musubi stamps created_at at ingest time via EpisodicMemory's
     # default factory.
     created_at: datetime | None = None
+
+    @field_validator("created_at")
+    @classmethod
+    def _tz_aware_created_at(cls, v: datetime | None) -> datetime | None:
+        return _require_tz_aware(v)
 
 
 class CaptureResponse(BaseModel):
@@ -88,6 +108,11 @@ class CaptureItem(BaseModel):
     # Per-item created_at override — operator scope required (checked
     # once on the outer batch before iterating).
     created_at: datetime | None = None
+
+    @field_validator("created_at")
+    @classmethod
+    def _tz_aware_created_at(cls, v: datetime | None) -> datetime | None:
+        return _require_tz_aware(v)
 
 
 class BatchCaptureRequest(BaseModel):

--- a/src/musubi/api/routers/writes_episodic.py
+++ b/src/musubi/api/routers/writes_episodic.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from fastapi import APIRouter, Body, Depends, Query, Request, Response
 from pydantic import BaseModel, ConfigDict, Field
 from qdrant_client import QdrantClient, models
@@ -31,6 +33,29 @@ def _check_body_scope(request: Request, namespace: str, settings: Settings) -> N
         raise APIError(status_code=err.status_code, code=code, detail=err.detail)
 
 
+def _require_operator_for_created_at(request: Request) -> None:
+    """Guard the ``created_at`` override on capture endpoints.
+
+    Overriding the created_at timestamp is an operator-only privilege:
+    it lets the migration path preserve source-truth timestamps when
+    ingesting historical data, but it must not be available to
+    regular consumers because it would let a token rewrite when an
+    event "happened". The bearer's ``AuthContext`` is already
+    attached by the ``require_auth`` dependency on the route; if the
+    scope list doesn't include ``operator`` we 403 before touching
+    the plane."""
+    ctx = getattr(request.state, "auth", None)
+    if ctx is None or "operator" not in (ctx.scopes or ()):
+        raise APIError(
+            status_code=403,
+            code="FORBIDDEN",
+            detail=(
+                "created_at override requires operator scope; pass an "
+                "operator token or omit the field"
+            ),
+        )
+
+
 router = APIRouter(prefix="/v1/memories", tags=["episodic-writes"])
 
 
@@ -40,6 +65,11 @@ class CaptureRequest(BaseModel):
     summary: str | None = None
     tags: list[str] = Field(default_factory=list)
     importance: int = Field(default=5, ge=1, le=10)
+    # Optional migration / replay override — operator scope required (see
+    # _require_operator_for_created_at below). Normal consumers omit this
+    # and Musubi stamps created_at at ingest time via EpisodicMemory's
+    # default factory.
+    created_at: datetime | None = None
 
 
 class CaptureResponse(BaseModel):
@@ -55,6 +85,9 @@ class CaptureItem(BaseModel):
     summary: str | None = None
     tags: list[str] = Field(default_factory=list)
     importance: int = Field(default=5, ge=1, le=10)
+    # Per-item created_at override — operator scope required (checked
+    # once on the outer batch before iterating).
+    created_at: datetime | None = None
 
 
 class BatchCaptureRequest(BaseModel):
@@ -96,14 +129,21 @@ async def capture(
     settings: Settings = Depends(get_settings_dep),
 ) -> CaptureResponse:
     _check_body_scope(request, body.namespace, settings)
+    memory_kwargs: dict[str, object] = {
+        "namespace": body.namespace,
+        "content": body.content,
+        "summary": body.summary,
+        "tags": body.tags,
+        "importance": body.importance,
+    }
+    preserve_created_at = False
+    if body.created_at is not None:
+        _require_operator_for_created_at(request)
+        memory_kwargs["created_at"] = body.created_at
+        preserve_created_at = True
     saved = await plane.create(
-        EpisodicMemory(
-            namespace=body.namespace,
-            content=body.content,
-            summary=body.summary,
-            tags=body.tags,
-            importance=body.importance,
-        )
+        EpisodicMemory(**memory_kwargs),  # type: ignore[arg-type]
+        preserve_created_at=preserve_created_at,
     )
     response = CaptureResponse(object_id=saved.object_id, state=saved.state)
     request.state.idempotency_response = response.model_dump()
@@ -123,16 +163,29 @@ async def batch_capture(
     settings: Settings = Depends(get_settings_dep),
 ) -> BatchCaptureResponse:
     _check_body_scope(request, body.namespace, settings)
+    # Check operator scope once up front if ANY item overrides
+    # created_at. A batch with mixed override / no-override is fine
+    # under operator scope; a batch with any override under a
+    # non-operator token is a 403 for the whole batch (simpler to
+    # reason about than per-item partial failures).
+    if any(item.created_at is not None for item in body.items):
+        _require_operator_for_created_at(request)
     out: list[str] = []
     for item in body.items:
+        memory_kwargs: dict[str, object] = {
+            "namespace": body.namespace,
+            "content": item.content,
+            "summary": item.summary,
+            "tags": item.tags,
+            "importance": item.importance,
+        }
+        preserve = False
+        if item.created_at is not None:
+            memory_kwargs["created_at"] = item.created_at
+            preserve = True
         saved = await plane.create(
-            EpisodicMemory(
-                namespace=body.namespace,
-                content=item.content,
-                summary=item.summary,
-                tags=item.tags,
-                importance=item.importance,
-            )
+            EpisodicMemory(**memory_kwargs),  # type: ignore[arg-type]
+            preserve_created_at=preserve,
         )
         out.append(saved.object_id)
     return BatchCaptureResponse(object_ids=out)

--- a/src/musubi/api/routers/writes_episodic.py
+++ b/src/musubi/api/routers/writes_episodic.py
@@ -15,7 +15,7 @@ from musubi.auth import AuthRequirement, authenticate_request
 from musubi.lifecycle.transitions import transition
 from musubi.planes.episodic import EpisodicPlane
 from musubi.settings import Settings
-from musubi.types.common import Err, Ok
+from musubi.types.common import Err, Ok, utc_now
 from musubi.types.episodic import EpisodicMemory
 
 
@@ -92,6 +92,23 @@ def _require_tz_aware(value: datetime | None) -> datetime | None:
     if value is not None and value.tzinfo is None:
         raise ValueError("created_at must be timezone-aware (ISO-8601 with offset or 'Z')")
     return value
+
+
+def _reject_future_created_at(value: datetime | None) -> None:
+    """Reject a ``created_at`` that sits in the future at request time.
+
+    The plane also guards this (``plane.create`` raises ``ValueError``
+    on the preserve path), but catching it at the API layer means the
+    client gets a clean 422 instead of relying on a generic 5xx
+    catchall. Both guards exist on purpose — belt-and-braces against
+    somebody calling the plane directly."""
+    if value is not None and value > utc_now():
+        raise APIError(
+            status_code=422,
+            code="BAD_REQUEST",
+            detail="created_at cannot be in the future",
+            hint="supply a past or present timestamp, or omit the field",
+        )
 
 
 class CaptureRequest(BaseModel):
@@ -184,6 +201,7 @@ async def capture(
     preserve_created_at = False
     if body.created_at is not None:
         _require_operator_for_created_at(request)
+        _reject_future_created_at(body.created_at)
         memory_kwargs["created_at"] = body.created_at
         preserve_created_at = True
     memory = _build_episodic(**memory_kwargs)
@@ -213,6 +231,8 @@ async def batch_capture(
     # reason about than per-item partial failures).
     if any(item.created_at is not None for item in body.items):
         _require_operator_for_created_at(request)
+        for item in body.items:
+            _reject_future_created_at(item.created_at)
     out: list[str] = []
     for item in body.items:
         memory_kwargs: dict[str, object] = {

--- a/src/musubi/planes/episodic/plane.py
+++ b/src/musubi/planes/episodic/plane.py
@@ -92,13 +92,26 @@ class EpisodicPlane:
     # Create
     # ------------------------------------------------------------------
 
-    async def create(self, memory: EpisodicMemory) -> EpisodicMemory:
+    async def create(
+        self,
+        memory: EpisodicMemory,
+        *,
+        preserve_created_at: bool = False,
+    ) -> EpisodicMemory:
         """Write ``memory`` to Qdrant, deduping against the same namespace.
 
         On a dedup hit, merges tags + bumps ``reinforcement_count`` and
         ``version`` on the existing row instead of inserting. Returns the
         final state of the row (original object id on dedup hit, new id on
         fresh insert).
+
+        ``preserve_created_at`` controls whether the incoming
+        ``memory.created_at`` is used verbatim (migration / replay path)
+        or replaced with ``utc_now()``. Default False keeps the historical
+        behaviour: every fresh insert gets a server-assigned ingest
+        timestamp. The migration path (API #140, SDK capture with
+        operator scope + explicit created_at) flips this on so source
+        timestamps round-trip through ingest.
         """
         if len(memory.content.encode("utf-8")) > 32768:
             raise ValueError("content exceeds 32KB limit, please use artifact plane instead")
@@ -110,6 +123,7 @@ class EpisodicPlane:
             raise ValueError("invalid namespace format")
 
         now = utc_now()
+        created_at = memory.created_at if preserve_created_at else now
         text = memory.summary or memory.content
         dense, sparse = await self._embed_both(text)
 
@@ -125,8 +139,8 @@ class EpisodicPlane:
             state="provisional",
             version=1,
             reinforcement_count=0,
-            created_at=now,
-            created_epoch=epoch_of(now),
+            created_at=created_at,
+            created_epoch=epoch_of(created_at),
             updated_at=now,
             updated_epoch=epoch_of(now),
         )

--- a/src/musubi/planes/episodic/plane.py
+++ b/src/musubi/planes/episodic/plane.py
@@ -123,6 +123,12 @@ class EpisodicPlane:
             raise ValueError("invalid namespace format")
 
         now = utc_now()
+        # Reject a future `created_at` on the preserve path up front. Without
+        # this, `EpisodicMemory.model_validate(...)` below would raise an opaque
+        # "updated_at precedes created_at" when `updated_at=now` lands, which
+        # surfaces as a 500. A direct guard gives the caller a clear message.
+        if preserve_created_at and memory.created_at > now:
+            raise ValueError("created_at cannot be in the future")
         created_at = memory.created_at if preserve_created_at else now
         text = memory.summary or memory.content
         dense, sparse = await self._embed_both(text)

--- a/src/musubi/sdk/async_client.py
+++ b/src/musubi/sdk/async_client.py
@@ -26,6 +26,7 @@ from musubi.sdk.client import (
     _IDEMPOTENCY_HEADER,
     _MIN_CORE_VERSION,
     _REQUEST_ID_HEADER,
+    _ensure_tz_aware_created_at,
     _is_older,
     _retry_after_from,
 )
@@ -328,7 +329,7 @@ class _AsyncMemories:
             "importance": importance,
         }
         if created_at is not None:
-            body["created_at"] = created_at.isoformat()
+            body["created_at"] = _ensure_tz_aware_created_at(created_at)
         return await self._c._json(
             "POST",
             "/memories",
@@ -381,7 +382,7 @@ class _AsyncBatchContext:
             "importance": importance,
         }
         if created_at is not None:
-            item["created_at"] = created_at.isoformat()
+            item["created_at"] = _ensure_tz_aware_created_at(created_at)
         self._items.append(item)
 
     async def __aenter__(self) -> _AsyncBatchContext:

--- a/src/musubi/sdk/async_client.py
+++ b/src/musubi/sdk/async_client.py
@@ -16,6 +16,7 @@ import json
 import logging
 import uuid
 from collections.abc import AsyncIterator
+from datetime import datetime
 from typing import Any
 
 import httpx
@@ -309,18 +310,30 @@ class _AsyncMemories:
         topics: list[str] | None = None,
         importance: int = 5,
         idempotency_key: str | None = None,
+        created_at: datetime | None = None,
     ) -> dict[str, Any]:
+        """Capture an episodic memory (async).
+
+        ``created_at`` is a migration / replay escape hatch: pass a
+        ``datetime`` to preserve a source-truth timestamp on the row.
+        The server requires the bearer token to carry ``operator``
+        scope when this field is present; a non-operator token 403s.
+        Omit for normal captures.
+        """
+        body: dict[str, Any] = {
+            "namespace": namespace,
+            "content": content,
+            "tags": tags or [],
+            "topics": topics or [],
+            "importance": importance,
+        }
+        if created_at is not None:
+            body["created_at"] = created_at.isoformat()
         return await self._c._json(
             "POST",
             "/memories",
             operation_name="memories.capture",
-            json_body={
-                "namespace": namespace,
-                "content": content,
-                "tags": tags or [],
-                "topics": topics or [],
-                "importance": importance,
-            },
+            json_body=body,
             idempotency_key=idempotency_key,
         )
 
@@ -357,8 +370,19 @@ class _AsyncBatchContext:
         content: str,
         tags: list[str] | None = None,
         importance: int = 5,
+        created_at: datetime | None = None,
     ) -> None:
-        self._items.append({"content": content, "tags": tags or [], "importance": importance})
+        """Queue one row into the async batch. ``created_at`` is the
+        migration override; the whole batch is 403'd on flush unless the
+        bearer carries ``operator`` scope when any item sets it."""
+        item: dict[str, Any] = {
+            "content": content,
+            "tags": tags or [],
+            "importance": importance,
+        }
+        if created_at is not None:
+            item["created_at"] = created_at.isoformat()
+        self._items.append(item)
 
     async def __aenter__(self) -> _AsyncBatchContext:
         return self

--- a/src/musubi/sdk/client.py
+++ b/src/musubi/sdk/client.py
@@ -24,6 +24,7 @@ import logging
 import time
 import uuid
 from collections.abc import Iterator
+from datetime import datetime
 from typing import Any
 
 import httpx
@@ -340,18 +341,30 @@ class _Memories:
         topics: list[str] | None = None,
         importance: int = 5,
         idempotency_key: str | None = None,
+        created_at: datetime | None = None,
     ) -> dict[str, Any]:
+        """Capture an episodic memory.
+
+        ``created_at`` is a migration / replay escape hatch: pass a
+        ``datetime`` to preserve a source-truth timestamp on the row.
+        The server requires the bearer token to carry ``operator`` scope
+        when this field is present; a non-operator token 403s. Omit
+        for normal captures — Musubi stamps created_at at ingest time.
+        """
+        body: dict[str, Any] = {
+            "namespace": namespace,
+            "content": content,
+            "tags": tags or [],
+            "topics": topics or [],
+            "importance": importance,
+        }
+        if created_at is not None:
+            body["created_at"] = created_at.isoformat()
         return self._c._json(
             "POST",
             "/memories",
             operation_name="memories.capture",
-            json_body={
-                "namespace": namespace,
-                "content": content,
-                "tags": tags or [],
-                "topics": topics or [],
-                "importance": importance,
-            },
+            json_body=body,
             idempotency_key=idempotency_key,
         )
 
@@ -388,8 +401,19 @@ class _BatchContext:
         content: str,
         tags: list[str] | None = None,
         importance: int = 5,
+        created_at: datetime | None = None,
     ) -> None:
-        self._items.append({"content": content, "tags": tags or [], "importance": importance})
+        """Queue one row into the batch. ``created_at`` is the migration
+        override; the whole batch is 403'd on flush unless the bearer
+        carries ``operator`` scope when any item sets it."""
+        item: dict[str, Any] = {
+            "content": content,
+            "tags": tags or [],
+            "importance": importance,
+        }
+        if created_at is not None:
+            item["created_at"] = created_at.isoformat()
+        self._items.append(item)
 
     def __enter__(self) -> _BatchContext:
         return self

--- a/src/musubi/sdk/client.py
+++ b/src/musubi/sdk/client.py
@@ -39,6 +39,23 @@ from musubi.sdk.retry import RetryPolicy
 
 log = logging.getLogger("musubi.sdk")
 
+
+def _ensure_tz_aware_created_at(value: datetime) -> str:
+    """Normalise a caller-supplied ``created_at`` for the wire.
+
+    The server rejects naive datetimes (``tzinfo is None``) because
+    the storage layer requires UTC. Failing fast in the SDK prevents
+    an avoidable round-trip and gives a clearer error than the 4xx
+    the server would return. The returned string is ISO-8601 with
+    offset, suitable for direct JSON serialisation."""
+    if value.tzinfo is None:
+        raise ValueError(
+            "created_at must be timezone-aware; pass e.g. "
+            "datetime.now(tz=timezone.utc), not datetime.utcnow()"
+        )
+    return value.isoformat()
+
+
 _MIN_CORE_VERSION = "0.1.0"
 """SDK's minimum supported Core version. Probe-time check warns or
 raises if the live Core advertises a lower version."""
@@ -359,7 +376,7 @@ class _Memories:
             "importance": importance,
         }
         if created_at is not None:
-            body["created_at"] = created_at.isoformat()
+            body["created_at"] = _ensure_tz_aware_created_at(created_at)
         return self._c._json(
             "POST",
             "/memories",
@@ -412,7 +429,7 @@ class _BatchContext:
             "importance": importance,
         }
         if created_at is not None:
-            item["created_at"] = created_at.isoformat()
+            item["created_at"] = _ensure_tz_aware_created_at(created_at)
         self._items.append(item)
 
     def __enter__(self) -> _BatchContext:

--- a/tests/api/test_api_v0_write.py
+++ b/tests/api/test_api_v0_write.py
@@ -127,6 +127,164 @@ def test_batch_capture_writes_each_row(client: TestClient, valid_token: str) -> 
 
 
 # ---------------------------------------------------------------------------
+# created_at override — operator-gated migration / replay path (#140)
+# ---------------------------------------------------------------------------
+
+
+def test_capture_created_at_override_requires_operator(
+    client: TestClient,
+    valid_token: str,
+) -> None:
+    """Non-operator token cannot override created_at — regression guard
+    that the gate is actually in place. Without this, a random consumer
+    could rewrite when an event "happened", which breaks event_at /
+    created_at audit semantics."""
+    r = client.post(
+        "/v1/memories",
+        headers={"Authorization": f"Bearer {valid_token}"},
+        json={
+            "namespace": "eric/claude-code/episodic",
+            "content": "historical-row",
+            "created_at": "2024-06-01T12:00:00Z",
+        },
+    )
+    assert r.status_code == 403
+    body = r.json()
+    assert body["error"]["code"] == "FORBIDDEN"
+    assert "operator" in body["error"]["detail"].lower()
+
+
+def test_capture_created_at_override_with_operator_round_trips(
+    client: TestClient,
+    api_settings: object,
+    episodic: EpisodicPlane,
+) -> None:
+    """With operator scope, an override lands on the row and comes back
+    on the GET. This is the migration use case: preserve source-truth
+    timestamps when ingesting historical data."""
+    from tests.api.conftest import mint_token
+
+    namespace = "eric/claude-code/episodic"
+    token = mint_token(
+        api_settings,  # type: ignore[arg-type]
+        scopes=["operator", f"{namespace}:rw"],
+    )
+    headers = {"Authorization": f"Bearer {token}"}
+    override = "2024-06-01T12:00:00Z"
+    r = client.post(
+        "/v1/memories",
+        headers=headers,
+        json={
+            "namespace": namespace,
+            "content": "historical-op-row",
+            "created_at": override,
+        },
+    )
+    assert r.status_code == 202, r.text
+    oid = r.json()["object_id"]
+    got = client.get(
+        f"/v1/memories/{oid}",
+        headers=headers,
+        params={"namespace": namespace},
+    )
+    assert got.status_code == 200, got.text
+    # Timestamp lands on created_at exactly as supplied.
+    assert got.json()["created_at"].startswith("2024-06-01T12:00:00")
+
+
+def test_capture_without_created_at_is_stamped_now(
+    client: TestClient,
+    valid_token: str,
+) -> None:
+    """Omitting created_at must continue to work unchanged — the field
+    is opt-in. Musubi stamps the current time via EpisodicMemory's
+    default factory."""
+    from datetime import UTC, datetime
+
+    before = datetime.now(UTC)
+    r = client.post(
+        "/v1/memories",
+        headers={"Authorization": f"Bearer {valid_token}"},
+        json={"namespace": "eric/claude-code/episodic", "content": "no-override"},
+    )
+    assert r.status_code == 202
+    oid = r.json()["object_id"]
+    got = client.get(
+        f"/v1/memories/{oid}",
+        headers={"Authorization": f"Bearer {valid_token}"},
+        params={"namespace": "eric/claude-code/episodic"},
+    )
+    assert got.status_code == 200
+    stamp = datetime.fromisoformat(got.json()["created_at"].replace("Z", "+00:00"))
+    assert stamp >= before
+
+
+def test_batch_capture_created_at_override_requires_operator(
+    client: TestClient,
+    valid_token: str,
+) -> None:
+    """Any item in a batch carrying created_at triggers the operator
+    check for the whole batch. Keeps semantics simple: mixed batches
+    fail fast rather than partially-succeed."""
+    r = client.post(
+        "/v1/memories/batch",
+        headers={"Authorization": f"Bearer {valid_token}"},
+        json={
+            "namespace": "eric/claude-code/episodic",
+            "items": [
+                {"content": "row-a"},
+                {"content": "row-b", "created_at": "2024-06-01T12:00:00Z"},
+            ],
+        },
+    )
+    assert r.status_code == 403
+    assert r.json()["error"]["code"] == "FORBIDDEN"
+
+
+def test_batch_capture_created_at_override_with_operator_applies_per_item(
+    client: TestClient,
+    api_settings: object,
+) -> None:
+    """Under operator scope, each item's created_at lands independently
+    on its row — the migration path needs per-item control because
+    source rows don't share a single timestamp."""
+    from tests.api.conftest import mint_token
+
+    namespace = "eric/claude-code/episodic"
+    token = mint_token(
+        api_settings,  # type: ignore[arg-type]
+        scopes=["operator", f"{namespace}:rw"],
+    )
+    headers = {"Authorization": f"Bearer {token}"}
+    r = client.post(
+        "/v1/memories/batch",
+        headers=headers,
+        json={
+            "namespace": namespace,
+            "items": [
+                {"content": "batch-op-a", "created_at": "2022-01-01T00:00:00Z"},
+                {"content": "batch-op-b", "created_at": "2023-06-15T12:00:00Z"},
+            ],
+        },
+    )
+    assert r.status_code == 202, r.text
+    oids = r.json()["object_ids"]
+    assert len(oids) == 2
+    a = client.get(
+        f"/v1/memories/{oids[0]}",
+        headers=headers,
+        params={"namespace": namespace},
+    ).json()
+    b = client.get(
+        f"/v1/memories/{oids[1]}",
+        headers=headers,
+        params={"namespace": namespace},
+    ).json()
+    assert a["created_at"].startswith("2022-01-01T00:00:00")
+    assert b["created_at"].startswith("2023-06-15T12:00:00")
+
+
+# ---------------------------------------------------------------------------
 # PATCH — non-state field updates
 # ---------------------------------------------------------------------------
 

--- a/tests/ingestion/test_capture.py
+++ b/tests/ingestion/test_capture.py
@@ -423,11 +423,11 @@ def test_capture_qdrant_retry_logic_succeeds_on_transient_failure(
     failures = {"count": 0}
     real_create = plane.create
 
-    async def flaky_create(memory: Any) -> Any:
+    async def flaky_create(memory: Any, *, preserve_created_at: bool = False) -> Any:
         if failures["count"] == 0:
             failures["count"] += 1
             raise TimeoutError("transient qdrant blip")
-        return await real_create(memory)
+        return await real_create(memory, preserve_created_at=preserve_created_at)
 
     plane.create = flaky_create  # type: ignore[method-assign]
     svc = CaptureService(plane=plane, sink=sink, idempotency_cache=cache)
@@ -447,7 +447,7 @@ def test_capture_qdrant_permanent_failure_returns_503(
 
     from typing import Any
 
-    async def always_fail(memory: Any) -> Any:
+    async def always_fail(memory: Any, *, preserve_created_at: bool = False) -> Any:
         raise TimeoutError("permanent qdrant outage")
 
     plane.create = always_fail  # type: ignore[method-assign]

--- a/tests/sdk/test_sdk.py
+++ b/tests/sdk/test_sdk.py
@@ -135,6 +135,68 @@ def test_thoughts_send_returns_acknowledgement() -> None:
     assert ack["object_id"] == "t" * 27
 
 
+def test_capture_threads_created_at_override_to_body() -> None:
+    """#140 — when caller supplies created_at on capture(), the SDK
+    serialises it as ISO-8601 on the outbound body. Whether the server
+    accepts the call depends on the bearer's scope; the SDK's only job
+    is to pass the hint through faithfully."""
+    from datetime import UTC, datetime
+
+    captured: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content))
+        return httpx.Response(202, json={"object_id": "z" * 27, "state": "provisional"})
+
+    client = _client(httpx.MockTransport(handler))
+    ts = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+    client.memories.capture(
+        namespace="eric/x/episodic",
+        content="historical",
+        created_at=ts,
+    )
+    assert captured and "created_at" in captured[0]
+    assert captured[0]["created_at"].startswith("2024-06-01T12:00:00")
+
+
+def test_capture_without_created_at_omits_field_from_body() -> None:
+    """Backwards compatibility — default capture() calls must NOT carry
+    a created_at key so the server's operator-scope gate stays dormant."""
+    captured: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content))
+        return httpx.Response(202, json={"object_id": "z" * 27, "state": "provisional"})
+
+    client = _client(httpx.MockTransport(handler))
+    client.memories.capture(namespace="eric/x/episodic", content="normal")
+    assert captured and "created_at" not in captured[0]
+
+
+def test_batch_context_threads_per_item_created_at() -> None:
+    """Batch context passes each item's created_at through verbatim;
+    items without the override remain bare."""
+    from datetime import UTC, datetime
+
+    captured: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content))
+        return httpx.Response(202, json={"object_ids": ["a" * 27, "b" * 27, "c" * 27]})
+
+    client = _client(httpx.MockTransport(handler))
+    with client.memories.batch(namespace="eric/x/episodic") as batch:
+        batch.capture(content="no-override")
+        batch.capture(content="with-override", created_at=datetime(2023, 1, 1, tzinfo=UTC))
+        batch.capture(content="also-no")
+
+    items = captured[0]["items"]
+    assert len(items) == 3
+    assert "created_at" not in items[0]
+    assert items[1]["created_at"].startswith("2023-01-01T00:00:00")
+    assert "created_at" not in items[2]
+
+
 def test_batch_context_one_http_call() -> None:
     """Bullet 4 — the batch context manager flushes a SINGLE
     POST /v1/memories/batch on exit, not N posts."""

--- a/tests/sdk/test_sdk.py
+++ b/tests/sdk/test_sdk.py
@@ -843,6 +843,79 @@ def test_async_batch_context_one_call() -> None:
     assert calls[0][0] == "/v1/memories/batch"
 
 
+def test_async_capture_threads_created_at_override_to_body() -> None:
+    """#140 async-parity — when a caller supplies ``created_at`` to
+    ``AsyncMusubiClient.memories.capture``, the SDK serialises it as
+    ISO-8601 on the outbound body. Server-side scope enforcement is
+    orthogonal (verified by the API-layer tests)."""
+    from datetime import UTC, datetime
+
+    captured: list[dict[str, Any]] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content))
+        return httpx.Response(202, json={"object_id": "a" * 27, "state": "provisional"})
+
+    ts = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+    async def _run() -> None:
+        async with _async_client(handler) as c:
+            await c.memories.capture(
+                namespace="eric/x/episodic",
+                content="historical",
+                created_at=ts,
+            )
+
+    asyncio.run(_run())
+    assert captured and "created_at" in captured[0]
+    assert captured[0]["created_at"].startswith("2024-06-01T12:00:00")
+
+
+def test_async_capture_without_created_at_omits_field() -> None:
+    """Async backwards-compat — default capture() calls must NOT carry
+    a created_at key so the server's operator-scope gate stays dormant."""
+    captured: list[dict[str, Any]] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content))
+        return httpx.Response(202, json={"object_id": "b" * 27, "state": "provisional"})
+
+    async def _run() -> None:
+        async with _async_client(handler) as c:
+            await c.memories.capture(namespace="eric/x/episodic", content="normal")
+
+    asyncio.run(_run())
+    assert captured and "created_at" not in captured[0]
+
+
+def test_async_batch_context_threads_per_item_created_at() -> None:
+    """Async batch context passes each item's created_at through; items
+    without the override remain bare."""
+    from datetime import UTC, datetime
+
+    captured: list[dict[str, Any]] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content))
+        return httpx.Response(202, json={"object_ids": ["x" * 27, "y" * 27, "z" * 27]})
+
+    async def _run() -> None:
+        async with (
+            _async_client(handler) as c,
+            c.memories.batch(namespace="eric/x/episodic") as batch,
+        ):
+            batch.capture(content="no-override")
+            batch.capture(content="with-override", created_at=datetime(2023, 1, 1, tzinfo=UTC))
+            batch.capture(content="also-no")
+
+    asyncio.run(_run())
+    items = captured[0]["items"]
+    assert len(items) == 3
+    assert "created_at" not in items[0]
+    assert items[1]["created_at"].startswith("2023-01-01T00:00:00")
+    assert "created_at" not in items[2]
+
+
 def test_async_batch_context_empty_skips_call() -> None:
     calls: list[str] = []
 


### PR DESCRIPTION
Closes #140.

## Summary

Cross-slice ticket from migration work: the POC migrator needs to preserve \`created_at\` timestamps from source data into Musubi. Previously the capture path had no way to express that — any row got a fresh ingest-time stamp, which was fine for new data but wrong for historical imports.

This PR adds an optional \`created_at\` field end-to-end, gated on \`operator\` scope so random consumers can't rewrite when an event "happened".

## Changes

### API (\`src/musubi/api/routers/writes_episodic.py\`)
- \`CaptureRequest\` + \`CaptureItem\` gain \`created_at: datetime | None = None\`.
- New \`_require_operator_for_created_at\` guard — reads \`request.state.auth\` (already attached by \`_check_body_scope\`) and 403s non-operators carrying the field.
- \`capture()\` threads the value through as \`preserve_created_at=True\` on the plane call.
- \`batch_capture()\` does the operator check once up front if **any** item overrides — simpler semantics than per-item partial failures.

### Plane (\`src/musubi/planes/episodic/plane.py\`)
- \`EpisodicPlane.create(memory, *, preserve_created_at=False)\`. Default keeps the historical behaviour (server stamps ingest time). When True, the incoming \`memory.created_at\` is used verbatim. \`updated_at\` always tracks \`utc_now()\` since it reflects the ingest event, not source-truth time.

### SDK (\`src/musubi/sdk/client.py\` + \`async_client.py\`)
- Both sync + async \`_Memories.capture\` accept \`created_at: datetime | None\`. When set, serialised as ISO-8601 on the body. Omitting leaves the body shape unchanged (so the server's operator gate stays dormant for regular consumers).
- \`_BatchContext.capture\` + \`_AsyncBatchContext.capture\` get per-item support.

## Test plan

- [x] 5 new API tests: non-operator 403, operator round-trip, no-override still works, batch 403 on mixed, batch operator per-item apply
- [x] 3 new SDK tests: body serialisation contract
- [x] 2 existing \`test_capture.py\` stubs updated to accept the new \`preserve_created_at\` kwarg
- [x] \`make check\` — 1178 passed, 231 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)