### PR TITLE
fix(lifecycle): wire promotion_attempts gate + last_reinforced_at reinforce clock

### DIFF
--- a/src/musubi/lifecycle/demotion.py
+++ b/src/musubi/lifecycle/demotion.py
@@ -109,20 +109,32 @@ async def demotion_episodic(deps: DemotionDeps, batch_size: int = 100) -> int:
 
 
 async def demotion_concept(deps: DemotionDeps, batch_size: int = 100) -> int:
-    """Demote mature concepts that haven't been reinforced recently."""
-    # Spec intent: demote when `last_reinforced_at < now - 30 days`. The
-    # field exists on SynthesizedConcept — current behavior proxies via
-    # `updated_epoch` (which ticks on *any* write), so the sweep is
-    # too lenient on concepts touched for reasons other than
-    # reinforcement (contradictions, importance re-scores). Fix is
-    # tracked in issue #218.
+    """Demote mature concepts that haven't been reinforced recently.
 
+    Selects on `last_reinforced_epoch < cutoff` when present, else
+    falls back to `created_epoch < cutoff` for concepts that have
+    never been reinforced. The fallback is qdrant-side via a `should`
+    clause (Qdrant OR); per-point re-verification in Python keeps the
+    logic honest against payload-schema drift.
+    """
     now = utc_now()
     cutoff_epoch = epoch_of(now) - (DEMOTION_CONCEPT_NO_REINFORCE_DAYS * 24 * 3600)
 
+    # Qdrant filter semantics: `must` is AND across its entries, `should`
+    # is OR. Combining must + should requires both to match — so
+    # `state == matured` must hold AND one of the two epoch branches
+    # must match.
     must_conditions: list[Any] = [
         models.FieldCondition(key="state", match=models.MatchValue(value="matured")),
-        models.FieldCondition(key="updated_epoch", range=models.Range(lt=cutoff_epoch)),
+    ]
+    should_conditions: list[Any] = [
+        models.FieldCondition(key="last_reinforced_epoch", range=models.Range(lt=cutoff_epoch)),
+        models.Filter(
+            must=[
+                models.IsNullCondition(is_null=models.PayloadField(key="last_reinforced_epoch")),
+                models.FieldCondition(key="created_epoch", range=models.Range(lt=cutoff_epoch)),
+            ]
+        ),
     ]
 
     offset = None
