### PR TITLE
chore(vault): repair asymmetric depends-on / blocks edges

### DIFF
--- a/docs/Musubi/_slices/slice-adapter-livekit.md
+++ b/docs/Musubi/_slices/slice-adapter-livekit.md
@@ -10,7 +10,7 @@ tags: [section/slices, status/done, type/slice]
 updated: 2026-04-19
 reviewed: true
 depends-on: ["[[_slices/slice-sdk-py]]", "[[_slices/slice-retrieval-fast]]", "[[_slices/slice-retrieval-deep]]"]
-blocks: []
+blocks: ["[[_slices/slice-adapter-livekit-e2e]]"]
 ---
 
 # Slice: LiveKit adapter

--- a/docs/Musubi/_slices/slice-adapter-livekit.md
+++ b/docs/Musubi/_slices/slice-adapter-livekit.md
@@ -7,7 +7,7 @@ status: done
 owner: vscode-cc-sonnet47
 phase: "6 Lifecycle"
 tags: [section/slices, status/done, type/slice]
-updated: 2026-04-19
+updated: 2026-04-23
 reviewed: true
 depends-on: ["[[_slices/slice-sdk-py]]", "[[_slices/slice-retrieval-fast]]", "[[_slices/slice-retrieval-deep]]"]
 blocks: ["[[_slices/slice-adapter-livekit-e2e]]"]

--- a/docs/Musubi/_slices/slice-lifecycle-promotion.md
+++ b/docs/Musubi/_slices/slice-lifecycle-promotion.md
@@ -7,7 +7,7 @@ status: done
 owner: gemini-3-1-pro-nyla
 phase: "6 Lifecycle"
 tags: [section/slices, status/done, type/slice]
-updated: 2026-04-19
+updated: 2026-04-23
 reviewed: true
 depends-on: ["[[_slices/slice-lifecycle-synthesis]]", "[[_slices/slice-plane-curated]]", "[[_slices/slice-vault-sync]]"]
 blocks: ["[[_slices/slice-lifecycle-promotion-builder]]", "[[_slices/slice-lifecycle-demotion-builder]]"]

--- a/docs/Musubi/_slices/slice-lifecycle-promotion.md
+++ b/docs/Musubi/_slices/slice-lifecycle-promotion.md
@@ -10,7 +10,7 @@ tags: [section/slices, status/done, type/slice]
 updated: 2026-04-19
 reviewed: true
 depends-on: ["[[_slices/slice-lifecycle-synthesis]]", "[[_slices/slice-plane-curated]]", "[[_slices/slice-vault-sync]]"]
-blocks: []
+blocks: ["[[_slices/slice-lifecycle-promotion-builder]]", "[[_slices/slice-lifecycle-demotion-builder]]"]
 ---
 
 # Slice: Promotion / demotion

--- a/docs/Musubi/_slices/slice-lifecycle-reflection.md
+++ b/docs/Musubi/_slices/slice-lifecycle-reflection.md
@@ -7,7 +7,7 @@ status: done
 owner: vscode-cc-sonnet47
 phase: "6 Lifecycle"
 tags: [section/slices, status/done, type/slice]
-updated: 2026-04-19
+updated: 2026-04-23
 reviewed: true
 depends-on: ["[[_slices/slice-lifecycle-engine]]", "[[_slices/slice-plane-curated]]"]
 blocks: ["[[_slices/slice-lifecycle-reflection-builder]]"]

--- a/docs/Musubi/_slices/slice-lifecycle-reflection.md
+++ b/docs/Musubi/_slices/slice-lifecycle-reflection.md
@@ -10,7 +10,7 @@ tags: [section/slices, status/done, type/slice]
 updated: 2026-04-19
 reviewed: true
 depends-on: ["[[_slices/slice-lifecycle-engine]]", "[[_slices/slice-plane-curated]]"]
-blocks: []
+blocks: ["[[_slices/slice-lifecycle-reflection-builder]]"]
 ---
 
 # Slice: Reflection job

--- a/docs/Musubi/_slices/slice-lifecycle-synthesis.md
+++ b/docs/Musubi/_slices/slice-lifecycle-synthesis.md
@@ -7,7 +7,7 @@ status: done
 owner: gemini-2-0-flash
 phase: "6 Lifecycle"
 tags: [section/slices, status/done, type/slice]
-updated: 2026-04-19
+updated: 2026-04-23
 reviewed: true
 depends-on: ["[[_slices/slice-lifecycle-engine]]", "[[_slices/slice-lifecycle-maturation]]", "[[_slices/slice-plane-concept]]"]
 blocks: ["[[_slices/slice-lifecycle-promotion]]", "[[_slices/slice-lifecycle-synthesis-builder]]"]

