### PR TITLE
chore(deploy): pin musubi_core_image to v0.4.0 digest

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"b50173cc-e273-4122-bdc2-0c768e454b15","pid":97997,"acquiredAt":1776887109193}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"b50173cc-e273-4122-bdc2-0c768e454b15","pid":97997,"acquiredAt":1776887109193}

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ id_ed25519
 id_ecdsa
 *.pfx
 *.p12
+.claude/scheduled_tasks.lock

--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -24,14 +24,13 @@ musubi_data_dirs:
 musubi_core_port: 8100
 # Musubi Core image. Pinned by immutable digest.
 #
-# Current pin: v0.4.0 release (#187). Rolls up #201 (ValidationError
-# → 422), #202 (backup/restore playbook repair), #203 (operator-gated
-# created_at override), and #204 (batch_create + longer-wins merge +
-# dedup-probe vector preservation). Not yet re-validated through
-# Gates 1-4 on the live box — the previous digest (post-#198,
-# sha256:4c51335e) was Gate-1/Gate-2 clean on 2026-04-23, and the
-# new code on top is behavior-preserving for the retrieve hot path.
-# Re-run Gates 1-4 after deploy before declaring pre-prod done.
+# Current pin: v0.4.0. Rolls up the ValidationError → 422 fix,
+# backup/restore playbook repair, operator-gated `created_at`
+# override, and batch_create + longer-wins merge (with dedup-probe
+# vector preservation). Gates 1 + 2 were clean on the previous
+# digest (post-#198 pooled TEI client, the retrieve hot path is
+# unchanged in v0.4.0) but the full Gate 1-4 perf sweep needs to be
+# re-run on v0.4.0 before declaring pre-prod done.
 #
 # Produced by `.github/workflows/publish-core-image.yml`; verified
 # cosign-signed + SBOM-attested + Trivy-CRITICAL-scanned. Bump this after

--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -24,10 +24,14 @@ musubi_data_dirs:
 musubi_core_port: 8100
 # Musubi Core image. Pinned by immutable digest.
 #
-# Current pin: post-#198 (TEI connection pooling fix). This is the digest
-# validated end-to-end through Gates 1-4 on 2026-04-23 against the live
-# musubi.mey.house box — baseline + load at 3 VUs + spike + 30-minute soak
-# all clean, no memory drift.
+# Current pin: v0.4.0 release (#187). Rolls up #201 (ValidationError
+# → 422), #202 (backup/restore playbook repair), #203 (operator-gated
+# created_at override), and #204 (batch_create + longer-wins merge +
+# dedup-probe vector preservation). Not yet re-validated through
+# Gates 1-4 on the live box — the previous digest (post-#198,
+# sha256:4c51335e) was Gate-1/Gate-2 clean on 2026-04-23, and the
+# new code on top is behavior-preserving for the retrieve hot path.
+# Re-run Gates 1-4 after deploy before declaring pre-prod done.
 #
 # Produced by `.github/workflows/publish-core-image.yml`; verified
 # cosign-signed + SBOM-attested + Trivy-CRITICAL-scanned. Bump this after

--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -33,7 +33,7 @@ musubi_core_port: 8100
 # cosign-signed + SBOM-attested + Trivy-CRITICAL-scanned. Bump this after
 # every release — the release note on the GitHub tag carries the new
 # digest line ready to paste.
-musubi_core_image: "ghcr.io/ericmey/musubi-core@sha256:4c51335e27e4bae2afb5645e4ac20df35708dbed5b62126818a7efa00450602f"
+musubi_core_image: "ghcr.io/ericmey/musubi-core@sha256:fcccb7f437ad6529d8db5f96369a5d996ee03da045fb60cb8a9bf1721ec09ed5"
 musubi_qdrant_image: "qdrant/qdrant:v1.17.1"
 # TEI image tag = <compute-capability>-<version>. RTX 3080 is Ampere,
 # compute 8.6 → `86-*`. Other GPUs: `turing-*` (RTX 20xx), `89-*` (RTX 40xx),


### PR DESCRIPTION
Bumps the pinned `musubi_core_image` from the post-#198 pooled-client digest to the v0.4.0 release image.

## Summary

- From: `sha256:4c51335e27e4bae2afb5645e4ac20df35708dbed5b62126818a7efa00450602f` (post #198 pooled-client)
- To: `sha256:fcccb7f437ad6529d8db5f96369a5d996ee03da045fb60cb8a9bf1721ec09ed5` (v0.4.0)

Rolls up tonight's merges — #201 (422), #202 (restore), #203 (created_at), #204 (batch_create + merge + vector-drift fix) — and the earlier #197 / #198 / #199 / #200 cycle already baked into the previous digest.

Digest sourced from `publish-core-image.yml` run 24821778485 on commit `3eb62dc` (release-please v0.4.0).

## Test plan
- [ ] Merge this PR
- [ ] Run Ansible `update.yml` against `musubi.mey.house`
- [ ] Verify `/v1/ops/status` reports version `0.1.0` (API contract version) and the new digest is in `docker inspect`
- [ ] Spot-check capture + retrieve still work

No tracking Issue: operational digest-pin after a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)