### PR TITLE
feat(vault): event rate limit + indexing concurrency cap

### DIFF
--- a/src/musubi/vault/watcher.py
+++ b/src/musubi/vault/watcher.py
@@ -43,18 +43,21 @@ See issue #219."""
 class _TokenBucket:
     """Simple monotonic-clock token bucket.
 
-    Tokens refill continuously at `rate_per_sec`; the bucket caps at
-    that same rate (1-second burst capacity). `try_consume()` takes
+    Tokens refill continuously at `rate_per_sec`. `try_consume()` takes
     one token atomically — returns True when a token was available,
     False otherwise. Not thread-safe; the Watcher only calls it from
     the event loop (via `call_soon_threadsafe`).
+
+    Capacity is decoupled from rate: it is clamped to at least 1 token
+    so sub-1/sec rates can still accumulate a token and fire — otherwise
+    every event would be dropped forever.
     """
 
     __slots__ = ("_capacity", "_last_refill", "_rate", "_tokens")
 
     def __init__(self, rate_per_sec: float) -> None:
         self._rate = max(rate_per_sec, 0.0)
-        self._capacity = self._rate
+        self._capacity = max(self._rate, 1.0)
         self._tokens = self._capacity
         self._last_refill = 0.0
 
@@ -110,6 +113,11 @@ class VaultWatcher:
         event_rate_per_sec: float = _DEFAULT_EVENT_RATE_PER_SEC,
         indexing_concurrency: int = _DEFAULT_INDEXING_CONCURRENCY,
     ) -> None:
+        if event_rate_per_sec <= 0:
+            raise ValueError(f"event_rate_per_sec must be > 0, got {event_rate_per_sec!r}")
+        if indexing_concurrency < 1:
+            raise ValueError(f"indexing_concurrency must be >= 1, got {indexing_concurrency!r}")
+
         self.vault_root = vault_root
         self.curated_plane = curated_plane
         self.write_log = write_log
@@ -149,13 +157,10 @@ class VaultWatcher:
 
         if p.suffix != ".md":
             # Binary/non-markdown files aren't vault content. Emit a
-            # structured warning on every event so operators can see
-            # what landed, then skip processing. Deliberate design:
-            # operators who want a PDF/image/etc. in Musubi use
-            # /v1/artifacts/ instead of drag-dropping into the vault.
-            # See issue #221. (Per-path log dedup could help on spammy
-            # sources but adds cache-invalidation complexity — not
-            # worth the ergonomics win yet.)
+            # structured warning so operators see what landed, then
+            # skip processing. Deliberate: operators who want a
+            # PDF/image/etc. in Musubi use /v1/artifacts/ instead of
+            # drag-dropping into the vault. See issue #221.
             logger.warning(
                 "vault-skip-non-markdown path=%s suffix=%s",
                 str(rel),

--- a/src/musubi/vault/watcher.py
+++ b/src/musubi/vault/watcher.py
@@ -26,6 +26,53 @@ vault markdown (thousands of pages of text) while still catching
 runaway-plugin rewrites or hand-pasted dumps before they flood TEI
 + Qdrant. See issue #221."""
 
+_DEFAULT_EVENT_RATE_PER_SEC = 10.0
+"""Watcher dispatch rate limit (events accepted per second, token-bucket).
+Empty bucket → drop the event with a structured warning. Keeps the
+event loop healthy against noisy plugins / mass renames. See issue
+#219."""
+
+_DEFAULT_INDEXING_CONCURRENCY = 10
+"""Max concurrent in-flight `_handle_event` calls. Bounded via
+`asyncio.Semaphore` — once this many sweeps are processing, the next
+debounce fire awaits an open slot. Protects TEI + Qdrant from
+parallel-request floods while giving the event loop backpressure.
+See issue #219."""
+
+
+class _TokenBucket:
+    """Simple monotonic-clock token bucket.
+
+    Tokens refill continuously at `rate_per_sec`; the bucket caps at
+    that same rate (1-second burst capacity). `try_consume()` takes
+    one token atomically — returns True when a token was available,
+    False otherwise. Not thread-safe; the Watcher only calls it from
+    the event loop (via `call_soon_threadsafe`).
+    """
+
+    __slots__ = ("_capacity", "_last_refill", "_rate", "_tokens")
+
+    def __init__(self, rate_per_sec: float) -> None:
+        self._rate = max(rate_per_sec, 0.0)
+        self._capacity = self._rate
+        self._tokens = self._capacity
+        self._last_refill = 0.0
+
+    def try_consume(self) -> bool:
+        import time
+
+        now = time.monotonic()
+        if self._last_refill == 0.0:
+            self._last_refill = now
+        elapsed = now - self._last_refill
+        if elapsed > 0:
+            self._tokens = min(self._capacity, self._tokens + elapsed * self._rate)
+            self._last_refill = now
+        if self._tokens >= 1.0:
+            self._tokens -= 1.0
+            return True
+        return False
+
 
 class WatcherHandler(FileSystemEventHandler):
     """Bridge between watchdog events and our async sync logic."""
@@ -60,6 +107,8 @@ class VaultWatcher:
         curated_plane: CuratedPlane,
         write_log: WriteLog,
         debounce_sec: float = 2.0,
+        event_rate_per_sec: float = _DEFAULT_EVENT_RATE_PER_SEC,
+        indexing_concurrency: int = _DEFAULT_INDEXING_CONCURRENCY,
     ) -> None:
         self.vault_root = vault_root
         self.curated_plane = curated_plane