--- a/docs/Musubi/_slices/slice-lifecycle-synthesis.md
+++ b/docs/Musubi/_slices/slice-lifecycle-synthesis.md
@@ -10,7 +10,7 @@ tags: [section/slices, status/done, type/slice]
 updated: 2026-04-19
 reviewed: true
 depends-on: ["[[_slices/slice-lifecycle-engine]]", "[[_slices/slice-lifecycle-maturation]]", "[[_slices/slice-plane-concept]]"]
-blocks: ["[[_slices/slice-lifecycle-promotion]]"]
+blocks: ["[[_slices/slice-lifecycle-promotion]]", "[[_slices/slice-lifecycle-synthesis-builder]]"]
 ---
 
 # Slice: Concept synthesis job

--- a/docs/Musubi/_slices/slice-ops-integration-harness.md
+++ b/docs/Musubi/_slices/slice-ops-integration-harness.md
@@ -10,7 +10,7 @@ tags: [section/slices, status/done, type/slice, integration, testing, phase-2]
 updated: 2026-04-20
 reviewed: true
 depends-on: ["[[_slices/slice-ops-compose]]"]
-blocks: ["[[_slices/slice-ops-hardening-suite]]"]
+blocks: ["[[_slices/slice-ops-hardening-suite]]", "[[_slices/slice-adapter-livekit-e2e]]"]
 ---
 
 # Slice: Integration test harness

--- a/docs/Musubi/_slices/slice-ops-integration-harness.md
+++ b/docs/Musubi/_slices/slice-ops-integration-harness.md
@@ -7,7 +7,7 @@ status: done
 owner: vscode-cc-sonnet47
 phase: "8 Ops"
 tags: [section/slices, status/done, type/slice, integration, testing, phase-2]
-updated: 2026-04-20
+updated: 2026-04-23
 reviewed: true
 depends-on: ["[[_slices/slice-ops-compose]]"]
 blocks: ["[[_slices/slice-ops-hardening-suite]]", "[[_slices/slice-adapter-livekit-e2e]]"]

--- a/docs/Musubi/_slices/slice-vault-sync.md
+++ b/docs/Musubi/_slices/slice-vault-sync.md
@@ -7,7 +7,7 @@ status: done
 owner: gemini-3-1-pro-nyla
 phase: "5 Vault"
 tags: [section/slices, status/done, type/slice]
-updated: 2026-04-19
+updated: 2026-04-23
 reviewed: true
 depends-on: ["[[_slices/slice-plane-curated]]", "[[_slices/slice-types]]"]
 blocks: ["[[_slices/slice-lifecycle-promotion]]", "[[_slices/slice-lifecycle-reflection]]", "[[_slices/slice-lifecycle-promotion-builder]]", "[[_slices/slice-lifecycle-reflection-builder]]"]

--- a/docs/Musubi/_slices/slice-vault-sync.md
+++ b/docs/Musubi/_slices/slice-vault-sync.md
@@ -10,7 +10,7 @@ tags: [section/slices, status/done, type/slice]
 updated: 2026-04-19
 reviewed: true
 depends-on: ["[[_slices/slice-plane-curated]]", "[[_slices/slice-types]]"]
-blocks: ["[[_slices/slice-lifecycle-promotion]]", "[[_slices/slice-lifecycle-reflection]]"]
+blocks: ["[[_slices/slice-lifecycle-promotion]]", "[[_slices/slice-lifecycle-reflection]]", "[[_slices/slice-lifecycle-promotion-builder]]", "[[_slices/slice-lifecycle-reflection-builder]]"]
 ---
 
 # Slice: Obsidian vault watcher + reconciler


### PR DESCRIPTION
No tracking Issue: vault hygiene cleanup in the same spirit as the tagging fix — starting v1.0 from a clean baseline.

## Summary
- `make agent-check` was emitting 8 persistent warnings about asymmetric graph edges (slice A declares `depends-on: B` but B's `blocks:` list doesn't include A).
- Every slice involved is `status: done`, so no active agent is being misled today — but the warnings trained us to tune out the vault-check output, and future builder/extension slices would walk an incomplete graph.
- This PR adds the missing `blocks:` entries across 6 files. `make agent-check` now exits clean — zero warnings.

## Edges repaired
| Upstream slice | `blocks:` gained |
|---|---|
| `slice-adapter-livekit` | `slice-adapter-livekit-e2e` |
| `slice-ops-integration-harness` | `slice-adapter-livekit-e2e` |
| `slice-lifecycle-promotion` | `slice-lifecycle-promotion-builder`, `slice-lifecycle-demotion-builder` |
| `slice-vault-sync` | `slice-lifecycle-promotion-builder`, `slice-lifecycle-reflection-builder` |
| `slice-lifecycle-reflection` | `slice-lifecycle-reflection-builder` |
| `slice-lifecycle-synthesis` | `slice-lifecycle-synthesis-builder` |

## Test plan
- [x] `make agent-check` — `OK`, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)