### PR TITLE
feat(plane): batch_create + longer-wins merge strategy (closes #141, #142)

### DIFF
--- a/src/musubi/ingestion/capture.py
+++ b/src/musubi/ingestion/capture.py
@@ -410,19 +410,89 @@ class CaptureService:
         items: list[CaptureRequest],
         token_jti: str = "",
     ) -> list[Result[CaptureResult, CaptureError]]:
-        """Capture N rows. Today: sequential loop. The single-TEI +
-        single-Qdrant batch optimisation requires
-        ``EpisodicPlane.batch_create`` (cross-slice follow-up); see
-        ``_inbox/cross-slice/slice-ingestion-capture-slice-plane-episodic-batch-create.md``.
-        Once that lands, this method swaps the loop for one bulk call.
+        """Capture N rows via a single TEI batch + single Qdrant upsert.
+
+        Delegates to ``EpisodicPlane.batch_create`` for the per-plane
+        optimisation. Keeps the same per-row Ok/Err shape as the
+        sequential-loop predecessor so existing callers don't have to
+        change, but the happy path now does exactly ONE embed round-trip
+        and ONE upsert for the whole batch (spec § Batched capture).
+
+        Dedup-idempotency-cache-checking is still per-row because that
+        lives in :meth:`capture` (sqlite-backed, jti-scoped). Items that
+        hit the cache get their replayed result without touching the
+        plane; the remainder are bulk-embedded and bulk-upserted together.
         """
+        if not items:
+            return []
+
         # Force every item's namespace to the batch's outer namespace
         # so a malformed item doesn't slip a different scope past the
         # auth gate (which already validated the outer ``namespace``).
+        normalised = [raw.model_copy(update={"namespace": namespace}) for raw in items]
+
+        # Build a list of EpisodicMemory objects in input order. The
+        # plane's batch_create handles validation (namespace format,
+        # content size) and raises on first bad row — we let that
+        # bubble up as a hard error rather than doing partial success
+        # dance.
+        memories = [
+            EpisodicMemory(
+                namespace=req.namespace,
+                content=req.content,
+                summary=None,
+                tags=list(req.tags),
+                importance=req.importance,
+            )
+            for req in normalised
+        ]
+
+        try:
+            saved_rows = await _retry(
+                lambda: self._plane.batch_create(memories),
+                attempts=_RETRY_BUDGET,
+                backoff_s=_RETRY_BACKOFF_S,
+            )
+        except _RetryExhausted as exc:
+            log.warning(
+                "ingestion-batch-capture-qdrant-failed namespace=%s err=%r",
+                namespace,
+                exc.last_exc,
+            )
+            err = CaptureError(
+                status_code=503,
+                code="BACKEND_UNAVAILABLE",
+                detail=f"Qdrant batch write failed after retry; last error: {exc.last_exc!r}",
+            )
+            return [Err(error=err) for _ in items]
+        except (ConnectionError, OSError) as exc:
+            log.warning(
+                "ingestion-batch-capture-tei-failed namespace=%s err=%r",
+                namespace,
+                exc,
+            )
+            err = CaptureError(
+                status_code=503,
+                code="BACKEND_UNAVAILABLE",
+                detail=f"embedder unreachable: {exc!r}",
+            )
+            return [Err(error=err) for _ in items]
+
         out: list[Result[CaptureResult, CaptureError]] = []
-        for raw in items:
-            normalised = raw.model_copy(update={"namespace": namespace})
-            out.append(await self.capture(normalised, token_jti=token_jti))
+        for saved in saved_rows:
+            dedup_action: str | None = "merged" if saved.version > 1 else None
+            out.append(
+                Ok(
+                    value=CaptureResult(
+                        object_id=saved.object_id,
+                        namespace=saved.namespace,
+                        state=saved.state,
+                        version=saved.version,
+                        dedup_action=dedup_action,
+                        replayed=False,
+                    )
+                )
+            )
         return out
 
 

--- a/src/musubi/ingestion/capture.py
+++ b/src/musubi/ingestion/capture.py
@@ -418,10 +418,11 @@ class CaptureService:
         change, but the happy path now does exactly ONE embed round-trip
         and ONE upsert for the whole batch (spec § Batched capture).
 
-        Dedup-idempotency-cache-checking is still per-row because that
-        lives in :meth:`capture` (sqlite-backed, jti-scoped). Items that
-        hit the cache get their replayed result without touching the
-        plane; the remainder are bulk-embedded and bulk-upserted together.
+        ``batch_capture`` does NOT consult
+        :class:`IngestionIdempotencyCache` — the batch ``CaptureRequest``
+        shape carries no per-item idempotency key. Every item flows
+        through the plane. The single-row :meth:`capture` path is still
+        where jti-scoped, sqlite-backed idempotency replay happens.
         """
         if not items:
             return []

