### PR TITLE
fix(ci): release-please tag push must use a PAT, not GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,6 +33,19 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Surface the fallback loudly. Without RELEASE_PLEASE_PAT, the job
+      # still runs — release PRs open and merge — but tag pushes
+      # authored by GITHUB_TOKEN don't trigger `publish-core-image.yml`,
+      # so no `:vX.Y.Z` image tag lands on GHCR. That's the exact silent
+      # failure this workflow is meant to prevent; if we're about to
+      # silently re-introduce it, say so in the Actions UI.
+      - name: Warn if RELEASE_PLEASE_PAT is unset
+        env:
+          RELEASE_PLEASE_PAT: ${{ secrets.RELEASE_PLEASE_PAT }}
+        if: ${{ env.RELEASE_PLEASE_PAT == '' }}
+        run: |
+          echo "::warning::RELEASE_PLEASE_PAT is unset — falling back to GITHUB_TOKEN. Release PRs will open / merge, but any vX.Y.Z tag this run creates will NOT trigger publish-core-image.yml (anti-recursion guard). No :vX.Y.Z image tag will be published to GHCR. Set the secret to restore version-tagged publishes."
+
       - uses: googleapis/release-please-action@v4
         with:
           # A single-package repo — release-please's `manifest` mode
@@ -45,17 +58,24 @@ jobs:
           # `GITHUB_TOKEN` — including the `vX.Y.Z` tag push that
           # release-please creates when its PR merges. With GITHUB_TOKEN,
           # `publish-core-image.yml` never fires on tag-push, so no
-          # `:vX.Y.Z` image tag is ever published (we observed this
-          # silently for v0.4.0, v0.5.0, and v0.5.1 — deploy digest pins
-          # still worked because digests are immutable, but there were
-          # no version-named image tags on GHCR).
+          # `:vX.Y.Z` image tag is ever published (observed silently for
+          # v0.4.0, v0.5.0, v0.5.1 — deploy digest pins still worked
+          # because digests are immutable, but there were no
+          # version-named image tags on GHCR).
           #
