### PR TITLE
feat(lifecycle): artifact archival sweep (opt-in) + slice-ops-storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,3 +49,8 @@ OAUTH_AUTHORITY=https://auth.example.test
 # --------------------------------------------------------------------------
 MUSUBI_GRPC=false
 MUSUBI_ALLOW_PLAINTEXT=false
+# Opt-in to the artifact-archival lifecycle sweep. When true, unreferenced
+# artifacts older than 180 days are transitioned to state=archived (blob
+# bytes preserved). Leave false on deploys that haven't decided archival
+# policy yet — the default is a no-op.
+MUSUBI_ARTIFACT_ARCHIVAL_ENABLED=false

--- a/docs/Musubi/08-deployment/compose-stack.md
+++ b/docs/Musubi/08-deployment/compose-stack.md
@@ -131,6 +131,11 @@ OAUTH_AUTHORITY=https://auth.internal.example.com
 # Feature flags
 MUSUBI_GRPC=false
 MUSUBI_ALLOW_PLAINTEXT=false
+# Opt-in to the artifact-archival lifecycle sweep. When true,
+# unreferenced artifacts older than 180 days transition to
+# state=archived (blob bytes preserved — archival is soft-delete only).
+# Default false keeps the sweep as a no-op.
+MUSUBI_ARTIFACT_ARCHIVAL_ENABLED=false
 ```
 
 ## Resource limits

--- a/src/musubi/lifecycle/demotion.py
+++ b/src/musubi/lifecycle/demotion.py
@@ -215,7 +215,15 @@ async def demotion_artifact(deps: DemotionDeps, batch_size: int = 100) -> int:
     `ArtifactPlane.transition`. The blob itself is preserved — archival
     is a soft-delete, not storage reclamation.
     """
-    if not deps.artifact_archival_enabled or deps.artifact_plane is None:
+    if not deps.artifact_archival_enabled:
+        return 0
+
+    if deps.artifact_plane is None:
+        log.warning(
+            "Artifact archival is enabled but artifact_plane is not configured; "
+            "skipping artifact demotion sweep. Wire `DemotionDeps.artifact_plane` "
+            "in the lifecycle-worker bootstrap."
+        )
         return 0
 
     now = utc_now()
@@ -247,7 +255,10 @@ async def demotion_artifact(deps: DemotionDeps, batch_size: int = 100) -> int:
             scroll_filter=models.Filter(must=must_conditions),
             limit=batch_size,
             offset=offset,
-            with_payload=True,
+            # Narrow payload: we only need the ids here, not the full
+            # artifact row (content-type, blob metadata, etc.). On
+            # sizable collections this saves real bytes per sweep.
+            with_payload=["namespace", "object_id"],
             with_vectors=False,
         )
         points, offset = resp[0], resp[1]
@@ -306,7 +317,10 @@ def _collect_referenced_artifact_ids(client: QdrantClient) -> set[str]:
                 collection_name=coll,
                 limit=500,
                 offset=offset,
-                with_payload=True,
+                # Narrow payload: we only read `supported_by` here, not
+                # the full row (which carries multi-KB `content` fields
+                # on curated/concept). Saves O(total-bytes) per sweep.
+                with_payload=["supported_by"],
                 with_vectors=False,
             )
             for point in points:
@@ -394,9 +408,12 @@ def build_demotion_jobs(
     """Return :class:`Job` objects for the demotion sweeps registered in
     :func:`musubi.lifecycle.scheduler.build_default_jobs`.
 
-    Two jobs today — ``demotion_episodic`` (weekly Sun 03:45 UTC) and
-    ``demotion_concept`` (daily 05:00 UTC). ``demotion_artifact`` stays
-    opt-in per-namespace and is not scheduled globally.
+    Three jobs — ``demotion_episodic`` (weekly Sun 03:45 UTC),
+    ``demotion_concept`` (daily 05:00 UTC), and ``demotion_artifact``
+    (weekly Sun 04:15 UTC). The artifact sweep self-gates on
+    ``deps.artifact_archival_enabled``; scheduling it unconditionally
+    keeps the cron registry stable while letting the feature flag
+    decide whether it does any work.
 
     The wrapper grabs a file lock per job so two workers on the same
     host can't double-execute, then runs the sweep via ``asyncio.run``
@@ -421,7 +438,13 @@ def build_demotion_jobs(
         elif name == "demotion_concept":
             kwargs = {"hour": 5, "minute": 0}
             grace = 3600
-        else:  # pragma: no cover — both names enumerated above
+        elif name == "demotion_artifact":
+            # Runs right after the episodic sweep so the referenced-by
+            # probe sees any fresh demotions before deciding which
+            # artifacts are orphans.
+            kwargs = {"day_of_week": "sun", "hour": 4, "minute": 15}
+            grace = 3600
+        else:  # pragma: no cover — all names enumerated above
             raise ValueError(f"unknown demotion job name: {name}")
         return Job(
             name=name,
@@ -439,6 +462,10 @@ def build_demotion_jobs(
         _wrap(
             "demotion_concept",
             lambda: demotion_concept(deps, batch_size=batch_size),
+        ),
+        _wrap(
+            "demotion_artifact",
+            lambda: demotion_artifact(deps, batch_size=batch_size),
         ),
     ]
 

--- a/src/musubi/lifecycle/demotion.py
+++ b/src/musubi/lifecycle/demotion.py
@@ -16,6 +16,7 @@ from qdrant_client import QdrantClient, models
 
 from musubi.lifecycle.events import LifecycleEventSink
 from musubi.lifecycle.scheduler import Job, file_lock
+from musubi.planes.artifact.plane import ArtifactPlane
 from musubi.planes.concept.plane import ConceptPlane
 from musubi.planes.episodic.plane import EpisodicPlane
 from musubi.types.common import epoch_of, utc_now
@@ -43,6 +44,8 @@ class DemotionDeps:
     concept_plane: ConceptPlane
     events: LifecycleEventSink
     thoughts: ThoughtEmitter
+    artifact_plane: ArtifactPlane | None = None
+    artifact_archival_enabled: bool = False
 
 
 async def demotion_episodic(deps: DemotionDeps, batch_size: int = 100) -> int:
@@ -200,10 +203,122 @@ async def demotion_concept(deps: DemotionDeps, batch_size: int = 100) -> int:
 
 
 async def demotion_artifact(deps: DemotionDeps, batch_size: int = 100) -> int:
-    """Archive old, unreferenced, large artifacts.
-    Off by default; opt-in per-namespace.
+    """Archive old, unreferenced artifacts.
+
+    Off by default. Set `DemotionDeps.artifact_archival_enabled = True`
+    (driven by `settings.musubi_artifact_archival_enabled`) to opt in.
+
+    When enabled: scrolls `musubi_artifact` for rows older than
+    `DEMOTION_ARTIFACT_AGE_DAYS` that aren't referenced by any memory
+    (no episodic/curated/concept row carries the artifact's id in its
+    `supported_by`). Transitions those to `state=archived` via
+    `ArtifactPlane.transition`. The blob itself is preserved — archival
+    is a soft-delete, not storage reclamation.
     """
-    return 0
+    if not deps.artifact_archival_enabled or deps.artifact_plane is None:
+        return 0
+
+    now = utc_now()
+    cutoff_epoch = epoch_of(now) - (DEMOTION_ARTIFACT_AGE_DAYS * 24 * 3600)
+
+    # Pre-compute the full set of referenced artifact ids once per sweep.
+    # Nested-list field filters (`supported_by.artifact_id`) aren't
+    # uniformly supported across Qdrant back-ends (notably the in-memory
+    # client), so we scroll every memory-carrying plane and accumulate
+    # the ids in Python. O(m) once, then O(n) membership checks — saves
+    # the O(n*m) per-artifact probe a naive implementation would do.
+    referenced_ids = _collect_referenced_artifact_ids(deps.qdrant)
+
+    from musubi.store.names import collection_for_plane
+
+    coll_name = collection_for_plane("artifact")
+
+    must_conditions: list[Any] = [
+        models.FieldCondition(key="state", match=models.MatchValue(value="matured")),
+        models.FieldCondition(key="created_epoch", range=models.Range(lt=cutoff_epoch)),
+    ]
+
+    offset = None
+    archived_count = 0
+
+    while True:
+        resp = deps.qdrant.scroll(
+            collection_name=coll_name,
+            scroll_filter=models.Filter(must=must_conditions),
+            limit=batch_size,
+            offset=offset,
+            with_payload=True,
+            with_vectors=False,
+        )
+        points, offset = resp[0], resp[1]
+
+        for point in points:
+            if not point.payload:
+                continue
+
+            object_id_str = point.payload.get("object_id")
+            namespace = point.payload.get("namespace")
+            if not object_id_str or not namespace:
+                continue
+
+            if object_id_str in referenced_ids:
+                continue
+
+            try:
+                _, _event = await deps.artifact_plane.transition(
+                    namespace=cast(Any, namespace),
+                    object_id=cast(Any, object_id_str),
+                    to_state="archived",
+                    actor=_LIFECYCLE_ACTOR,
+                    reason="decay-rule:unreferenced-expired",
+                )
+                archived_count += 1
+            except Exception as e:
+                log.error(
+                    "Failed to archive artifact %s: %s",
+                    object_id_str,
+                    e,
+                    exc_info=True,
+                )
+
+        if not offset:
+            break
+
+    return archived_count
+
+
+def _collect_referenced_artifact_ids(client: QdrantClient) -> set[str]:
+    """Return the set of artifact ids referenced by any live memory.
+
+    Scrolls `musubi_episodic`, `musubi_curated`, `musubi_concept` — the
+    three planes whose payloads carry `supported_by`. Demoted / archived
+    rows still pin their artifacts (we don't reclaim retroactively);
+    per-row state filtering lives at retrieval, not here.
+    """
+    from musubi.store.names import collection_for_plane
+
+    referenced: set[str] = set()
+    for plane_name in ("episodic", "curated", "concept"):
+        coll = collection_for_plane(plane_name)
+        offset: Any = None
+        while True:
+            points, offset = client.scroll(
+                collection_name=coll,
+                limit=500,
+                offset=offset,
+                with_payload=True,
+                with_vectors=False,
+            )
+            for point in points:
+                if not point.payload:
+                    continue
+                for ref in point.payload.get("supported_by") or []:
+                    artifact_id = ref.get("artifact_id") if isinstance(ref, dict) else None
+                    if artifact_id:
+                        referenced.add(str(artifact_id))
+            if not offset:
+                break
+    return referenced
 
 
 async def reinstate(deps: DemotionDeps, namespace: str, object_id: str, reason: str) -> None:

--- a/src/musubi/lifecycle/runner.py
+++ b/src/musubi/lifecycle/runner.py
@@ -343,6 +343,9 @@ async def _main_async() -> None:
         cursor=cursor,
         lock_dir=lock_dir,
     )
+    from musubi.planes.artifact.plane import ArtifactPlane
+
+    artifact_plane = ArtifactPlane(client=qdrant, embedder=embedder)
     dem_jobs = build_demotion_jobs(
         deps=DemotionDeps(
             qdrant=qdrant,
@@ -350,6 +353,8 @@ async def _main_async() -> None:
             concept_plane=concept_plane,
             events=sink,
             thoughts=thought_emitter,
+            artifact_plane=artifact_plane,
+            artifact_archival_enabled=settings.musubi_artifact_archival_enabled,
         ),
         lock_dir=lock_dir,
     )

--- a/src/musubi/settings.py
+++ b/src/musubi/settings.py
@@ -94,6 +94,17 @@ class Settings(BaseSettings):
     # ------------------------------------------------------------------
     musubi_grpc: bool = Field(default=False, description="Expose the gRPC API alongside REST.")
 
+    musubi_artifact_archival_enabled: bool = Field(
+        default=False,
+        description=(
+            "Opt in to the artifact-archival lifecycle sweep. When False (default), "
+            "`demotion_artifact` is a no-op. When True, artifacts older than "
+            "`DEMOTION_ARTIFACT_AGE_DAYS` (180d) and not referenced by any memory "
+            "are transitioned to state=archived. Blob bytes are preserved; "
+            "storage reclamation is a separate follow-up (issue #222)."
+        ),
+    )
+
     # Rate limits — per-bucket, per-minute — live in
     # `src/musubi/api/rate_limit.py::DEFAULT_BUCKETS`. See ADR 0027 for
     # the rationale on why they are not tunable via settings.

--- a/tests/lifecycle/test_demotion.py
+++ b/tests/lifecycle/test_demotion.py
@@ -16,6 +16,7 @@ from musubi.lifecycle.events import LifecycleEventSink
 from musubi.planes.concept.plane import ConceptPlane
 from musubi.planes.episodic.plane import EpisodicPlane
 from musubi.store.bootstrap import bootstrap
+from musubi.types.artifact import SourceArtifact
 from musubi.types.common import epoch_of, generate_ksuid, utc_now
 from musubi.types.concept import SynthesizedConcept
 from musubi.types.episodic import EpisodicMemory
@@ -354,19 +355,159 @@ async def test_concept_reinforcement_resets_demotion_clock(deps: DemotionDeps) -
 
 
 # Artifact
-@pytest.mark.skip(reason="deferred to issue #222: artifact archival policy + slice-ops-storage")
-def test_artifact_archival_off_by_default() -> None:
-    pass
+@pytest.mark.asyncio
+async def test_artifact_archival_off_by_default(
+    qdrant: QdrantClient,
+    episodic_plane: EpisodicPlane,
+    concept_plane: ConceptPlane,
+    events_sink: LifecycleEventSink,
+) -> None:
+    # Omit artifact_plane + leave the toggle False. `demotion_artifact`
+    # must no-op even when the data would otherwise qualify for archival.
+    from musubi.lifecycle.demotion import demotion_artifact
+    from musubi.planes.artifact.plane import ArtifactPlane
+
+    artifact_plane = ArtifactPlane(client=qdrant, embedder=FakeEmbedder())
+    art = await artifact_plane.create(
+        SourceArtifact(
+            namespace="eric/shared/artifact",
+            title="old unreferenced",
+            filename="a.txt",
+            sha256="a" * 64,
+            content_type="text/plain",
+            size_bytes=2_000_000,
+            chunker="none",
+        )
+    )
+
+    # Stale created_epoch so it would qualify if archival were enabled.
+    from musubi.planes.artifact.plane import _point_id as ap_id
+
+    qdrant.set_payload(
+        collection_name="musubi_artifact",
+        payload={"created_epoch": epoch_of(utc_now()) - 200 * 24 * 3600},
+        points=[ap_id(str(art.object_id))],
+    )
+
+    # Default toggles: archival disabled.
+    deps = DemotionDeps(
+        qdrant=qdrant,
+        episodic_plane=episodic_plane,
+        concept_plane=concept_plane,
+        events=events_sink,
+        thoughts=FakeThoughtEmitter(),
+    )
+    count = await demotion_artifact(deps)
+    assert count == 0
+
+    after = await artifact_plane.get(namespace=art.namespace, object_id=art.object_id)
+    assert after is not None and after.state == "matured"
 
 
-@pytest.mark.skip(reason="deferred to issue #222: artifact archival policy + slice-ops-storage")
-def test_artifact_archival_respects_referenced_by() -> None:
-    pass
+@pytest.mark.asyncio
+async def test_artifact_archival_respects_referenced_by(
+    qdrant: QdrantClient,
+    episodic_plane: EpisodicPlane,
+    concept_plane: ConceptPlane,
+    events_sink: LifecycleEventSink,
+) -> None:
+    from musubi.lifecycle.demotion import demotion_artifact
+    from musubi.planes.artifact.plane import ArtifactPlane
+    from musubi.planes.artifact.plane import _point_id as ap_id
+    from musubi.types.common import ArtifactRef, generate_ksuid
+
+    artifact_plane = ArtifactPlane(client=qdrant, embedder=FakeEmbedder())
+    art = await artifact_plane.create(
+        SourceArtifact(
+            namespace="eric/shared/artifact",
+            title="old but referenced",
+            filename="b.txt",
+            sha256="b" * 64,
+            content_type="text/plain",
+            size_bytes=2_000_000,
+            chunker="none",
+        )
+    )
+    qdrant.set_payload(
+        collection_name="musubi_artifact",
+        payload={"created_epoch": epoch_of(utc_now()) - 200 * 24 * 3600},
+        points=[ap_id(str(art.object_id))],
+    )
+
+    # Episodic memory that cites this artifact in supported_by.
+    memory = EpisodicMemory(
+        namespace="eric/shared/episodic",
+        content="cites the artifact",
+        state="matured",
+        supported_by=[ArtifactRef(artifact_id=art.object_id, chunk_id=generate_ksuid())],
+    )
+    await episodic_plane.create(memory)
+
+    deps = DemotionDeps(
+        qdrant=qdrant,
+        episodic_plane=episodic_plane,
+        concept_plane=concept_plane,
+        events=events_sink,
+        thoughts=FakeThoughtEmitter(),
+        artifact_plane=artifact_plane,
+        artifact_archival_enabled=True,
+    )
+    count = await demotion_artifact(deps)
+    assert count == 0
+
+    after = await artifact_plane.get(namespace=art.namespace, object_id=art.object_id)
+    assert after is not None and after.state == "matured"
 
 
-@pytest.mark.skip(reason="deferred to issue #222: artifact archival policy + slice-ops-storage")
-def test_artifact_archival_transitions_to_archived_keeps_blob() -> None:
-    pass
+@pytest.mark.asyncio
+async def test_artifact_archival_transitions_to_archived_keeps_blob(
+    qdrant: QdrantClient,
+    episodic_plane: EpisodicPlane,
+    concept_plane: ConceptPlane,
+    events_sink: LifecycleEventSink,
+) -> None:
+    from musubi.lifecycle.demotion import demotion_artifact
+    from musubi.planes.artifact.plane import ArtifactPlane
+    from musubi.planes.artifact.plane import _point_id as ap_id
+
+    artifact_plane = ArtifactPlane(client=qdrant, embedder=FakeEmbedder())
+    art = await artifact_plane.create(
+        SourceArtifact(
+            namespace="eric/shared/artifact",
+            title="old unreferenced",
+            filename="c.txt",
+            sha256="c" * 64,
+            content_type="text/plain",
+            size_bytes=2_000_000,
+            chunker="none",
+        )
+    )
+    qdrant.set_payload(
+        collection_name="musubi_artifact",
+        payload={"created_epoch": epoch_of(utc_now()) - 200 * 24 * 3600},
+        points=[ap_id(str(art.object_id))],
+    )
+
+    deps = DemotionDeps(
+        qdrant=qdrant,
+        episodic_plane=episodic_plane,
+        concept_plane=concept_plane,
+        events=events_sink,
+        thoughts=FakeThoughtEmitter(),
+        artifact_plane=artifact_plane,
+        artifact_archival_enabled=True,
+    )
+    count = await demotion_artifact(deps)
+    assert count == 1
+
+    after = await artifact_plane.get(namespace=art.namespace, object_id=art.object_id)
+    assert after is not None
+    assert after.state == "archived"
+    # Blob-adjacent metadata is preserved — state transition doesn't touch
+    # the artifact-side fields that describe the blob itself.
+    assert after.sha256 == "c" * 64
+    assert after.filename == "c.txt"
+    assert after.size_bytes == 2_000_000
 
 
 # Reinstatement


### PR DESCRIPTION
Closes #222.

## Summary
- Replaces the `demotion_artifact` stub with a real archival sweep: scrolls `musubi_artifact` for rows older than `DEMOTION_ARTIFACT_AGE_DAYS` (180d) that no live memory references, transitions them to `state=archived`, and preserves the blob bytes.
- Storage reclamation (deleting the underlying blob file) is a separate follow-up — archival is a soft-delete only.

## Opt-in gate
New setting `musubi_artifact_archival_enabled` (default `False`) drives new fields on `DemotionDeps`:
- `artifact_plane: ArtifactPlane | None = None`
- `artifact_archival_enabled: bool = False`

With the flag off (default), `demotion_artifact` returns 0 without touching Qdrant — matches the "off by default, opt in per-deploy" spec.

## Referenced-by check
An artifact is "referenced" when any `musubi_episodic`, `musubi_curated`, or `musubi_concept` row carries its id in `supported_by`. The sweep pre-computes the full referenced set once per run (one scroll per plane), then does O(1) membership checks per candidate artifact — **O(n+m) total, vs O(n*m)** for a per-candidate Qdrant probe. Also sidesteps the nested-list field-filter quirks in the in-memory Qdrant client used by unit tests.

## Tests
Three previously-skipped Test Contract bullets filled in:
| Test | What it proves |
|---|---|
| `test_artifact_archival_off_by_default` | Default toggles ⇒ no archival even when data qualifies. |
| `test_artifact_archival_respects_referenced_by` | Referenced artifact stays `matured` even when old enough. |
| `test_artifact_archival_transitions_to_archived_keeps_blob` | Unreferenced old artifact → `archived`; blob-side fields (sha256, filename, size_bytes) preserved. |

## Test plan
- [x] `make check` — 1202 passed, 209 skipped, 17 deselected.
- [x] `make agent-check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)