--- a/src/musubi/planes/episodic/plane.py
+++ b/src/musubi/planes/episodic/plane.py
@@ -140,10 +140,13 @@ class EpisodicPlane:
         if len(dense) != 1024:
             raise ValueError(f"vector dimension mismatch: got {len(dense)}, expected 1024")
 
-        existing = self._find_dedup_candidate(memory.namespace, dense)
-        if existing is not None:
+        found = self._find_dedup_candidate(memory.namespace, dense)
+        if found is not None:
+            existing, existing_dense, existing_sparse = found
             return self._reinforce(
                 existing=existing,
+                existing_dense=existing_dense,
+                existing_sparse=existing_sparse,
                 new=memory,
                 dense=dense,
                 sparse=sparse,
@@ -226,15 +229,28 @@ class EpisodicPlane:
         points: list[models.PointStruct] = []
         finalised: list[EpisodicMemory] = []
         for memory, dense, sparse in zip(memories, dense_batch, sparse_batch, strict=True):
-            existing = self._find_dedup_candidate(memory.namespace, dense)
-            if existing is not None:
-                updated = self._reinforce_without_upsert(
+            found = self._find_dedup_candidate(memory.namespace, dense)
+            if found is not None:
+                existing, existing_dense, existing_sparse = found
+                updated, existing_content_won = self._merge_row(
                     existing=existing,
                     new=memory,
                     merge_strategy=merge_strategy,
                     now=now,
                 )
-                points.append(self._make_point(updated, dense=dense, sparse=sparse))
+                # Preserve existing vectors when existing content won
+                # (otherwise we'd overwrite them with the new text's
+                # embeddings — a payload/vector drift bug).
+                if (
+                    existing_content_won
+                    and existing_dense is not None
+                    and existing_sparse is not None
+                ):
+                    points.append(
+                        self._make_point(updated, dense=existing_dense, sparse=existing_sparse)
+                    )
+                else:
+                    points.append(self._make_point(updated, dense=dense, sparse=sparse))
                 finalised.append(updated)
             else:
                 data = memory.model_dump()
@@ -255,21 +271,31 @@ class EpisodicPlane:
         self._client.upsert(collection_name=self._collection, points=points)
         return finalised
 
-    def _reinforce_without_upsert(
+    def _merge_row(
         self,
         *,
         existing: EpisodicMemory,
         new: EpisodicMemory,
         merge_strategy: MergeStrategy,
         now: Any,
-    ) -> EpisodicMemory:
-        """Compute the merged row without writing it — used by
-        ``batch_create`` so all rows land in one terminal upsert."""
+    ) -> tuple[EpisodicMemory, bool]:
+        """Compute the merged row without writing it.
+
+        Returns ``(updated, existing_content_won)``. The boolean tells
+        the caller which text's embeddings should accompany the upsert:
+        if ``existing_content_won`` is True we must preserve the
+        existing point's vectors, otherwise we write with the new
+        text's freshly-computed vectors. Without this bookkeeping the
+        payload and vectors drift out of sync (the bug Copilot caught
+        on the batch path)."""
         merged_tags = sorted(set(existing.tags) | set(new.tags))
+        existing_content_won = False
         if merge_strategy == "longer-wins":
-            kept_content = (
-                existing.content if len(existing.content) > len(new.content) else new.content
-            )
+            if len(existing.content) > len(new.content):
+                kept_content = existing.content
+                existing_content_won = True
+            else:
+                kept_content = new.content
         else:
             kept_content = new.content
         data = existing.model_dump()
@@ -281,7 +307,7 @@ class EpisodicPlane:
             updated_at=now,
             updated_epoch=epoch_of(now),
         )
-        return EpisodicMemory.model_validate(data)
+        return EpisodicMemory.model_validate(data), existing_content_won
 
     def _make_point(
         self,
@@ -306,6 +332,8 @@ class EpisodicPlane:
         self,
         *,
         existing: EpisodicMemory,
+        existing_dense: list[float] | None,
+        existing_sparse: dict[int, float] | None,
         new: EpisodicMemory,
         dense: list[float],
         sparse: dict[int, float],
@@ -313,29 +341,20 @@ class EpisodicPlane:
     ) -> EpisodicMemory:
         """Merge ``new`` into ``existing`` and re-upsert under the same id.
 
-        The kept ``content`` depends on ``merge_strategy``: ``longer-wins``
-        (spec default) keeps ``existing.content`` iff it's strictly longer
-        than ``new.content``; ``replace`` always takes the new text.
-        """
-        merged_tags = sorted(set(existing.tags) | set(new.tags))
-        if merge_strategy == "longer-wins":
-            kept_content = (
-                existing.content if len(existing.content) > len(new.content) else new.content
-            )
-        else:
-            kept_content = new.content
+        ``existing_dense`` / ``existing_sparse`` are the vectors Qdrant
+        already has for the matched point (fetched by the dedup probe).
+        When ``merge_strategy="longer-wins"`` keeps the existing content,
+        we rewrite the payload but retain those existing vectors so the
+        embeddings stay aligned with what the row actually says. When
+        new content wins we swap in the new vectors."""
         now = utc_now()
-        data = existing.model_dump()
-        data.update(
-            content=kept_content,
-            tags=merged_tags,
-            reinforcement_count=existing.reinforcement_count + 1,
-            version=existing.version + 1,
-            updated_at=now,
-            updated_epoch=epoch_of(now),
+        updated, existing_content_won = self._merge_row(
+            existing=existing, new=new, merge_strategy=merge_strategy, now=now
         )
-        updated = EpisodicMemory.model_validate(data)
-        self._upsert(updated, dense=dense, sparse=sparse)
+        if existing_content_won and existing_dense is not None and existing_sparse is not None:
+            self._upsert(updated, dense=existing_dense, sparse=existing_sparse)
+        else:
+            self._upsert(updated, dense=dense, sparse=sparse)
         return updated
 
     def _upsert(
@@ -359,8 +378,17 @@ class EpisodicPlane:
     # Dedup
     # ------------------------------------------------------------------
 
-    def _find_dedup_candidate(self, namespace: str, dense: list[float]) -> EpisodicMemory | None:
-        """Return the best existing point above the dedup threshold, if any."""
+    def _find_dedup_candidate(
+        self, namespace: str, dense: list[float]
+    ) -> tuple[EpisodicMemory, list[float] | None, dict[int, float] | None] | None:
+        """Return the best existing point above the dedup threshold, if any.
+
+        Returns the rehydrated :class:`EpisodicMemory` plus the point's
+        stored dense and sparse vectors. The vectors let the
+        reinforce path preserve the existing embeddings when
+        ``longer-wins`` keeps the existing content — otherwise the
+        payload and vectors would drift apart on every dedup hit where
+        new text was shorter."""
         resp = self._client.query_points(
             collection_name=self._collection,
             query=dense,
@@ -373,13 +401,26 @@ class EpisodicPlane:
             limit=1,
             score_threshold=self._dedup_threshold,
             with_payload=True,
+            with_vectors=True,
         )
         if not resp.points:
             return None
-        payload = resp.points[0].payload
+        point = resp.points[0]
+        payload = point.payload
         if not payload:
             return None
-        return _memory_from_payload(payload)
+        memory = _memory_from_payload(payload)
+        existing_dense: list[float] | None = None
+        existing_sparse: dict[int, float] | None = None
+        vectors = point.vector
+        if isinstance(vectors, dict):
+            raw_dense = vectors.get(DENSE_VECTOR_NAME)
+            if isinstance(raw_dense, list) and raw_dense and isinstance(raw_dense[0], float):
+                existing_dense = raw_dense  # type: ignore[assignment]
+            raw_sparse = vectors.get(SPARSE_VECTOR_NAME)
+            if isinstance(raw_sparse, models.SparseVector):
+                existing_sparse = dict(zip(raw_sparse.indices, raw_sparse.values, strict=True))
+        return memory, existing_dense, existing_sparse
 
     # ------------------------------------------------------------------
     # Read

--- a/src/musubi/planes/episodic/plane.py
+++ b/src/musubi/planes/episodic/plane.py
@@ -31,7 +31,7 @@ Design notes:
 from __future__ import annotations
 
 import uuid
-from typing import Any
+from typing import Any, Literal
 
 from qdrant_client import QdrantClient, models
 
@@ -49,6 +49,18 @@ _POINT_NS = uuid.UUID("6b0d5e2e-1e8e-4e0f-8e3e-000000000001")
 _DEFAULT_DEDUP_THRESHOLD = 0.92
 _VISIBLE_STATES: tuple[LifecycleState, ...] = ("matured",)
 _VISIBLE_STATES_WITH_DEMOTED: tuple[LifecycleState, ...] = ("matured", "demoted")
+
+# Content-merge strategy on dedup hit.
+#
+#   ``longer-wins`` — keep whichever of existing / new content is
+#   strictly longer. Matches the spec ([[06-ingestion/capture]]
+#   § Step 4): a short follow-up shouldn't silently overwrite a
+#   detailed earlier capture.
+#
+#   ``replace`` — always take the new content. Pre-spec behaviour;
+#   preserved for explicit callers (migration / replay paths that
+#   genuinely want the newest text).
+MergeStrategy = Literal["replace", "longer-wins"]
 
 
 def _point_id(object_id: str) -> str:
@@ -92,13 +104,25 @@ class EpisodicPlane:
     # Create
     # ------------------------------------------------------------------
 
-    async def create(self, memory: EpisodicMemory) -> EpisodicMemory:
+    async def create(
+        self,
+        memory: EpisodicMemory,
+        *,
+        merge_strategy: MergeStrategy = "longer-wins",
+    ) -> EpisodicMemory:
         """Write ``memory`` to Qdrant, deduping against the same namespace.
 
         On a dedup hit, merges tags + bumps ``reinforcement_count`` and
-        ``version`` on the existing row instead of inserting. Returns the
-        final state of the row (original object id on dedup hit, new id on
-        fresh insert).
+        ``version`` on the existing row instead of inserting. ``content``
+        is kept vs replaced based on ``merge_strategy``:
+
+        - ``longer-wins`` (default, matches spec §06-ingestion/capture):
+          keep whichever of existing / new content is strictly longer.
+        - ``replace``: always take the new content. Explicit opt-in for
+          migration / replay paths that genuinely want the newest text.
+
+        Returns the final state of the row (original object id on dedup
+        hit, new id on fresh insert).
         """
         if len(memory.content.encode("utf-8")) > 32768:
             raise ValueError("content exceeds 32KB limit, please use artifact plane instead")
@@ -118,7 +142,13 @@ class EpisodicPlane:
 
         existing = self._find_dedup_candidate(memory.namespace, dense)
         if existing is not None:
-            return self._reinforce(existing=existing, new=memory, dense=dense, sparse=sparse)
+            return self._reinforce(
+                existing=existing,
+                new=memory,
+                dense=dense,
+                sparse=sparse,
+                merge_strategy=merge_strategy,
+            )
 
         data = memory.model_dump()
         data.update(
@@ -134,6 +164,144 @@ class EpisodicPlane:
         self._upsert(fresh, dense=dense, sparse=sparse)
         return fresh
 
+    async def batch_create(
+        self,
+        memories: list[EpisodicMemory],
+        *,
+        merge_strategy: MergeStrategy = "longer-wins",
+    ) -> list[EpisodicMemory]:
+        """Write N memories in one TEI embed call + one Qdrant upsert.
+
+        The per-row ``create`` method does one TEI call + one Qdrant
+        upsert each. Spec ``[[06-ingestion/capture]] § Batched capture``
+        requires the batch path to fold those into a single TEI batch
+        and a single Qdrant upsert. That's the difference this method
+        makes: one round-trip to TEI for all N rows' dense vectors,
+        one for sparse, then one atomic Qdrant upsert at the end.
+
+        Dedup probes are per-row because Qdrant doesn't have a
+        "batch query_points" shape we can use today — but every dedup
+        hit writes via the same single terminal upsert (reinforce
+        updates + fresh inserts land in one call).
+
+        Returns the final row for each input position in input order,
+        same as ``create`` (existing row on dedup hit, fresh row
+        otherwise).
+        """
+        if not memories:
+            return []
+
+        # Per-row validation — same as create(). Fail fast on the whole
+        # batch if any row is malformed; partial success would be harder
+        # to reason about for callers.
+        import re
+
+        ns_pattern = re.compile(r"^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$")
+        for memory in memories:
+            if len(memory.content.encode("utf-8")) > 32768:
+                raise ValueError(
+                    "content exceeds 32KB limit on batch row "
+                    f"{memory.object_id}; use artifact plane instead"
+                )
+            if memory.event_at > utc_now():
+                raise ValueError(
+                    f"event_at cannot be in the future on batch row {memory.object_id}"
+                )
+            if not ns_pattern.match(memory.namespace):
+                raise ValueError(f"invalid namespace format on batch row {memory.object_id}")
+
+        # Single TEI dense + single TEI sparse over the whole batch.
+        texts = [m.summary or m.content for m in memories]
+        dense_batch = await self._embedder.embed_dense(texts)
+        sparse_batch = await self._embedder.embed_sparse(texts)
+
+        if any(len(v) != 1024 for v in dense_batch):
+            dims = [len(v) for v in dense_batch]
+            raise ValueError(f"dense vector dimension mismatch across batch: {dims}")
+
+        now = utc_now()
+
+        # Walk the batch, decide fresh-insert vs reinforce, collect all
+        # final rows + their vectors, then do a SINGLE terminal upsert.
+        points: list[models.PointStruct] = []
+        finalised: list[EpisodicMemory] = []
+        for memory, dense, sparse in zip(memories, dense_batch, sparse_batch, strict=True):
+            existing = self._find_dedup_candidate(memory.namespace, dense)
+            if existing is not None:
+                updated = self._reinforce_without_upsert(
+                    existing=existing,
+                    new=memory,
+                    merge_strategy=merge_strategy,
+                    now=now,
+                )
+                points.append(self._make_point(updated, dense=dense, sparse=sparse))
+                finalised.append(updated)
+            else:
+                data = memory.model_dump()
+                data.update(
+                    state="provisional",
+                    version=1,
+                    reinforcement_count=0,
+                    created_at=now,
+                    created_epoch=epoch_of(now),
+                    updated_at=now,
+                    updated_epoch=epoch_of(now),
+                )
+                fresh = EpisodicMemory.model_validate(data)
+                points.append(self._make_point(fresh, dense=dense, sparse=sparse))
+                finalised.append(fresh)
+
+        # Single Qdrant upsert for the whole batch.
+        self._client.upsert(collection_name=self._collection, points=points)
+        return finalised
+
+    def _reinforce_without_upsert(
+        self,
+        *,
+        existing: EpisodicMemory,
+        new: EpisodicMemory,
+        merge_strategy: MergeStrategy,
+        now: Any,
+    ) -> EpisodicMemory:
+        """Compute the merged row without writing it — used by
+        ``batch_create`` so all rows land in one terminal upsert."""
+        merged_tags = sorted(set(existing.tags) | set(new.tags))
+        if merge_strategy == "longer-wins":
+            kept_content = (
+                existing.content if len(existing.content) > len(new.content) else new.content
+            )
+        else:
+            kept_content = new.content
+        data = existing.model_dump()
+        data.update(
+            content=kept_content,
+            tags=merged_tags,
+            reinforcement_count=existing.reinforcement_count + 1,
+            version=existing.version + 1,
+            updated_at=now,
+            updated_epoch=epoch_of(now),
+        )
+        return EpisodicMemory.model_validate(data)
+
+    def _make_point(
+        self,
+        memory: EpisodicMemory,
+        *,
+        dense: list[float],
+        sparse: dict[int, float],
+    ) -> models.PointStruct:
+        """Build a Qdrant PointStruct for ``memory``. Kept out of
+        ``_upsert`` so ``batch_create`` can collect points without
+        calling upsert per row."""
+        return models.PointStruct(
+            id=_point_id(memory.object_id),
+            payload=memory.model_dump(mode="json"),
+            vector={
+                DENSE_VECTOR_NAME: dense,
+                SPARSE_VECTOR_NAME: _sparse_to_model(sparse),
+            },
+        )
+
     def _reinforce(
         self,
         *,
@@ -141,13 +309,25 @@ class EpisodicPlane:
         new: EpisodicMemory,
         dense: list[float],
         sparse: dict[int, float],
+        merge_strategy: MergeStrategy = "longer-wins",
     ) -> EpisodicMemory:
-        """Merge ``new`` into ``existing`` and re-upsert under the same id."""
+        """Merge ``new`` into ``existing`` and re-upsert under the same id.
+
+        The kept ``content`` depends on ``merge_strategy``: ``longer-wins``
+        (spec default) keeps ``existing.content`` iff it's strictly longer
+        than ``new.content``; ``replace`` always takes the new text.
+        """
         merged_tags = sorted(set(existing.tags) | set(new.tags))
+        if merge_strategy == "longer-wins":
+            kept_content = (
+                existing.content if len(existing.content) > len(new.content) else new.content
+            )
+        else:
+            kept_content = new.content
         now = utc_now()
         data = existing.model_dump()
         data.update(
-            content=new.content,
+            content=kept_content,
             tags=merged_tags,
             reinforcement_count=existing.reinforcement_count + 1,
             version=existing.version + 1,

--- a/tests/ingestion/test_capture.py
+++ b/tests/ingestion/test_capture.py
@@ -257,15 +257,23 @@ def test_dedup_keeps_longer_content(plane: EpisodicPlane, ns: str) -> None:
     async def _probe(long_first: bool) -> EpisodicMemory:
         first_text = long_content if long_first else short_content
         second_text = short_content if long_first else long_content
-        first = asyncio.run_coroutine_threadsafe.__self__ if False else None  # noqa: F841 — placate mypy
         existing = await plane.create(EpisodicMemory(namespace=ns, content=first_text))
         # Compute vectors for the second call so we can drive _reinforce
         # directly without needing the FakeEmbedder to produce a dedup
         # hit (it won't).
         dense = (await plane._embedder.embed_dense([second_text]))[0]
         sparse = (await plane._embedder.embed_sparse([second_text]))[0]
+        existing_dense = (await plane._embedder.embed_dense([first_text]))[0]
+        existing_sparse = (await plane._embedder.embed_sparse([first_text]))[0]
         new = EpisodicMemory(namespace=ns, content=second_text)
-        return plane._reinforce(existing=existing, new=new, dense=dense, sparse=sparse)
+        return plane._reinforce(
+            existing=existing,
+            existing_dense=existing_dense,
+            existing_sparse=existing_sparse,
+            new=new,
+            dense=dense,
+            sparse=sparse,
+        )
 
     merged_long_first = asyncio.run(_probe(long_first=True))
     assert merged_long_first.content == long_content, "long-first: longer existing should win"
@@ -285,9 +293,13 @@ def test_reinforce_replace_strategy_preserves_new_content(plane: EpisodicPlane, 
         existing = await plane.create(EpisodicMemory(namespace=ns, content=long_content))
         dense = (await plane._embedder.embed_dense([short_content]))[0]
         sparse = (await plane._embedder.embed_sparse([short_content]))[0]
+        existing_dense = (await plane._embedder.embed_dense([long_content]))[0]
+        existing_sparse = (await plane._embedder.embed_sparse([long_content]))[0]
         new = EpisodicMemory(namespace=ns, content=short_content)
         return plane._reinforce(
             existing=existing,
+            existing_dense=existing_dense,
+            existing_sparse=existing_sparse,
             new=new,
             dense=dense,
             sparse=sparse,

--- a/tests/ingestion/test_capture.py
+++ b/tests/ingestion/test_capture.py
@@ -48,6 +48,7 @@ from musubi.lifecycle import LifecycleEventSink
 from musubi.planes.episodic import EpisodicPlane
 from musubi.store import bootstrap
 from musubi.types.common import Err, Ok
+from musubi.types.episodic import EpisodicMemory
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -236,16 +237,65 @@ def test_dedup_merges_tag_union(service: CaptureService, plane: EpisodicPlane, n
     assert set(fetched.tags) == {"a", "b", "c"}
 
 
-@pytest.mark.skip(
-    reason="deferred to slice-plane-episodic-content-merge-strategy: spec "
-    "calls for 'new content wins iff strictly longer'; the plane's "
-    "current reinforce always replaces with new content. Cross-slice "
-    "ticket "
-    "_inbox/cross-slice/slice-ingestion-capture-slice-plane-episodic-merge-strategy.md "
-    "tracks the plane-side follow-up to add a reinforce strategy parameter."
-)
-def test_dedup_keeps_longer_content() -> None:
-    """Bullet 10 — placeholder."""
+def test_dedup_keeps_longer_content(plane: EpisodicPlane, ns: str) -> None:
+    """Bullet 10 — spec § Step 4: on a dedup hit, keep the longer of
+    existing / new content. A short follow-up must not silently
+    overwrite an earlier detailed capture.
+
+    Closed by #142 — the plane now defaults ``merge_strategy`` to
+    ``longer-wins`` on ``create``.
+
+    Tests at the plane level because FakeEmbedder is content-hash-based:
+    two different texts produce different dense vectors and never meet
+    the dedup threshold, so service-level tests can't exercise the
+    reinforce path with non-identical content. We probe the merge rule
+    directly by feeding ``_reinforce`` two rows with differing content
+    lengths."""
+    long_content = "Eric said the alpha build of the telemetry harness went live at 03:12"
+    short_content = "Eric said the alpha build went live."
+
+    async def _probe(long_first: bool) -> EpisodicMemory:
+        first_text = long_content if long_first else short_content
+        second_text = short_content if long_first else long_content
+        first = asyncio.run_coroutine_threadsafe.__self__ if False else None  # noqa: F841 — placate mypy
+        existing = await plane.create(EpisodicMemory(namespace=ns, content=first_text))
+        # Compute vectors for the second call so we can drive _reinforce
+        # directly without needing the FakeEmbedder to produce a dedup
+        # hit (it won't).
+        dense = (await plane._embedder.embed_dense([second_text]))[0]
+        sparse = (await plane._embedder.embed_sparse([second_text]))[0]
+        new = EpisodicMemory(namespace=ns, content=second_text)
+        return plane._reinforce(existing=existing, new=new, dense=dense, sparse=sparse)
+
+    merged_long_first = asyncio.run(_probe(long_first=True))
+    assert merged_long_first.content == long_content, "long-first: longer existing should win"
+
+    merged_short_first = asyncio.run(_probe(long_first=False))
+    assert merged_short_first.content == long_content, "short-first: longer new should win"
+
+
+def test_reinforce_replace_strategy_preserves_new_content(plane: EpisodicPlane, ns: str) -> None:
+    """Explicit ``merge_strategy=replace`` must keep the new text even
+    when it's shorter — preserves the pre-spec behaviour for callers
+    that genuinely want always-new-wins (migration / replay)."""
+    long_content = "Eric said the alpha build of the telemetry harness went live at 03:12"
+    short_content = "Eric said the alpha build went live."
+
+    async def _run() -> EpisodicMemory:
+        existing = await plane.create(EpisodicMemory(namespace=ns, content=long_content))
+        dense = (await plane._embedder.embed_dense([short_content]))[0]
+        sparse = (await plane._embedder.embed_sparse([short_content]))[0]
+        new = EpisodicMemory(namespace=ns, content=short_content)
+        return plane._reinforce(
+            existing=existing,
+            new=new,
+            dense=dense,
+            sparse=sparse,
+            merge_strategy="replace",
+        )
+
+    merged = asyncio.run(_run())
+    assert merged.content == short_content
 
 
 def test_dedup_disabled_on_curated() -> None:
@@ -423,11 +473,11 @@ def test_capture_qdrant_retry_logic_succeeds_on_transient_failure(
     failures = {"count": 0}
     real_create = plane.create
 
-    async def flaky_create(memory: Any) -> Any:
+    async def flaky_create(memory: Any, **kw: Any) -> Any:
         if failures["count"] == 0:
             failures["count"] += 1
             raise TimeoutError("transient qdrant blip")
-        return await real_create(memory)
+        return await real_create(memory, **kw)
 
     plane.create = flaky_create  # type: ignore[method-assign]
     svc = CaptureService(plane=plane, sink=sink, idempotency_cache=cache)
@@ -447,7 +497,7 @@ def test_capture_qdrant_permanent_failure_returns_503(
 
     from typing import Any
 
-    async def always_fail(memory: Any) -> Any:
+    async def always_fail(memory: Any, **kw: Any) -> Any:
         raise TimeoutError("permanent qdrant outage")
 
     plane.create = always_fail  # type: ignore[method-assign]
@@ -478,25 +528,61 @@ def test_batch_capture_writes_each_row(
         assert len(r.value.object_id) == 27
 
 
-@pytest.mark.skip(
-    reason="deferred to slice-plane-episodic-batch-create: requires a "
-    "new EpisodicPlane.batch_create(memories) method that does ONE TEI "
-    "embed call + ONE Qdrant upsert for the whole batch. Cross-slice "
-    "ticket "
-    "_inbox/cross-slice/slice-ingestion-capture-slice-plane-episodic-batch-create.md "
-    "tracks the plane-side follow-up; today's batch loops one-by-one."
-)
-def test_batch_capture_single_tei_embed_call() -> None:
-    """Bullet 20 — placeholder."""
+def test_batch_capture_single_tei_embed_call(
+    service: CaptureService, ns: str, embedder: FakeEmbedder
+) -> None:
+    """Bullet 20 — a 5-item batch_capture hits TEI exactly ONCE for
+    dense embeddings (and once for sparse), not 5 times. The plane's
+    ``batch_create`` folds all vectors into a single embedder call
+    per modality (#141)."""
+    dense_calls = {"count": 0}
+    sparse_calls = {"count": 0}
+    real_dense = embedder.embed_dense
+    real_sparse = embedder.embed_sparse
+
+    async def counting_dense(texts: list[str]) -> list[list[float]]:
+        dense_calls["count"] += 1
+        return await real_dense(texts)
+
+    async def counting_sparse(texts: list[str]) -> list[dict[int, float]]:
+        sparse_calls["count"] += 1
+        return await real_sparse(texts)
+
+    embedder.embed_dense = counting_dense  # type: ignore[method-assign]
+    embedder.embed_sparse = counting_sparse  # type: ignore[method-assign]
+
+    items = [_req(ns, content=f"batch-tei-{i}") for i in range(5)]
+    results = asyncio.run(service.batch_capture(namespace=ns, items=items))
+
+    assert len(results) == 5 and all(isinstance(r, Ok) for r in results)
+    # One dense call, one sparse call — regardless of N.
+    assert dense_calls["count"] == 1, f"expected 1 dense call, got {dense_calls['count']}"
+    assert sparse_calls["count"] == 1, f"expected 1 sparse call, got {sparse_calls['count']}"
 
 
-@pytest.mark.skip(
-    reason="deferred to slice-plane-episodic-batch-create: same follow-up "
-    "as bullet 20 — a single Qdrant upsert across all batch items "
-    "requires plane.batch_create."
-)
-def test_batch_capture_single_qdrant_upsert() -> None:
-    """Bullet 21 — placeholder."""
+def test_batch_capture_single_qdrant_upsert(
+    service: CaptureService, ns: str, plane: EpisodicPlane
+) -> None:
+    """Bullet 21 — a 5-item batch lands as exactly ONE Qdrant upsert,
+    not 5. ``batch_create`` walks the batch to resolve dedup per-row
+    but accumulates PointStructs and issues a single terminal upsert
+    (#141)."""
+    upsert_calls: list[int] = []
+    real_upsert = plane._client.upsert
+
+    def counting_upsert(*args: object, **kwargs: object) -> object:
+        points = kwargs.get("points", [])
+        upsert_calls.append(len(points) if isinstance(points, list) else 1)
+        return real_upsert(*args, **kwargs)  # type: ignore[arg-type]
+
+    plane._client.upsert = counting_upsert  # type: ignore[method-assign,assignment]
+
+    items = [_req(ns, content=f"batch-upsert-{i}") for i in range(5)]
+    results = asyncio.run(service.batch_capture(namespace=ns, items=items))
+
+    assert len(results) == 5 and all(isinstance(r, Ok) for r in results)
+    assert len(upsert_calls) == 1, f"expected 1 upsert call, got {len(upsert_calls)}"
+    assert upsert_calls[0] == 5, f"expected 5 points in the single upsert, got {upsert_calls[0]}"
 
 
 @pytest.mark.skip(


### PR DESCRIPTION
Closes #141, closes #142.

## Summary

Two cross-slice tickets against `EpisodicPlane`, closed together because they touch adjacent code paths.

### #142 — longer-wins merge strategy
Spec `§06-ingestion/capture § Step 4` says a dedup hit should keep the longer of existing / new content. The plane's `_reinforce` was always-new-wins — a short follow-up silently overwrote a longer earlier capture.

Fix:
- New `MergeStrategy = Literal["replace", "longer-wins"]`.
- `EpisodicPlane.create(memory, *, merge_strategy=...)` — default `"longer-wins"`.
- Merge logic refactored into a shared `_merge_row()` helper so the single-row and batch paths stay in lockstep. Returns `(updated, existing_content_won)` so the caller knows which vectors to keep.
- `"replace"` preserves pre-spec behaviour for explicit callers (migration / replay).

### #141 — `batch_create` (single TEI + single Qdrant)
Spec `§Batched capture` calls for one TEI embed + one Qdrant upsert per batch. The service was looping `create` N times → N of each.

Fix:
- New `EpisodicPlane.batch_create(memories)`: single `embed_dense`, single `embed_sparse`, single `client.upsert` with all points (dedup reinforce + fresh inserts both land in the same terminal upsert).
- `_make_point` helper factors shaping from writing so the batch path can collect PointStructs.
- `CaptureService.batch_capture` swapped from loop to `plane.batch_create`. **Batch capture does NOT consult the ingestion idempotency cache** — the batch `CaptureRequest` shape carries no per-item idempotency key. Every batch row flows straight through to the plane. Single-row `capture` still goes through the sqlite-backed idempotency replay.

### Payload/vector drift fix (Copilot review)
`_find_dedup_candidate` now requests `with_vectors=True` so the dedup probe returns the stored point's dense + sparse vectors alongside the memory. When `longer-wins` keeps existing content we preserve those vectors on the reinforce upsert; when new content wins we swap in the new vectors. Without this, a dedup hit where existing content won would silently overwrite existing vectors with new-text embeddings, drifting payload and vectors out of sync on subsequent retrievals.

## Tests

- **Unskipped** bullet 10 `test_dedup_keeps_longer_content` — probes `_reinforce` directly in both orderings. Companion `test_reinforce_replace_strategy_preserves_new_content` pins the opt-in branch.
- **Unskipped** bullets 20/21 `test_batch_capture_single_tei_embed_call` + `test_batch_capture_single_qdrant_upsert` — spy on `FakeEmbedder` + `QdrantClient.upsert`; assert a 5-item batch fires exactly one of each.
- Two existing retry stubs switched to `**kw` so they tolerate the new kwargs.

## Test plan
- [x] `make check` — 1191 passed, 228 skipped
- [x] Contract-test bullet 10 / 20 / 21 now in passing Closure state

🤖 Generated with [Claude Code](https://claude.com/claude-code)