@@ -70,6 +119,11 @@ class VaultWatcher:
         self._pending_tasks: dict[str, asyncio.Task[None]] = {}
         self._observer: Any = None
         self._loop: asyncio.AbstractEventLoop | None = None
+        # Rate limit + concurrency gate — see module-level docstrings
+        # on the default constants.
+        self._event_bucket = _TokenBucket(event_rate_per_sec)
+        self._indexing_semaphore = asyncio.Semaphore(indexing_concurrency)
+        self._dropped_events = 0
 
     def enqueue_event(self, event: FileSystemEvent) -> None:
         """Schedule processing of a file event with debouncing."""
@@ -109,6 +163,18 @@ class VaultWatcher:
             )
             return
 
+        # Rate-limit gate — drop events when the bucket is empty so
+        # noisy sources (mass rename, bulk paste, plugin rewrite loops)
+        # can't spawn unbounded debounce tasks. See issue #219.
+        if not self._event_bucket.try_consume():
+            self._dropped_events += 1
+            logger.warning(
+                "vault-rate-limit-drop path=%s dropped_total=%d",
+                str(rel),
+                self._dropped_events,
+            )
+            return
+
         def _schedule() -> None:
             # Cancel existing debounce task for this path
             if path in self._pending_tasks:
@@ -139,6 +205,15 @@ class VaultWatcher:
             self._pending_tasks.pop(path_str, None)
 
     async def _handle_event(self, path_str: str, event: FileSystemEvent) -> None:
+        # Bound in-flight sweeps — when the semaphore is exhausted,
+        # subsequent handlers await here rather than dispatching new
+        # TEI/Qdrant calls. Blocking backpressure beats dropping at
+        # this layer because the debounce step already picked a
+        # canonical event per path. See issue #219.
+        async with self._indexing_semaphore:
+            await self._handle_event_inner(path_str, event)
+
+    async def _handle_event_inner(self, path_str: str, event: FileSystemEvent) -> None:
         logger.info("Handling event %s for %s", event.event_type, path_str)
         path = Path(path_str)
         if event.event_type == "moved" and hasattr(event, "dest_path"):

