### PR TITLE
fix(rate-limit): delete dead settings-backed rate fields (closes #193)

### DIFF
--- a/docs/Musubi/13-decisions/0027-rate-limit-per-bucket.md
+++ b/docs/Musubi/13-decisions/0027-rate-limit-per-bucket.md
@@ -1,0 +1,117 @@
+---
+title: "ADR 0027: Per-bucket rate limits, not global per-second rates"
+section: 13-decisions
+type: adr
+status: accepted
+date: 2026-04-23
+deciders: [Eric]
+tags: [section/decisions, status/accepted, type/adr]
+updated: 2026-04-23
+up: "[[13-decisions/index]]"
+reviewed: false
+supersedes: ""
+superseded-by: ""
+---
+
+# ADR 0027: Per-bucket rate limits, not global per-second rates
+
+**Status:** accepted
+**Date:** 2026-04-23
+**Deciders:** Eric
+**Closes:** #193
+
+## Context
+
+Two places in the codebase looked like they controlled rate limits:
+
+1. `src/musubi/settings.py` — global per-second floats
+   (`rate_limit_capture: 10.0`, `rate_limit_retrieve: 20.0`,
+   `rate_limit_thought: 5.0`).
+2. `src/musubi/api/rate_limit.py` — a `DEFAULT_BUCKETS` dict with
+   per-bucket, per-minute capacities plus a 10× operator multiplier
+   applied at `allow()` time.
+
+The `RateLimiter.__init__` method read the settings values into
+`self._capture_rate` / `_retrieve_rate` / `_thought_rate` and then
+**never referenced them anywhere**. `allow()` exclusively consults
+`bucket.capacity_per_min`. The settings fields were dead code —
+tunable knobs that did nothing.
+
+Issue #193 surfaced this: a serial seed of 10k episodic rows started
+getting 429s around row 1,600 against an operator-scoped token.
+That's consistent with the real cap being `100/min × 10 = 1000/min`
+for the `capture` bucket — the bucket cap was working, but the
+`settings.rate_limit_capture=10.0` (= 600/min) was never in effect.
+Two knobs, one of them inert.
+
+## Decision
+
+Keep the **per-bucket, per-minute** model. Delete the global
+per-second settings fields. Document that the buckets are the only
+rate-limit surface.
+
+Why per-bucket beats per-second:
+
+- Different endpoints need different ceilings. `artifact-upload` at
+  20/min and `capture` at 100/min live together because the cost
+  profile is different (large multipart body vs. small JSON).
+- Per-minute windows tolerate short bursts naturally. A voice turn
+  that fires 4 captures in 3 seconds doesn't trip the cap; a
+  misbehaving client firing 4/sec steady-state does.
+- The bucket name is already in each route's `operation_id`, so the
+  mapping is declarative and visible at the endpoint definition.
+- A single `rate_limit_capture: 10/s` knob gives operators no way to
+  distinguish batch-write throughput from singleton capture; the
+  bucket model does.
+
+## Rate values (re-confirmed)
+
+These stand for v1; revisit if Gate-2 re-run on v0.4.0 surfaces a
+real bottleneck.
+
+| Bucket | Base | ×10 operator |
+|--------|------|--------------|
+| `capture` | 100/min | 1000/min |
+| `batch-write` | 50/min | 500/min |
+| `thought` | 100/min | 1000/min |
+| `transition` | 50/min | 500/min |
+| `artifact-upload` | 20/min | 200/min |
+| `default` | 200/min | 2000/min |
+
+Realistic per-user steady-state math (captured here so we don't
+re-derive later):
+
+- Voice turn: ~4 captures per turn (open + 2-3 tool calls)
+- Browser supplements: ~2 captures/min
+- Capture mirror: ~1/min
+- Steady: ~15 captures/min/user
+- Burst (mid-voice-turn): 4 captures in ~5s, spreads under the window
+
+At 1000/min operator cap the system comfortably supports ~60
+concurrent active users before capture becomes the bottleneck —
+well past the "small team fleet" target.
+
+**Seed / backfill is not normal traffic.** A 10k serial seed will
+trip 1000/min by design. The seed harness (`scripts/perf/seed_corpus.py`)
+honors `Retry-After` and backs off — that's the correct protocol for
+bulk loads against a production cap.
+
+## Consequences
+
+- `settings.rate_limit_capture` / `_retrieve` / `_thought` are
+  removed; nothing reads them. `RateLimiter.__init__` no longer
+  imports settings.
+- `DEFAULT_BUCKETS` is now the single source of truth for rate
+  ceilings. Changing one is a code change + commit, not an env var
+  flip — the trade-off is a bit more friction for a lot more
+  visibility.
+- When `slice-api-rate-limit-distributed` lands (moving state to
+  Redis / Kong), it inherits the per-bucket model and the 10×
+  operator multiplier unchanged.
+
+## Deferred
+
+The operator multiplier is still a single constant (`_OPERATOR_MULTIPLIER = 10`).
+If we ever want per-bucket multipliers (e.g. operator gets 20× on
+`capture` for migrations, only 5× on `artifact-upload`) the bucket
+spec grows a field — not today.

--- a/src/musubi/api/rate_limit.py
+++ b/src/musubi/api/rate_limit.py
@@ -73,18 +73,6 @@ class RateLimiter:
         self._buckets: dict[tuple[str, str], _BucketState] = {}
         self._lock = threading.Lock()
 
-        try:
-            from musubi.config import get_settings
-
-            settings = get_settings()
-            self._capture_rate = getattr(settings, "rate_limit_capture", 10.0)
-            self._retrieve_rate = getattr(settings, "rate_limit_retrieve", 20.0)
-            self._thought_rate = getattr(settings, "rate_limit_thought", 5.0)
-        except Exception:
-            self._capture_rate = 10.0
-            self._retrieve_rate = 20.0
-            self._thought_rate = 5.0
-
     @staticmethod
     def token_key(bearer: str | None) -> str:
         """Hash the bearer to a stable per-token key. Avoids storing the

--- a/src/musubi/settings.py
+++ b/src/musubi/settings.py
@@ -94,14 +94,9 @@ class Settings(BaseSettings):
     # ------------------------------------------------------------------
     musubi_grpc: bool = Field(default=False, description="Expose the gRPC API alongside REST.")
 
-    # ------------------------------------------------------------------
-    # Rate limits (tokens per second)
-    # ------------------------------------------------------------------
-    rate_limit_capture: float = Field(default=10.0, description="Tokens per second for capture.")
-    rate_limit_retrieve: float = Field(default=20.0, description="Tokens per second for retrieve.")
-    rate_limit_thought: float = Field(
-        default=5.0, description="Tokens per second for thought sending."
-    )
+    # Rate limits — per-bucket, per-minute — live in
+    # `src/musubi/api/rate_limit.py::DEFAULT_BUCKETS`. See ADR 0027 for
+    # the rationale on why they are not tunable via settings.
 
     musubi_allow_plaintext: bool = Field(
         default=False,

--- a/tests/api/test_rate_limits.py
+++ b/tests/api/test_rate_limits.py
@@ -5,15 +5,20 @@ from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
-from musubi.api.rate_limit import get_rate_limiter
+from musubi.api.rate_limit import DEFAULT_BUCKETS, get_rate_limiter
+
+# Derive the exhaust size from the bucket spec so the tests don't
+# become stale when the cap changes — see ADR 0027.
+_CAPTURE_CAP = DEFAULT_BUCKETS["capture"].capacity_per_min
+_CAPTURE_EXHAUST = _CAPTURE_CAP + 5
 
 
 def test_capture_rate_limit_returns_429_on_over_limit(client: TestClient, valid_token: str) -> None:
     limiter = get_rate_limiter()
     limiter.reset_for_test()
-    # capture bucket is 100/min (see DEFAULT_BUCKETS + ADR 0027).
-    # 105 requests from a non-operator token must trip the cap.
-    for _ in range(105):
+    # Exhaust the capture bucket. Size derived from DEFAULT_BUCKETS
+    # so changing the cap doesn't require updating N test literals.
+    for _ in range(_CAPTURE_EXHAUST):
         resp = client.post(
             "/v1/memories",
             json={"namespace": "eric/claude-code/episodic", "content": "hit"},
@@ -33,7 +38,7 @@ def test_capture_rate_limit_returns_429_on_over_limit(client: TestClient, valid_
 def test_capture_rate_limit_resets_after_window(client: TestClient, valid_token: str) -> None:
     limiter = get_rate_limiter()
     limiter.reset_for_test()
-    for _ in range(105):
+    for _ in range(_CAPTURE_EXHAUST):
         client.post(
             "/v1/memories",
             json={"namespace": "eric/claude-code/episodic", "content": "hit"},
@@ -60,7 +65,7 @@ def test_retrieve_rate_limit_separate_bucket_from_capture(
 ) -> None:
     limiter = get_rate_limiter()
     limiter.reset_for_test()
-    for _ in range(105):
+    for _ in range(_CAPTURE_EXHAUST):
         client.post(
             "/v1/memories",
             json={"namespace": "eric/claude-code/episodic", "content": "hit"},
@@ -78,7 +83,7 @@ def test_retrieve_rate_limit_separate_bucket_from_capture(
 def test_retry_after_header_present_on_429(client: TestClient, valid_token: str) -> None:
     limiter = get_rate_limiter()
     limiter.reset_for_test()
-    for _ in range(105):
+    for _ in range(_CAPTURE_EXHAUST):
         client.post(
             "/v1/memories",
             json={"namespace": "eric/claude-code/episodic", "content": "hit"},

--- a/tests/api/test_rate_limits.py
+++ b/tests/api/test_rate_limits.py
@@ -3,27 +3,16 @@ from __future__ import annotations
 import time
 from unittest.mock import patch
 
-import pytest
 from fastapi.testclient import TestClient
 
 from musubi.api.rate_limit import get_rate_limiter
 
 
-@pytest.fixture(autouse=True)
-def mock_settings(monkeypatch: pytest.MonkeyPatch) -> None:
-
-    class MockSettings:
-        rate_limit_capture = 10.0
-        rate_limit_retrieve = 20.0
-        rate_limit_thought = 5.0
-
-    monkeypatch.setattr("musubi.config.get_settings", lambda: MockSettings())
-
-
 def test_capture_rate_limit_returns_429_on_over_limit(client: TestClient, valid_token: str) -> None:
     limiter = get_rate_limiter()
     limiter.reset_for_test()
-    # capture limit is 10/s => 600/min? Wait, what is the default in the current codebase? 100.
+    # capture bucket is 100/min (see DEFAULT_BUCKETS + ADR 0027).
+    # 105 requests from a non-operator token must trip the cap.
     for _ in range(105):
         resp = client.post(
             "/v1/memories",

--- a/uv.lock
+++ b/uv.lock
@@ -732,7 +732,7 @@ wheels = [
 
 [[package]]
 name = "musubi"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Closes #193.

## Summary

\`RateLimiter.__init__\` read \`settings.rate_limit_capture\`, \`rate_limit_retrieve\`, and \`rate_limit_thought\` into ivars and then **never referenced them anywhere**. \`allow()\` exclusively consults \`bucket.capacity_per_min\` from \`DEFAULT_BUCKETS\`. The settings fields were tunable knobs that did nothing; the test suite had a \`mock_settings\` fixture patching an import path that no production code read.

This is the bug #193 suspected — "not being applied where we think." The 429s Eric saw around row 1,600 of a serial 10k seed were from the real \`capture\` bucket cap (\`100/min × 10 operator = 1000/min\`), which was working correctly. The \`settings.rate_limit_capture=10.0\` (= 600/min) was just inert.

### Cleanup
- Remove \`rate_limit_capture\` / \`_retrieve\` / \`_thought\` from \`Settings\`.
- Remove the settings read from \`RateLimiter.__init__\`.
- Drop the \`mock_settings\` fixture from \`test_rate_limits.py\`.
- Pick up \`uv.lock\` bump to v0.4.0 (release-please missed it).

### ADR 0027
Captures the decision — per-bucket, per-minute ceilings with a single 10× operator multiplier beats a global per-second knob for this workload. Includes realistic peak math (voice turn ≈ 4 captures, ~15/min/user steady) showing 1000/min operator-scoped capture comfortably supports ~60 concurrent active users.

## Test plan

- [x] \`make check\` — 1191 passed
- [x] Existing rate-limit tests still pass without the mock fixture (confirms they weren't relying on it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)