-          # The PAT needs `repo` + `workflow` scopes. Stored as
-          # `secrets.RELEASE_PLEASE_PAT`. Rotation: bump the secret and
-          # confirm the next release-please run tags the image as
-          # `:vX.Y.Z`. If the secret is missing, the workflow falls back
-          # to `GITHUB_TOKEN` so release PRs still open / merge — but
-          # tag-push-triggered builds will silently skip (the known bug
-          # this config guards against). See the stamping rationale in
-          # https://github.com/googleapis/release-please-action#github-actions
+          # Required scope: `repo` only. Classic PATs also offer
+          # `workflow`, but that scope permits modifying workflow files
+          # and is NOT needed here — release-please only touches
+          # `pyproject.toml`, `CHANGELOG.md`, and the manifest. Prefer,
+          # in order:
+          #   1. A GitHub App token (cleanest rotation, org-level policy).
+          #   2. A fine-grained PAT scoped to this repo with
+          #      "Contents: read & write" + "Pull requests: read & write".
+          #   3. A classic PAT with just `repo` scope.
+          #
+          # Stored as `secrets.RELEASE_PLEASE_PAT`. If the secret is
+          # missing, the workflow falls back to `GITHUB_TOKEN` so
+          # release PRs still open / merge — but the step above
+          # emits an `::warning::` so the regression doesn't slip
+          # by silently.
           token: ${{ secrets.RELEASE_PLEASE_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,10 +39,23 @@ jobs:
           # still applies because our config lives in a manifest file.
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
-          # `GITHUB_TOKEN` with the scopes above suffices. Use a PAT
-          # only if we ever need releases to trigger OTHER workflows
-          # (GHA refuses to fire workflows on actions taken by the
-          # default GITHUB_TOKEN — but `publish-core-image.yml` is
-          # triggered by tag-push, which WORKS with GITHUB_TOKEN for
-          # tag creation, confirmed).
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Must be a PAT (or GitHub App token), NOT the default
+          # `GITHUB_TOKEN`. GitHub's anti-recursion guard silently
+          # suppresses workflow runs for events authored by
+          # `GITHUB_TOKEN` — including the `vX.Y.Z` tag push that
+          # release-please creates when its PR merges. With GITHUB_TOKEN,
+          # `publish-core-image.yml` never fires on tag-push, so no
+          # `:vX.Y.Z` image tag is ever published (we observed this
+          # silently for v0.4.0, v0.5.0, and v0.5.1 — deploy digest pins
+          # still worked because digests are immutable, but there were
+          # no version-named image tags on GHCR).
+          #
+          # The PAT needs `repo` + `workflow` scopes. Stored as
+          # `secrets.RELEASE_PLEASE_PAT`. Rotation: bump the secret and
+          # confirm the next release-please run tags the image as
+          # `:vX.Y.Z`. If the secret is missing, the workflow falls back
+          # to `GITHUB_TOKEN` so release PRs still open / merge — but
+          # tag-push-triggered builds will silently skip (the known bug
+          # this config guards against). See the stamping rationale in
+          # https://github.com/googleapis/release-please-action#github-actions
+          token: ${{ secrets.RELEASE_PLEASE_PAT || secrets.GITHUB_TOKEN }}

--- a/deploy/runbooks/upgrade-image.md
+++ b/deploy/runbooks/upgrade-image.md
@@ -5,9 +5,10 @@ Use this when you need to move `musubi.example.local` to a newer
 `ghcr.io/ericmey/musubi-core` digest. For a first-deploy-from-scratch,
 see [`first-deploy.md`](first-deploy.md) instead.
 
-Cadence: on demand. Every merge to `v2` publishes a fresh floating
-`:v2` tag + a digest. Every `v*` tag push publishes a versioned tag
-+ digest. The deploy itself is a separate, human-reviewed PR.
+Cadence: on demand. Every merge to `main` publishes a fresh floating
+`:main` tag + a digest. Every `v*` tag push publishes `:vX.Y.Z` +
+digest (requires `RELEASE_PLEASE_PAT` — see ADR 0026 addendum dated
+2026-04-23). The deploy itself is a separate, human-reviewed PR.
 
 ---
 

--- a/deploy/runbooks/upgrade-image.md
+++ b/deploy/runbooks/upgrade-image.md
@@ -7,8 +7,13 @@ see [`first-deploy.md`](first-deploy.md) instead.
 
 Cadence: on demand. Every merge to `main` publishes a fresh floating
 `:main` tag + a digest. Every `v*` tag push publishes `:vX.Y.Z` +
-digest (requires `RELEASE_PLEASE_PAT` — see ADR 0026 addendum dated
-2026-04-23). The deploy itself is a separate, human-reviewed PR.
+digest — *any* `v*` tag push does this, including a manual `git
+push origin v1.2.3` from an operator. The caveat is release-please's
+automated tag push: with the default `GITHUB_TOKEN` it gets silenced
+by GitHub's anti-recursion guard, so release-please's workflow must
+authenticate with `RELEASE_PLEASE_PAT` for its tag pushes to fire
+this build. See the ADR 0026 addendum dated 2026-04-23 for the full
+story. The deploy itself is a separate, human-reviewed PR.
 
 ---
 

--- a/docs/Musubi/13-decisions/0026-release-please-for-versioning.md
+++ b/docs/Musubi/13-decisions/0026-release-please-for-versioning.md
@@ -6,7 +6,7 @@ status: accepted
 date: 2026-04-21
 deciders: [Eric]
 tags: [section/decisions, status/accepted, type/adr]
-updated: 2026-04-21
+updated: 2026-04-23
 up: "[[13-decisions/index]]"
 reviewed: false
 supersedes: ""
@@ -56,6 +56,9 @@ Adopt `googleapis/release-please-action@v4` to manage versioning:
   Release.
 - The tag push triggers `publish-core-image.yml`, which
   builds + scans (Trivy) + signs (cosign) + publishes to GHCR.
+  **Requires release-please to authenticate with a PAT (or GitHub
+  App token), not the default `GITHUB_TOKEN`** — see [Addendum
+  2026-04-23](#addendum-2026-04-23-tag-push-requires-a-pat).
 
 End-to-end: **operator merges feature PRs into v2 → approves the
 release PR when the batch is ready → signed versioned image appears
@@ -141,3 +144,40 @@ line.
 - [[_slices/slice-ops-core-image-publish]] (the publish workflow)
 - `.github/workflows/release-please.yml`
 - `.release-please-config.json` + `.release-please-manifest.json`
+
+## Addendum 2026-04-23 — tag push requires a PAT
+
+The original "tag push triggers `publish-core-image.yml`" step
+assumed `GITHUB_TOKEN` would suffice. **It does not.** GitHub's
+anti-recursion guard silently suppresses workflow runs for events
+authored by the default `GITHUB_TOKEN` (see
+[GitHub Actions: triggering a workflow from a workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)).
+That includes the `vX.Y.Z` tag push release-please creates on merge.
+
+We didn't notice immediately because:
+
+- `publish-core-image.yml` also fires on `push: branches: [main]`,
+  so the release-please merge commit still produces a built +
+  signed image — just tagged `:main` instead of `:vX.Y.Z`.
+- Digest pins don't care about version tags (digests are
+  immutable content addresses), so the ansible deploy continued
+  to work by pasting the digest from the `:main` build.
+
+Observed impact: v0.4.0, v0.5.0, v0.5.1 were all published to GHCR
+without a `:vX.Y.Z` image tag. Only `:main`, `:latest`, and
+`:v0.3.0` (manual tag, pre-release-please) exist on the registry.
+
+**Fix.** Authenticate release-please with a PAT (or GitHub App
+token) that has `repo` + `workflow` scopes, stored as
+`secrets.RELEASE_PLEASE_PAT`. Tag pushes authored by a PAT *do*
+fire downstream workflows. Rotation: bump the secret, confirm the
+next release-please run publishes `:vX.Y.Z`. The workflow falls
+back to `GITHUB_TOKEN` if the secret is missing so release PRs
+continue to open (just without tagged images).
+
+**Why the addendum, not a revision of the Decision section.**
+The original decision ("release-please drives versioning") is
+still right. Only the *mechanism* for cross-workflow triggering
+was incorrectly described. Keeping the original text + an
+addendum preserves the history of why v0.4.0/v0.5.0/v0.5.1 shipped
+without `:vX.Y.Z` tags.


### PR DESCRIPTION
No tracking Issue: infra fix — was going to file one then decided to ship it straight.

## Summary
- Every release-please release since v0.3.0 has silently skipped the tag-triggered image publish. GHCR has `:main`, `:latest`, `:v0.3.0`, plus orphan `:v2` — but **no `:v0.4.0` / `:v0.5.0` / `:v0.5.1`**. Only digest pins have saved our deploys.
- Root cause: GitHub's anti-recursion guard suppresses workflow runs for tag pushes authored by `GITHUB_TOKEN`. release-please was using `GITHUB_TOKEN` to create the release tag, so `publish-core-image.yml`'s `push: tags: v*` trigger never fired. The comment in `release-please.yml` claiming otherwise is wrong — confirmed by `gh api /repos/.../actions/runs` showing zero `head_branch=v*` runs.
- Fix: authenticate release-please with a PAT (`secrets.RELEASE_PLEASE_PAT`), with a `|| secrets.GITHUB_TOKEN` fallback so release PRs still open if the secret is missing.

## Why this matters for v1.0
- Operators will want to grep for `:v1.0` on GHCR. Today they'd only find `:main`. Future "what's on this host?" / "what did we ship last Tuesday?" forensics is much cleaner with version-tagged images.
- Aligns the `gh release view vX.Y.Z` page with the actually-published artefact — the release body auto-appended by `publish-core-image.yml` will finally appear for each release, not just for `:main` pushes.

## Setup required (one-time, by operator)
1. Create a classic PAT at https://github.com/settings/tokens with scopes: `repo`, `workflow`.
2. Store it as `RELEASE_PLEASE_PAT` in repo secrets (Settings → Secrets and variables → Actions → New repository secret).
3. Next release-please merge should emit a tag-push workflow run and publish `:vX.Y.(Z+1)` on GHCR. Confirm via `gh run list --event push --branch v<next>` and the GHCR tag list.

## Files changed
- `.github/workflows/release-please.yml` — token swap + correct the stale comment.
- `docs/Musubi/13-decisions/0026-release-please-for-versioning.md` — addendum recording the gotcha + evidence + fix. Original decision text intact.
- `deploy/runbooks/upgrade-image.md` — fix "floating `:v2` tag" → "floating `:main` tag" and note that `:vX.Y.Z` requires the PAT.

## Test plan
- [x] Repo-local: `make agent-check` clean (warnings only, pre-existing).
- [ ] Post-merge + secret-set: next release-please cut produces a `:vX.Y.Z` image tag visible at `https://github.com/ericmey/musubi/pkgs/container/musubi-core`.
- [ ] Post-merge + secret-set: `gh run list --event push` shows a run with `head_branch=v<next>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)