@@ -134,7 +146,7 @@ async def demotion_concept(deps: DemotionDeps, batch_size: int = 100) -> int:
     while True:
         resp = deps.qdrant.scroll(
             collection_name=coll_name,
-            scroll_filter=models.Filter(must=must_conditions),
+            scroll_filter=models.Filter(must=must_conditions, should=should_conditions),
             limit=batch_size,
             offset=offset,
             with_payload=True,
@@ -144,6 +156,19 @@ async def demotion_concept(deps: DemotionDeps, batch_size: int = 100) -> int:
 
         for point in points:
             if not point.payload:
+                continue
+
+            # Re-verify in Python: the qdrant `should` clause gates which
+            # payloads we see, but a concept with null last_reinforced
+            # and fresh created_at would slip through if the fallback
+            # clause were mis-wired. Belt-and-braces.
+            last_reinforced_epoch = point.payload.get("last_reinforced_epoch")
+            reference_epoch = (
+                last_reinforced_epoch
+                if last_reinforced_epoch is not None
+                else point.payload.get("created_epoch")
+            )
+            if reference_epoch is None or reference_epoch >= cutoff_epoch:
                 continue
 
             try:
@@ -211,6 +236,25 @@ async def reinstate(deps: DemotionDeps, namespace: str, object_id: str, reason: 
                 to_state="matured",
                 actor=_LIFECYCLE_ACTOR,
                 reason=f"reinstatement: {reason}",
+            )
+            # Reset the reinforcement clock — otherwise the concept's
+            # old `last_reinforced_epoch` (which triggered demotion in
+            # the first place) still sits below the cutoff and the
+            # next sweep re-demotes it immediately. Reinstatement is
+            # an explicit operator call to give the concept a fresh
+            # chance, so set the clock to now.
+            now = utc_now()
+            now_epoch = epoch_of(now)
+            from musubi.planes.concept.plane import _point_id
+            from musubi.store.names import collection_for_plane
+
+            deps.qdrant.set_payload(
+                collection_name=collection_for_plane("concept"),
+                payload={
+                    "last_reinforced_at": now.isoformat(),
+                    "last_reinforced_epoch": now_epoch,
+                },
+                points=[_point_id(object_id)],
             )
             return
     except LookupError:

--- a/src/musubi/lifecycle/promotion.py
+++ b/src/musubi/lifecycle/promotion.py
@@ -174,7 +174,14 @@ def compute_path(concept: SynthesizedConcept) -> str:
     # neither file under `_misc` — deliberately not auto-synthesized
     # because that'd hide a real synthesis gap.
     topics = concept.topics or concept.linked_to_topics
-    primary_topic = topics[0] if topics else "_misc"
+    # Slugify topic-derived segments — topics can carry anything an LLM
+    # hallucinates (path separators, `..`, spaces). `slugify` reduces
+    # to `[a-z0-9-]`, making path traversal impossible at this layer.
+    # `VaultWriter.write_curated` also rejects paths that escape
+    # vault_root as defense-in-depth. When no topic is available, fall
+    # back to the `_misc` sentinel literal — preserves the leading
+    # underscore so synthesis gaps are visible on disk.
+    primary_topic = (slugify(topics[0]) or "_misc") if topics else "_misc"
     slug = slugify(concept.title)
     return f"curated/{namespace_to_dir(concept.namespace)}/{primary_topic}/{slug}.md"
 
@@ -270,9 +277,15 @@ async def run_promotion_sweep(
 
 async def _promote_concept(deps: PromotionDeps, concept: SynthesizedConcept) -> bool:
     """Attempt to promote one concept. Returns True iff it actually shipped
-    a curated row + vault file. The rejection path (LLM render failed)
-    bumps `promotion_attempts` via `record_promotion_rejection` and
-    returns False — the sweep counts only true promotions."""
+    a curated row + vault file.
+
+    Any failure — render, vault write, curated-plane create, concept
+    transition, thought emit — records a rejection via
+    :meth:`ConceptPlane.record_promotion_rejection`, which bumps
+    `promotion_attempts`. The three-strikes gate then locks the concept
+    out after three consecutive failures. Transient infra issues (e.g.
+    Qdrant briefly down) do burn an attempt — accepted cost for making
+    a genuinely broken concept stop poisoning every sweep."""
     now = utc_now()
 
     # Render markdown via LLM
@@ -285,110 +298,138 @@ async def _promote_concept(deps: PromotionDeps, concept: SynthesizedConcept) -> 
         )
     except Exception as e:
         log.warning("Rendering failed for concept %s: %s", concept.object_id, e)
+        await _record_rejection(deps, concept, reason=f"Rendering failed: {e}")
+        return False
+
+    # Post-render path. Any exception below bumps promotion_attempts via
+    # `record_promotion_rejection` so a broken concept can't poison every
+    # sweep indefinitely; the three-strikes gate will lock it out for
+    # operator attention after three consecutive failures.
+    try:
+        rel_path = compute_path(concept)
+
+        # Check conflict
+        full_path = deps.vault_writer.vault_root / rel_path
+        if full_path.exists():
+            try:
+                content = full_path.read_text(encoding="utf-8")
+                data, _ = parse_frontmatter(content)
+                fm = CuratedFrontmatter.model_validate(data)
+
+                if fm.musubi_managed and fm.promoted_from == concept.object_id:
+                    # Idempotent rewrite allowed
+                    pass
+                elif fm.musubi_managed and fm.promoted_from != concept.object_id:
+                    # Sibling
+                    slug = slugify(concept.title)
+                    rel_path = rel_path.replace(f"{slug}.md", f"{slug}-v2.md")
+                    await deps.thoughts.emit(
+                        "ops-alerts",
+                        f"Path conflict handled with sibling: {rel_path}",
+                        "Path Conflict",
+                    )
+                else:
+                    # Human authored
+                    slug = slugify(concept.title)
+                    short_id = str(concept.object_id)[:8]
+                    rel_path = rel_path.replace(f"{slug}.md", f"{slug}-promoted-{short_id}.md")
+                    await deps.thoughts.emit(
+                        "ops-alerts",
+                        f"Path conflict with human file handled with sibling: {rel_path}",
+                        "Path Conflict",
+                    )
+
+            except Exception as e:
+                log.warning("Path conflict resolution failed for %s: %s", rel_path, e)
+
+        curated_id = generate_ksuid()
+
+        fm_obj = CuratedFrontmatter(  # type: ignore
+            object_id=curated_id,
+            namespace=concept.namespace,
+            title=concept.title,
+            topics=concept.topics or concept.linked_to_topics,
+            tags=concept.tags,
+            importance=concept.importance,
+            state="matured",
+            musubi_managed=True,
+            created=now,
+            updated=now,
+            promoted_from=concept.object_id,
+            promoted_at=now,
+        )
+
+        # Write to vault
+        deps.vault_writer.write_curated(rel_path, fm_obj, render.body)
+
+        # Create Qdrant point
+        body_hash = hashlib.sha256(render.body.encode("utf-8")).hexdigest()
+        memory = CuratedKnowledge(
+            object_id=curated_id,
+            namespace=concept.namespace,
+            vault_path=rel_path,
+            body_hash=body_hash,
+            title=concept.title,
+            content=render.body,
+            summary=concept.summary,
+            state="matured",
+            importance=concept.importance,
+            topics=concept.topics or concept.linked_to_topics,
+            tags=concept.tags,
+            promoted_from=concept.object_id,
+            promoted_at=now,
+        )
+
+        await deps.curated_plane.create(memory)
+
+        # Transition concept
+        await deps.concept_plane.transition(
+            namespace=concept.namespace,
+            object_id=concept.object_id,
+            to_state="promoted",
+            actor=_LIFECYCLE_ACTOR,
+            reason="lifecycle-promotion-sweep",
+            promoted_to=curated_id,
+            promoted_at=now,
+        )
+
+        # Notification Thought
+        await deps.thoughts.emit(
+            "ops-alerts",
+            f"Promoted concept '{concept.title}' to {rel_path}. Please review.",
+            "Concept Promoted",
+        )
+        return True
+    except Exception as e:
+        log.warning("Post-render promotion failed for concept %s: %s", concept.object_id, e)
+        await _record_rejection(deps, concept, reason=f"Post-render failed: {e}")
+        return False
+
+
+async def _record_rejection(
+    deps: PromotionDeps, concept: SynthesizedConcept, *, reason: str
+) -> None:
+    """Record a promotion rejection (bumps attempts); swallow if the
+    rejection-write itself fails so the sweep keeps going.
+
+    `record_promotion_rejection` touches Qdrant too — if the
+    underlying failure was Qdrant being unreachable, this write will
+    fail as well. We log and move on rather than propagate, so a single
+    infra blip doesn't crash the whole sweep.
+    """
+    try:
         await deps.concept_plane.record_promotion_rejection(
             namespace=concept.namespace,
             object_id=concept.object_id,
-            reason=f"Rendering failed: {e}",
+            reason=reason,
         )
-        return False
-
-    # Compute path
-    rel_path = compute_path(concept)
-
-    # Check conflict
-    full_path = deps.vault_writer.vault_root / rel_path
-    if full_path.exists():
-        try:
-            content = full_path.read_text(encoding="utf-8")
-            data, _ = parse_frontmatter(content)
-            fm = CuratedFrontmatter.model_validate(data)
-
-            if fm.musubi_managed and fm.promoted_from == concept.object_id:
-                # Idempotent rewrite allowed
-                pass
-            elif fm.musubi_managed and fm.promoted_from != concept.object_id:
-                # Sibling
-                slug = slugify(concept.title)
-                rel_path = rel_path.replace(f"{slug}.md", f"{slug}-v2.md")
-                await deps.thoughts.emit(
-                    "ops-alerts", f"Path conflict handled with sibling: {rel_path}", "Path Conflict"
-                )
-            else:
-                # Human authored
-                slug = slugify(concept.title)
-                short_id = str(concept.object_id)[:8]
-                rel_path = rel_path.replace(f"{slug}.md", f"{slug}-promoted-{short_id}.md")
-                await deps.thoughts.emit(
-                    "ops-alerts",
-                    f"Path conflict with human file handled with sibling: {rel_path}",
-                    "Path Conflict",
-                )
-
-        except Exception as e:
-            log.warning("Path conflict resolution failed for %s: %s", rel_path, e)
-
-    curated_id = generate_ksuid()
-
-    fm_obj = CuratedFrontmatter(  # type: ignore
-        object_id=curated_id,
-        namespace=concept.namespace,
-        title=concept.title,
-        topics=concept.topics or concept.linked_to_topics,
-        tags=concept.tags,
-        importance=concept.importance,
-        state="matured",
-        musubi_managed=True,
-        created=now,
-        updated=now,
-        promoted_from=concept.object_id,
-        promoted_at=now,
-    )
-
-    # Write to vault
-    deps.vault_writer.write_curated(rel_path, fm_obj, render.body)
-
-    # Create Qdrant point
-    body_hash = hashlib.sha256(render.body.encode("utf-8")).hexdigest()
-    memory = CuratedKnowledge(
-        object_id=curated_id,
-        namespace=concept.namespace,
-        vault_path=rel_path,
-        body_hash=body_hash,
-        title=concept.title,
-        content=render.body,
-        summary=concept.summary,
-        state="matured",
-        importance=concept.importance,
-        topics=concept.topics or concept.linked_to_topics,
-        tags=concept.tags,
-        promoted_from=concept.object_id,
-        promoted_at=now,
-    )
-
-    await deps.curated_plane.create(memory)
-
-    # Transition concept
-    await deps.concept_plane.transition(
-        namespace=concept.namespace,
-        object_id=concept.object_id,
-        to_state="promoted",
-        actor=_LIFECYCLE_ACTOR,
-        reason="lifecycle-promotion-sweep",
-        promoted_to=curated_id,
-        promoted_at=now,
-    )
-
-    # Emit LifecycleEvent for curated
-    # Curated knowledge starts at matured and has no provisional state,
-    # so we don't emit a state-change event for its creation.
-
-    # Notification Thought
-    await deps.thoughts.emit(
-        "ops-alerts",
-        f"Promoted concept '{concept.title}' to {rel_path}. Please review.",
-        "Concept Promoted",
-    )
-    return True
+    except Exception as e:
+        log.error(
+            "record_promotion_rejection also failed for %s: %s",
+            concept.object_id,
+            e,
+            exc_info=True,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/musubi/lifecycle/promotion.py
+++ b/src/musubi/lifecycle/promotion.py
@@ -36,6 +36,7 @@ log = logging.getLogger(__name__)
 _LIFECYCLE_ACTOR = "lifecycle-worker"
 PROMOTION_REINFORCEMENT_THRESHOLD = 3
 PROMOTION_IMPORTANCE_THRESHOLD = 6
+PROMOTION_MAX_ATTEMPTS = 3
 
 _REG = default_registry()
 _DURATION = _REG.histogram(
@@ -164,14 +165,15 @@ def namespace_to_dir(namespace: str) -> str:
 
 
 def compute_path(concept: SynthesizedConcept) -> str:
-    # `concept.topics` is always present (Field(default_factory=list)), so the
-    # previous `getattr(concept, "topics", concept.linked_to_topics)` could
-    # never actually fall through to `linked_to_topics` — the fallback was
-    # dead code. Replaced with the direct access that matches the runtime
-    # behavior exactly. Whether `topics` should fall back to
-    # `linked_to_topics` when empty is a semantic question (topic-hint
-    # unification) tracked in issue #217, not a drive-by cleanup.
-    topics = concept.topics
+    # Topic-hint unification: prefer `concept.topics` (populated by the
+    # synthesis job from the cluster); fall back to `linked_to_topics`
+    # (inherited from the originating memories) when topics is empty.
+    # `linked_to_topics` exists on every MemoryObject, so older concepts
+    # synthesized before `topics` was populated reliably still get a
+    # meaningful primary_topic from their source memories. Concepts with
+    # neither file under `_misc` — deliberately not auto-synthesized
+    # because that'd hide a real synthesis gap.
+    topics = concept.topics or concept.linked_to_topics
     primary_topic = topics[0] if topics else "_misc"
     slug = slugify(concept.title)
     return f"curated/{namespace_to_dir(concept.namespace)}/{primary_topic}/{slug}.md"
@@ -189,10 +191,11 @@ def _is_eligible(concept: SynthesizedConcept, now_epoch: float) -> bool:
     if now_epoch - created_epoch < 48 * 3600:
         return False
 
-    # `promotion_attempts >= 3` gate is deferred to issue #217 — the field
-    # exists on SynthesizedConcept but nothing increments it on failure yet,
-    # so a gate check here would never fire in practice. Current behavior:
-    # failed promotions retry indefinitely.
+    # Three-strikes gate. Every `ConceptPlane.record_promotion_rejection`
+    # bumps `promotion_attempts`, so after three failed renders a concept
+    # is locked out of further sweeps until an operator reinstates it.
+    if concept.promotion_attempts >= PROMOTION_MAX_ATTEMPTS:
+        return False
 
     if concept.contradicts:
         return False
@@ -217,6 +220,11 @@ async def run_promotion_sweep(
         ),
         models.FieldCondition(
             key="importance", range=models.Range(gte=PROMOTION_IMPORTANCE_THRESHOLD)
+        ),
+        # Three-strikes filter. Skips the payload-parse + `_is_eligible`
+        # call on concepts already locked out by prior rejections.
+        models.FieldCondition(
+            key="promotion_attempts", range=models.Range(lt=PROMOTION_MAX_ATTEMPTS)
         ),
     ]
 
@@ -246,8 +254,8 @@ async def run_promotion_sweep(
                 continue
 
             try:
-                await _promote_concept(deps, concept)
-                promoted_count += 1
+                if await _promote_concept(deps, concept):
+                    promoted_count += 1
             except Exception as e:
                 log.error("Failed to promote concept %s: %s", concept.object_id, e, exc_info=True)
 
@@ -260,7 +268,11 @@ async def run_promotion_sweep(
     return promoted_count
 
 
-async def _promote_concept(deps: PromotionDeps, concept: SynthesizedConcept) -> None:
+async def _promote_concept(deps: PromotionDeps, concept: SynthesizedConcept) -> bool:
+    """Attempt to promote one concept. Returns True iff it actually shipped
+    a curated row + vault file. The rejection path (LLM render failed)
+    bumps `promotion_attempts` via `record_promotion_rejection` and
+    returns False — the sweep counts only true promotions."""
     now = utc_now()
 
     # Render markdown via LLM
@@ -278,7 +290,7 @@ async def _promote_concept(deps: PromotionDeps, concept: SynthesizedConcept) -> 
             object_id=concept.object_id,
             reason=f"Rendering failed: {e}",
         )
-        return
+        return False
 
     # Compute path
     rel_path = compute_path(concept)
@@ -321,7 +333,7 @@ async def _promote_concept(deps: PromotionDeps, concept: SynthesizedConcept) -> 
         object_id=curated_id,
         namespace=concept.namespace,
         title=concept.title,
-        topics=concept.topics,
+        topics=concept.topics or concept.linked_to_topics,
         tags=concept.tags,
         importance=concept.importance,
         state="matured",
@@ -347,7 +359,7 @@ async def _promote_concept(deps: PromotionDeps, concept: SynthesizedConcept) -> 
         summary=concept.summary,
         state="matured",
         importance=concept.importance,
-        topics=concept.topics,
+        topics=concept.topics or concept.linked_to_topics,
         tags=concept.tags,
         promoted_from=concept.object_id,
         promoted_at=now,
@@ -376,6 +388,7 @@ async def _promote_concept(deps: PromotionDeps, concept: SynthesizedConcept) -> 
         f"Promoted concept '{concept.title}' to {rel_path}. Please review.",
         "Concept Promoted",
     )
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/src/musubi/planes/concept/plane.py
+++ b/src/musubi/planes/concept/plane.py
@@ -309,16 +309,13 @@ class ConceptPlane:
         data = current.model_dump()
         data.update(
             reinforcement_count=current.reinforcement_count + 1,
+            last_reinforced_at=now,
+            last_reinforced_epoch=epoch_of(now),
             merged_from=merged_from,
             version=current.version + 1,
             updated_at=now,
             updated_epoch=epoch_of(now),
         )
-        # NOTE: spec calls for ``last_reinforced_at = now`` here too, but
-        # the SynthesizedConcept type lacks the field (extra="forbid"
-        # rejects it). Cross-slice ticket
-        # ``_inbox/cross-slice/slice-plane-concept-slice-types-promotion-attempts.md``
-        # tracks the type-side fix.
         updated = SynthesizedConcept.model_validate(data)
         self._client.set_payload(
             collection_name=self._collection,
@@ -453,16 +450,11 @@ class ConceptPlane:
         data.update(
             promotion_rejected_at=now,
             promotion_rejected_reason=reason,
+            promotion_attempts=current.promotion_attempts + 1,
             version=current.version + 1,
             updated_at=now,
             updated_epoch=epoch_of(now),
         )
-        # NOTE: spec calls for ``promotion_attempts`` to bump here too, but
-        # the SynthesizedConcept type lacks the field (extra="forbid"
-        # rejects it). Cross-slice ticket
-        # ``_inbox/cross-slice/slice-plane-concept-slice-types-promotion-attempts.md``
-        # tracks the type-side fix; once it lands, slice-lifecycle-promotion
-        # can update its retry-backoff predicate.
         updated = SynthesizedConcept.model_validate(data)
         self._client.set_payload(
             collection_name=self._collection,

--- a/src/musubi/types/concept.py
+++ b/src/musubi/types/concept.py
@@ -38,15 +38,17 @@ class SynthesizedConcept(MemoryObject):
     topics: list[str] = Field(default_factory=list)
     promotion_attempts: int = Field(default=0, ge=0)
     last_reinforced_at: datetime | None = None
-
-    @property
-    def last_reinforced_epoch(self) -> float | None:
-        from musubi.types.common import epoch_of
-
-        return epoch_of(self.last_reinforced_at) if self.last_reinforced_at else None
+    # Derived from `last_reinforced_at` by the validator; null when the
+    # concept has never been reinforced. Kept as a real field (not a
+    # computed property) so it lands in the Qdrant payload and can drive
+    # scroll filters — mirrors the `created_epoch` / `updated_epoch`
+    # pattern on MemoryObject.
+    last_reinforced_epoch: float | None = None
 
     @model_validator(mode="after")
     def _normalise_and_guard(self) -> SynthesizedConcept:
+        from musubi.types.common import epoch_of
+
         if self.promoted_at is not None:
             object.__setattr__(self, "promoted_at", ensure_utc(self.promoted_at))
         if self.promotion_rejected_at is not None:
@@ -57,6 +59,8 @@ class SynthesizedConcept(MemoryObject):
             )
         if self.last_reinforced_at is not None:
             object.__setattr__(self, "last_reinforced_at", ensure_utc(self.last_reinforced_at))
+            if self.last_reinforced_epoch is None:
+                object.__setattr__(self, "last_reinforced_epoch", epoch_of(self.last_reinforced_at))
 
         if self.state == "promoted" and (self.promoted_to is None or self.promoted_at is None):
             raise ValueError("state=promoted requires promoted_to and promoted_at to be set")

--- a/src/musubi/vault/writer.py
+++ b/src/musubi/vault/writer.py
@@ -29,7 +29,18 @@ class VaultWriter:
 
         Updates the write-log beforehand to ensure the watcher ignores this event.
         """
-        full_path = self.vault_root / vault_relative_path.lstrip("/")
+        # Defense-in-depth: reject any path that escapes `vault_root`.
+        # The promotion sweep sanitizes topics with `slugify` before
+        # composing the path, but anything that wires a new caller to
+        # `write_curated` could forget. Resolve both sides and verify
+        # the target sits under vault_root.
+        full_path = (self.vault_root / vault_relative_path.lstrip("/")).resolve()
+        vault_root_resolved = self.vault_root.resolve()
+        if vault_root_resolved not in full_path.parents and full_path != vault_root_resolved:
+            raise ValueError(
+                f"vault-path-escape: {vault_relative_path!r} resolves outside "
+                f"vault_root {vault_root_resolved}"
+            )
         full_path.parent.mkdir(parents=True, exist_ok=True)
 
         # Normalize body and compute hash

--- a/tests/lifecycle/test_demotion.py
+++ b/tests/lifecycle/test_demotion.py
@@ -199,12 +199,91 @@ async def test_episodic_demotion_transitions_and_emits_event(deps: DemotionDeps)
 
 
 # Concept
-@pytest.mark.skip(
-    reason="deferred to issue #218: use last_reinforced_epoch in demotion scroll filter; "
-    "field exists on SynthesizedConcept, demotion currently proxies via updated_epoch"
-)
-def test_concept_demotion_selects_by_last_reinforced() -> None:
-    pass
+@pytest.mark.asyncio
+async def test_concept_demotion_selects_by_last_reinforced(deps: DemotionDeps) -> None:
+    # Concept was created long ago BUT reinforced recently. It should NOT
+    # demote — the `updated_epoch`-based proxy would have (any write ticks
+    # updated_epoch); the `last_reinforced_epoch` filter gets it right.
+    from musubi.planes.concept.plane import _point_id as cp_id
+
+    now = utc_now()
+    c = SynthesizedConcept(
+        object_id=generate_ksuid(),
+        namespace="eric/shared/concept",
+        title="Recently reinforced",
+        content="C",
+        synthesis_rationale="R",
+        created_at=now - timedelta(days=100),
+        updated_at=now - timedelta(days=100),
+        merged_from=[generate_ksuid() for _ in range(3)],
+    )
+    await deps.concept_plane.create(c)
+    await deps.concept_plane.transition(
+        namespace=c.namespace, object_id=c.object_id, to_state="matured", actor="sys", reason="test"
+    )
+
+    # Backdate created/updated to 100 days ago, but set last_reinforced
+    # to 5 days ago (well inside the 30-day no-reinforce window).
+    old_epoch = epoch_of(now) - 100 * 24 * 3600
+    recent_epoch = epoch_of(now) - 5 * 24 * 3600
+    deps.qdrant.set_payload(
+        collection_name="musubi_concept",
+        payload={
+            "created_epoch": old_epoch,
+            "updated_epoch": old_epoch,
+            "last_reinforced_epoch": recent_epoch,
+        },
+        points=[cp_id(str(c.object_id))],
+    )
+
+    count = await demotion_concept(deps)
+    assert count == 0
+
+    after = await deps.concept_plane.get(namespace=c.namespace, object_id=c.object_id)
+    assert after is not None and after.state == "matured"
+
+
+@pytest.mark.asyncio
+async def test_concept_demotion_selects_when_never_reinforced_and_stale(
+    deps: DemotionDeps,
+) -> None:
+    # Concept that was never reinforced: last_reinforced_epoch is null,
+    # so we fall back to created_epoch. If the concept is old enough by
+    # that measure, it demotes.
+    from musubi.planes.concept.plane import _point_id as cp_id
+
+    now = utc_now()
+    c = SynthesizedConcept(
+        object_id=generate_ksuid(),
+        namespace="eric/shared/concept",
+        title="Never reinforced",
+        content="C",
+        synthesis_rationale="R",
+        created_at=now - timedelta(days=40),
+        updated_at=now - timedelta(days=40),
+        merged_from=[generate_ksuid() for _ in range(3)],
+    )
+    await deps.concept_plane.create(c)
+    await deps.concept_plane.transition(
+        namespace=c.namespace, object_id=c.object_id, to_state="matured", actor="sys", reason="test"
+    )
+
+    old_epoch = epoch_of(now) - 40 * 24 * 3600
+    deps.qdrant.set_payload(
+        collection_name="musubi_concept",
+        payload={
+            "created_epoch": old_epoch,
+            "updated_epoch": old_epoch,
+            # last_reinforced_epoch deliberately absent / null
+        },
+        points=[cp_id(str(c.object_id))],
+    )
+
+    count = await demotion_concept(deps)
+    assert count == 1
+
+    after = await deps.concept_plane.get(namespace=c.namespace, object_id=c.object_id)
+    assert after is not None and after.state == "demoted"
 
 
 @pytest.mark.asyncio
@@ -232,12 +311,46 @@ async def test_concept_demotion_emits_ops_thought(deps: DemotionDeps) -> None:
     assert cast(Any, deps.thoughts).calls[0][0] == "ops-alerts"
 
 
-@pytest.mark.skip(
-    reason="deferred to issue #218: use last_reinforced_epoch in demotion scroll filter; "
-    "field exists on SynthesizedConcept, demotion currently proxies via updated_epoch"
-)
-def test_concept_reinforcement_resets_demotion_clock() -> None:
-    pass
+@pytest.mark.asyncio
+async def test_concept_reinforcement_resets_demotion_clock(deps: DemotionDeps) -> None:
+    # Concept was old + unreinforced; then gets reinforced. The reinforce
+    # call must stamp `last_reinforced_epoch` so the next sweep skips it.
+    from musubi.planes.concept.plane import _point_id as cp_id
+
+    now = utc_now()
+    c = SynthesizedConcept(
+        object_id=generate_ksuid(),
+        namespace="eric/shared/concept",
+        title="Stale then reinforced",
+        content="C",
+        synthesis_rationale="R",
+        created_at=now - timedelta(days=40),
+        updated_at=now - timedelta(days=40),
+        merged_from=[generate_ksuid() for _ in range(3)],
+    )
+    await deps.concept_plane.create(c)
+    await deps.concept_plane.transition(
+        namespace=c.namespace, object_id=c.object_id, to_state="matured", actor="sys", reason="test"
+    )
+
+    old_epoch = epoch_of(now) - 40 * 24 * 3600
+    deps.qdrant.set_payload(
+        collection_name="musubi_concept",
+        payload={"created_epoch": old_epoch, "updated_epoch": old_epoch},
+        points=[cp_id(str(c.object_id))],
+    )
+
+    # Reinforce bumps count AND stamps last_reinforced_at/epoch to now.
+    reinforced = await deps.concept_plane.reinforce(namespace=c.namespace, object_id=c.object_id)
+    assert reinforced.last_reinforced_at is not None
+    assert reinforced.last_reinforced_epoch is not None
+
+    # Sweep sees a fresh last_reinforced_epoch; shouldn't demote.
+    count = await demotion_concept(deps)
+    assert count == 0
+
+    after = await deps.concept_plane.get(namespace=c.namespace, object_id=c.object_id)
+    assert after is not None and after.state == "matured"
 
 
 # Artifact
@@ -274,12 +387,58 @@ async def test_reinstate_moves_back_to_matured(deps: DemotionDeps) -> None:
     assert p and p.state == "matured"
 
 
-@pytest.mark.skip(
-    reason="deferred to issue #218: use last_reinforced_epoch in demotion scroll filter; "
-    "field exists on SynthesizedConcept, demotion currently proxies via updated_epoch"
-)
-def test_reinstate_resets_reinforced_clock() -> None:
-    pass
+@pytest.mark.asyncio
+async def test_reinstate_resets_reinforced_clock(deps: DemotionDeps) -> None:
+    # Concept demoted by stale last_reinforced_epoch gets reinstated; the
+    # reinstate path must stamp a fresh last_reinforced so the next sweep
+    # doesn't immediately re-demote it.
+    from musubi.planes.concept.plane import _point_id as cp_id
+
+    now = utc_now()
+    c = SynthesizedConcept(
+        object_id=generate_ksuid(),
+        namespace="eric/shared/concept",
+        title="Reinstated",
+        content="C",
+        synthesis_rationale="R",
+        created_at=now - timedelta(days=40),
+        updated_at=now - timedelta(days=40),
+        merged_from=[generate_ksuid() for _ in range(3)],
+    )
+    await deps.concept_plane.create(c)
+    await deps.concept_plane.transition(
+        namespace=c.namespace, object_id=c.object_id, to_state="matured", actor="sys", reason="test"
+    )
+    await deps.concept_plane.transition(
+        namespace=c.namespace,
+        object_id=c.object_id,
+        to_state="demoted",
+        actor="sys",
+        reason="stale",
+    )
+
+    # Simulate the state that caused demotion in the first place: old
+    # last_reinforced_epoch sitting below the 30-day cutoff.
+    old_epoch = epoch_of(now) - 40 * 24 * 3600
+    deps.qdrant.set_payload(
+        collection_name="musubi_concept",
+        payload={
+            "created_epoch": old_epoch,
+            "updated_epoch": old_epoch,
+            "last_reinforced_epoch": old_epoch,
+        },
+        points=[cp_id(str(c.object_id))],
+    )
+
+    await reinstate(deps, c.namespace, str(c.object_id), "operator override")
+
+    after = await deps.concept_plane.get(namespace=c.namespace, object_id=c.object_id)
+    assert after is not None
+    assert after.state == "matured"
+    assert after.last_reinforced_epoch is not None
+    # Fresh clock — well within the 30-day no-reinforce window.
+    cutoff = epoch_of(now) - 30 * 24 * 3600
+    assert after.last_reinforced_epoch > cutoff
 
 
 @pytest.mark.skip(reason="event emitted via transition method")

--- a/tests/lifecycle/test_promotion.py
+++ b/tests/lifecycle/test_promotion.py
@@ -20,6 +20,7 @@ from musubi.planes.curated.plane import CuratedPlane
 from musubi.store.bootstrap import bootstrap
 from musubi.types.common import epoch_of, generate_ksuid, utc_now
 from musubi.types.concept import SynthesizedConcept
+from musubi.vault.frontmatter import CuratedFrontmatter
 
 
 class FakePromotionLLM:
@@ -231,6 +232,39 @@ def test_path_uses_misc_when_both_topic_sources_empty() -> None:
     # synthesis gap is visible on disk rather than silently disappearing.
     path = compute_path(_concept(topics=[], linked_to_topics=[]))
     assert "_misc" in path
+
+
+def test_path_sanitizes_topics_against_traversal() -> None:
+    # If a topic contains `..` or `/`, slugify must flatten it so the
+    # composed path can't escape vault_root.
+    path = compute_path(_concept(title="T", topics=["../../etc/passwd"]))
+    assert ".." not in path
+    assert "/etc/passwd" not in path
+    # Whatever segment ends up as the primary topic, it's sluggy.
+    path_parts = path.split("/")
+    primary_topic = path_parts[-2]
+    assert primary_topic.replace("-", "").replace("_", "").isalnum()
+
+
+def test_vault_writer_rejects_path_escape(tmp_path: Path) -> None:
+    # Defense-in-depth: even if compute_path misbehaved, the VaultWriter
+    # must reject a vault_relative_path that resolves outside vault_root.
+    from musubi.vault.writelog import WriteLog
+    from musubi.vault.writer import VaultWriter
+
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+    writer = VaultWriter(vault_root=vault_root, write_log=WriteLog(db_path=tmp_path / "wl.db"))
+    fm = CuratedFrontmatter(  # type: ignore[call-arg]
+        object_id=generate_ksuid(),
+        namespace="eric/shared/curated",
+        title="T",
+        musubi_managed=True,
+        created=utc_now(),
+        updated=utc_now(),
+    )
+    with pytest.raises(ValueError, match="vault-path-escape"):
+        writer.write_curated("../../../etc/passwd", fm, "## H2\n" + "A" * 100)
 
 
 @pytest.mark.asyncio
@@ -504,6 +538,58 @@ async def test_rendering_failure_increments_attempts_not_promotes(deps: Any) -> 
     # Rejection fields set, not promotion fields.
     assert after.promotion_rejected_at is not None
     assert after.promotion_rejected_reason is not None
+    assert after.promoted_to is None
+
+
+class _ExplodingVaultWriter(FakeVaultWriter):
+    """Vault writer that raises from `write_curated` — exercises the
+    post-render failure path (not the render path)."""
+
+    def write_curated(self, vault_relative_path: str, frontmatter: Any, body: str) -> Path:
+        raise OSError("simulated disk failure")
+
+
+@pytest.mark.asyncio
+async def test_post_render_failure_also_bumps_attempts(
+    qdrant: QdrantClient,
+    concept_plane: ConceptPlane,
+    curated_plane: CuratedPlane,
+    events_sink: LifecycleEventSink,
+    vault_root: Path,
+) -> None:
+    # Render succeeds (FakePromotionLLM returns a valid body), but the
+    # vault writer raises. The three-strikes gate has to cover this too
+    # — otherwise a concept whose LLM renders but whose FS op breaks
+    # would retry forever.
+
+    from musubi.lifecycle.promotion import PromotionDeps, run_promotion_sweep
+
+    deps = PromotionDeps(
+        qdrant=qdrant,
+        concept_plane=concept_plane,
+        curated_plane=curated_plane,
+        events=events_sink,
+        llm=FakePromotionLLM(),
+        vault_writer=_ExplodingVaultWriter(vault_root),
+        thoughts=FakeThoughtEmitter(),
+    )
+
+    c = _concept()
+    await deps.concept_plane.create(c)
+    await deps.concept_plane.transition(
+        namespace=c.namespace, object_id=c.object_id, to_state="matured", actor="sys", reason="test"
+    )
+    _set_old(deps, "concept", str(c.object_id))
+
+    count = await run_promotion_sweep(deps)
+    assert count == 0
+
+    after = await deps.concept_plane.get(namespace=c.namespace, object_id=c.object_id)
+    assert after is not None
+    assert after.promotion_attempts == 1
+    assert after.promotion_rejected_reason is not None
+    assert "Post-render failed" in after.promotion_rejected_reason
+    # Not promoted.
     assert after.promoted_to is None
 
 

--- a/tests/lifecycle/test_promotion.py
+++ b/tests/lifecycle/test_promotion.py
@@ -173,12 +173,12 @@ def test_gate_blocks_on_active_contradiction() -> None:
     assert not _is_eligible(_concept(contradicts=[generate_ksuid()]), now_epoch)
 
 
-@pytest.mark.skip(
-    reason="deferred to issue #217: wire promotion_attempts gate + increment logic; "
-    "field exists on SynthesizedConcept, gate is commented out + nothing increments it"
-)
 def test_gate_blocks_after_3_attempts() -> None:
-    pass
+    now_epoch = epoch_of(utc_now())
+    assert _is_eligible(_concept(promotion_attempts=0), now_epoch)
+    assert _is_eligible(_concept(promotion_attempts=2), now_epoch)
+    assert not _is_eligible(_concept(promotion_attempts=3), now_epoch)
+    assert not _is_eligible(_concept(promotion_attempts=5), now_epoch)
 
 
 def test_gate_skips_already_promoted() -> None:
@@ -210,12 +210,27 @@ def test_rendering_retry_corrective_prompt() -> None:
 
 
 # Path:
-@pytest.mark.skip(
-    reason="deferred to issue #217: drop stale getattr fallback + use concept.topics directly; "
-    "topics field exists on SynthesizedConcept"
-)
 def test_path_derived_from_topic_and_title() -> None:
-    pass
+    # Primary topic comes from `topics` when populated.
+    path = compute_path(_concept(title="My Title", topics=["gpu-notes"]))
+    assert "gpu-notes" in path
+    assert "my-title" in path
+    assert path.endswith(".md")
+
+
+def test_path_falls_back_to_linked_to_topics_when_topics_empty() -> None:
+    # `linked_to_topics` fills in when synthesis didn't populate `topics`
+    # (older concepts, edge cases). Exercises the topic-hint unification
+    # fallback (see issue #217 discussion).
+    path = compute_path(_concept(topics=[], linked_to_topics=["fallback-topic"]))
+    assert "fallback-topic" in path
+
+
+def test_path_uses_misc_when_both_topic_sources_empty() -> None:
+    # Neither topics nor linked_to_topics — file under _misc so a real
+    # synthesis gap is visible on disk rather than silently disappearing.
+    path = compute_path(_concept(topics=[], linked_to_topics=[]))
+    assert "_misc" in path
 
 
 @pytest.mark.asyncio
@@ -456,20 +471,83 @@ async def test_thought_emitted_to_ops_alerts(deps: Any) -> None:
 
 
 # Failure:
-@pytest.mark.skip(
-    reason="deferred to issue #217: wire promotion_attempts gate + increment logic; "
-    "field exists on SynthesizedConcept, gate is commented out + nothing increments it"
-)
-def test_promotion_rejected_after_3_attempts_stops_retrying() -> None:
-    pass
+class _AlwaysFailingLLM:
+    """LLM that raises on every render — drives the rejection path."""
+
+    async def render_curated_markdown(
+        self, title: str, content: str, rationale: str, top_memories: list[str]
+    ) -> PromotionRender:
+        raise RuntimeError("LLM render failed")
 
 
-@pytest.mark.skip(
-    reason="deferred to issue #217: wire promotion_attempts gate + increment logic; "
-    "field exists on SynthesizedConcept, gate is commented out + nothing increments it"
-)
-def test_rendering_failure_increments_attempts_not_promotes() -> None:
-    pass
+@pytest.mark.asyncio
+async def test_rendering_failure_increments_attempts_not_promotes(deps: Any) -> None:
+    from dataclasses import replace
+
+    from musubi.lifecycle.promotion import run_promotion_sweep
+
+    failing_deps = replace(deps, llm=_AlwaysFailingLLM())
+    c = _concept()
+    await failing_deps.concept_plane.create(c)
+    await failing_deps.concept_plane.transition(
+        namespace=c.namespace, object_id=c.object_id, to_state="matured", actor="sys", reason="test"
+    )
+    _set_old(failing_deps, "concept", str(c.object_id))
+
+    promoted_count = await run_promotion_sweep(failing_deps)
+    assert promoted_count == 0
+
+    after = await failing_deps.concept_plane.get(namespace=c.namespace, object_id=c.object_id)
+    assert after is not None
+    # Render failure took the rejection path, which bumps attempts.
+    assert after.promotion_attempts == 1
+    # Rejection fields set, not promotion fields.
+    assert after.promotion_rejected_at is not None
+    assert after.promotion_rejected_reason is not None
+    assert after.promoted_to is None
+
+
+@pytest.mark.asyncio
+async def test_promotion_rejected_after_3_attempts_stops_retrying(deps: Any) -> None:
+    from dataclasses import replace
+
+    from musubi.lifecycle.promotion import run_promotion_sweep
+
+    failing_deps = replace(deps, llm=_AlwaysFailingLLM())
+    c = _concept()
+    await failing_deps.concept_plane.create(c)
+    await failing_deps.concept_plane.transition(
+        namespace=c.namespace, object_id=c.object_id, to_state="matured", actor="sys", reason="test"
+    )
+    _set_old(failing_deps, "concept", str(c.object_id))
+
+    # Three sweeps, three rejections.
+    for _ in range(3):
+        await run_promotion_sweep(failing_deps)
+
+    after = await failing_deps.concept_plane.get(namespace=c.namespace, object_id=c.object_id)
+    assert after is not None
+    assert after.promotion_attempts == 3
+
+    # Fourth sweep — gate + scroll filter should both exclude this concept,
+    # so the LLM never gets called again.
+    class _CountingFailLLM:
+        calls = 0
+
+        async def render_curated_markdown(
+            self, title: str, content: str, rationale: str, top_memories: list[str]
+        ) -> PromotionRender:
+            _CountingFailLLM.calls += 1
+            raise RuntimeError("LLM render failed")
+
+    counting_deps = replace(failing_deps, llm=_CountingFailLLM())
+    await run_promotion_sweep(counting_deps)
+    assert _CountingFailLLM.calls == 0
+
+    # attempts count didn't go up — the concept was never loaded.
+    final = await counting_deps.concept_plane.get(namespace=c.namespace, object_id=c.object_id)
+    assert final is not None
+    assert final.promotion_attempts == 3
 
 
 # Concurrency:


### PR DESCRIPTION
Closes #217, #218.

## Summary
Two `SynthesizedConcept` fields were declared but never wired — `promotion_attempts` and `last_reinforced_at`. Stale `NOTE:` comments in multiple places claimed the fields were "missing from the type". They weren't; the plane methods just never set them.

Net effect before this PR: failed promotions retried indefinitely (no three-strikes gate); concept demotion was too lenient because it proxied via `updated_epoch`, which ticks on any write (contradictions, importance re-scores), not just reinforcement.

## Changes
### `SynthesizedConcept` ([src/musubi/types/concept.py](src/musubi/types/concept.py))
- `last_reinforced_epoch` promoted from `@property` → real field, derived in validator. Mirrors the `created_epoch` / `updated_epoch` pattern on `MemoryObject` so pydantic serialises it into the Qdrant payload where the scroll filter can see it.

### `ConceptPlane` ([src/musubi/planes/concept/plane.py](src/musubi/planes/concept/plane.py))
- `reinforce()` stamps both `last_reinforced_at` and `last_reinforced_epoch = now`.
- `record_promotion_rejection()` bumps `promotion_attempts` (was silently skipped per stale NOTE).

### Promotion sweep ([src/musubi/lifecycle/promotion.py](src/musubi/lifecycle/promotion.py))
- `_is_eligible` rejects `promotion_attempts >= 3`.
- Qdrant scroll filter adds `promotion_attempts < 3` so rejected concepts aren't even loaded.
- `_promote_concept` returns bool so the rejection path doesn't inflate `promoted_count`.
- `compute_path` + CuratedFrontmatter + CuratedKnowledge use `concept.topics or concept.linked_to_topics` — the topic-hint unification Copilot flagged on #223, now deliberate: prefer synthesis-derived `topics`, fall back to source-memory `linked_to_topics`, `_misc` only when both empty.

### Demotion sweep ([src/musubi/lifecycle/demotion.py](src/musubi/lifecycle/demotion.py))
- `demotion_concept` Qdrant filter: `last_reinforced_epoch < cutoff` OR (`last_reinforced_epoch is null` AND `created_epoch < cutoff`). Python-side re-verification catches payload-schema drift.
- `reinstate` stamps `last_reinforced_at = now` so a reinstated concept doesn't immediately re-demote on the next sweep.

## Tests
Ten previously-skipped test bodies filled in:

| Test | What it proves |
|---|---|
| `test_gate_blocks_after_3_attempts` | `_is_eligible` rejects at 3+ attempts |
| `test_path_derived_from_topic_and_title` | primary topic comes from `topics` |
| `test_path_falls_back_to_linked_to_topics_when_topics_empty` | fallback wiring |
| `test_path_uses_misc_when_both_topic_sources_empty` | `_misc` only when both empty |
| `test_rendering_failure_increments_attempts_not_promotes` | render fail → attempts=1, no promotion |
| `test_promotion_rejected_after_3_attempts_stops_retrying` | sweep skips past the 3-strike point without even calling the LLM |
| `test_concept_demotion_selects_by_last_reinforced` | old concept with fresh reinforce is NOT demoted (the bug this fixes) |
| `test_concept_demotion_selects_when_never_reinforced_and_stale` | null-last-reinforced fallback to created_epoch works |
| `test_concept_reinforcement_resets_demotion_clock` | `reinforce()` actually stamps the timestamp |
| `test_reinstate_resets_reinforced_clock` | reinstated concept has a fresh clock |

## Test plan
- [x] `make check` — 1209 passed, 205 skipped, 17 deselected.
- [x] `make agent-check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)