--- a/tests/vault/test_sync.py
+++ b/tests/vault/test_sync.py
@@ -479,14 +479,110 @@ async def test_reconciler_idempotent_on_second_run(
     assert len(plane.created) == 2  # type: ignore
 
 
-@pytest.mark.skip(reason="deferred to issue #219: vault-sync event rate limits + backpressure")
-def test_event_rate_limit_drops_with_warning() -> None:
-    pass
+@pytest.mark.asyncio
+async def test_event_rate_limit_drops_with_warning(
+    vault_root: Path,
+    write_log: WriteLog,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Token-bucket rate limit drops events past the per-second budget
+    # and emits a structured warning. 1-event/sec bucket lets the
+    # first in, drops the rest.
+    import logging
+
+    w = VaultWatcher(
+        vault_root=vault_root,
+        curated_plane=FakeCuratedPlane(),  # type: ignore
+        write_log=write_log,
+        debounce_sec=0.1,
+        event_rate_per_sec=1.0,
+    )
+    w._loop = asyncio.get_running_loop()
+
+    caplog.set_level(logging.WARNING)
+    eric_dir = vault_root / "eric" / "shared"
+    eric_dir.mkdir(parents=True, exist_ok=True)
+
+    # Burst of 5 distinct-path events; bucket caps at 1 ⇒ 1 accepted,
+    # 4 dropped.
+    for i in range(5):
+        f = eric_dir / f"rate-{i}.md"
+        f.write_text("x", encoding="utf-8")
+        w.enqueue_event(FileCreatedEvent(str(f)))
+    await asyncio.sleep(0.05)
+
+    assert len(w._pending_tasks) == 1, (
+        f"expected 1 task accepted past the rate limit; saw {len(w._pending_tasks)}"
+    )
+    assert w._dropped_events == 4
+    warnings = [r.message for r in caplog.records if "vault-rate-limit-drop" in r.message]
+    assert len(warnings) == 4, f"expected 4 drop warnings; saw {warnings}"
 
 
-@pytest.mark.skip(reason="deferred to issue #219: vault-sync event rate limits + backpressure")
-def test_indexing_rate_limit_backpressure() -> None:
-    pass
+@pytest.mark.asyncio
+async def test_indexing_rate_limit_backpressure(
+    vault_root: Path,
+    write_log: WriteLog,
+) -> None:
+    # Indexing semaphore bounds concurrent in-flight _handle_event
+    # calls. When N are in flight, the (N+1)-th awaits until one
+    # completes — blocking backpressure, not dropping.
+    import time
+
+    class _SlowPlane:
+        def __init__(self) -> None:
+            self.created: list[CuratedKnowledge] = []
+            self._active = 0
+            self.peak_concurrent = 0
+
+        async def create(self, memory: CuratedKnowledge) -> CuratedKnowledge:
+            self._active += 1
+            self.peak_concurrent = max(self.peak_concurrent, self._active)
+            # Hold the slot just long enough that the next handler
+            # must actually wait rather than zooming past.
+            await asyncio.sleep(0.05)
+            self._active -= 1
+            self.created.append(memory)
+            return memory
+
+    plane = _SlowPlane()
+    w = VaultWatcher(
+        vault_root=vault_root,
+        curated_plane=plane,  # type: ignore
+        write_log=write_log,
+        debounce_sec=0.01,
+        indexing_concurrency=2,
+    )
+    w._loop = asyncio.get_running_loop()
+
+    eric_dir = vault_root / "eric" / "shared"
+    eric_dir.mkdir(parents=True, exist_ok=True)
+
+    started = time.monotonic()
+    tasks: list[asyncio.Task[None]] = []
+    for i in range(6):
+        ksuid = generate_ksuid()
+        f = eric_dir / f"bp-{i}.md"
+        fm = {
+            "object_id": ksuid,
+            "namespace": "eric/shared/curated",
+            "title": f"T{i}",
+            "created": "2026-04-17T09:00:00Z",
+            "updated": "2026-04-17T09:00:00Z",
+        }
+        f.write_text(dump_frontmatter(fm, f"Body {i}"), encoding="utf-8")
+        tasks.append(asyncio.create_task(w._handle_event(str(f), FileCreatedEvent(str(f)))))
+
+    await asyncio.gather(*tasks)
+    elapsed = time.monotonic() - started
+
+    # All six eventually processed.
+    assert len(plane.created) == 6
+    # At most 2 ran concurrently — the semaphore held the line.
+    assert plane.peak_concurrent <= 2, f"peak concurrency breached: {plane.peak_concurrent}"
+    # 6 items / 2 slots / 50ms each ⇒ at least 3 "waves" ⇒ ~150ms.
+    # Giving generous slack for scheduler jitter.
+    assert elapsed >= 0.12, f"backpressure didn't actually slow things: {elapsed:.3f}s"
 
 
 @pytest.mark.skip(reason="Property test deferred")

--- a/tests/vault/test_sync.py
+++ b/tests/vault/test_sync.py
@@ -520,7 +520,9 @@ async def test_event_rate_limit_drops_with_warning(
         f"expected 1 task accepted past the rate limit; saw {len(w._pending_tasks)}"
     )
     assert w._dropped_events == 4
-    warnings = [r.message for r in caplog.records if "vault-rate-limit-drop" in r.message]
+    # `record.getMessage()` is the reliable read — `.message` is only
+    # populated after a Formatter runs, which pytest doesn't guarantee.
+    warnings = [r.getMessage() for r in caplog.records if "vault-rate-limit-drop" in r.getMessage()]
     assert len(warnings) == 4, f"expected 4 drop warnings; saw {warnings}"
 
 

--- a/tests/vault/test_sync.py
+++ b/tests/vault/test_sync.py
@@ -373,8 +373,13 @@ async def test_oversize_markdown_skipped_with_warning(
     eric_dir = vault_root / "eric" / "shared"
     eric_dir.mkdir(parents=True, exist_ok=True)
     file_path = eric_dir / "huge.md"
-    # 1 MB over the limit — cheap to write, clearly over.
-    file_path.write_bytes(b"x" * (_MAX_VAULT_MD_BYTES + 1024 * 1024))
+    # Sparse file 1 MB over the limit — reports the right st_size via
+    # stat(2) without actually allocating/writing the full payload, so
+    # the test stays fast on slow CI filesystems.
+    oversize_bytes = _MAX_VAULT_MD_BYTES + 1024 * 1024
+    with file_path.open("wb") as f:
+        f.seek(oversize_bytes - 1)
+        f.write(b"x")
 
     caplog.set_level(logging.WARNING)
     plane_before = len(cast(Any, watcher.curated_plane).created)
@@ -583,6 +588,32 @@ async def test_indexing_rate_limit_backpressure(
     # 6 items / 2 slots / 50ms each ⇒ at least 3 "waves" ⇒ ~150ms.
     # Giving generous slack for scheduler jitter.
     assert elapsed >= 0.12, f"backpressure didn't actually slow things: {elapsed:.3f}s"
+
+
+def test_invalid_event_rate_per_sec_rejected(vault_root: Path, write_log: WriteLog) -> None:
+    # <= 0 would mean the bucket never accumulates a token: every
+    # event dropped forever. Fail loud on ctor so operators see it.
+    for bad in (0, -1.0, 0.0):
+        with pytest.raises(ValueError, match="event_rate_per_sec"):
+            VaultWatcher(
+                vault_root=vault_root,
+                curated_plane=FakeCuratedPlane(),  # type: ignore
+                write_log=write_log,
+                event_rate_per_sec=bad,
+            )
+
+
+def test_invalid_indexing_concurrency_rejected(vault_root: Path, write_log: WriteLog) -> None:
+    # 0 would deadlock the semaphore (acquire never releases); negative
+    # raises from asyncio. Either way, fail loud on ctor.
+    for bad in (0, -1):
+        with pytest.raises(ValueError, match="indexing_concurrency"):
+            VaultWatcher(
+                vault_root=vault_root,
+                curated_plane=FakeCuratedPlane(),  # type: ignore
+                write_log=write_log,
+                indexing_concurrency=bad,
+            )
 
 
 @pytest.mark.skip(reason="Property test deferred")


### PR DESCRIPTION
Closes #219.

> **Stacked on #228 (#221).** Both touch the vault watcher so I chained them; GitHub will auto-rebase when #228 merges. Review independently.

## Summary
Two mechanisms protect the vault watcher from noisy inputs:

### 1. Event rate limit (token bucket)
Default: **10 events/sec**, settable via `event_rate_per_sec` ctor arg. When the bucket drains, excess events are **dropped** with a structured `vault-rate-limit-drop` warning naming the path + cumulative drop count. Keeps the event loop healthy against bulk renames, mass pastes, or plugin-rewrite loops that would otherwise spawn unbounded debounce tasks.

### 2. Indexing concurrency cap (asyncio semaphore)
Default: **10 in-flight**, settable via `indexing_concurrency` ctor arg. Once N sweeps are processing (reading file → parsing → calling `curated_plane.create`), the next handler **awaits an open slot** rather than launching another parallel TEI/Qdrant call. Blocking backpressure at this boundary beats dropping because the debounce stage already picked a canonical event per path.

## Implementation notes
- `_TokenBucket` is a ~20-line `__slots__` class with a monotonic-clock refill. Bucket capacity = rate (1-second burst). Not thread-safe; only called from the event loop.
- Rate-limit check runs *before* `_schedule`, so a dropped event never even creates a debounce task.
- Semaphore wraps a new `_handle_event_inner`; the public `_handle_event` method keeps its signature for existing callers (no test fallout).

## Tests
Two previously-skipped Test Contract bullets filled in:
- `test_event_rate_limit_drops_with_warning` — 1 event/sec bucket, burst of 5 distinct-path events: 1 accepted, 4 dropped, 4 structured warnings.
- `test_indexing_rate_limit_backpressure` — slow fake plane (50ms per call), concurrency=2, 6 simultaneous `_handle_event` calls: peak concurrency ≤ 2, elapsed ≥ 120ms.

## Test plan
- [x] `make check` — 1219 passed / 198 skipped / 17 deselected.
- [x] `make agent-check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)