### PR TITLE
feat(api): promote `title` to top-level on RetrieveResultRow (breaking)

### DIFF
--- a/src/musubi/api/responses.py
+++ b/src/musubi/api/responses.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class HealthResponse(BaseModel):
@@ -45,7 +45,7 @@ class RetrieveResultRow(BaseModel):
     content: str
     namespace: str
     title: str | None = None
-    extra: dict[str, Any] = {}
+    extra: dict[str, Any] = Field(default_factory=dict)
 
 
 class RetrieveResponse(BaseModel):

--- a/src/musubi/api/responses.py
+++ b/src/musubi/api/responses.py
@@ -44,6 +44,7 @@ class RetrieveResultRow(BaseModel):
     plane: str
     content: str
     namespace: str
+    title: str | None = None
     extra: dict[str, Any] = {}
 
 

--- a/src/musubi/api/routers/retrieve.py
+++ b/src/musubi/api/routers/retrieve.py
@@ -216,13 +216,14 @@ async def retrieve(
                 plane=hit.plane,
                 content=hit.snippet,
                 namespace=hit.namespace,
-                # Rich context stays in `extra` so the top-level response
-                # shape (RetrieveResultRow) doesn't break for callers that
-                # only want object_id / score / content.
+                # `title` is top-level for curated/concept/artifact (None
+                # for episodic — no stable title field on that plane).
+                # Consumers with a UI shouldn't have to reach into `extra`
+                # for a universal display field.
+                title=hit.title,
                 extra={
                     "score_components": hit.score_components,
                     "lineage": hit.lineage,
-                    "title": hit.title,
                 },
             )
         )

--- a/tests/api/test_api_v0_read.py
+++ b/tests/api/test_api_v0_read.py
@@ -900,6 +900,104 @@ def test_retrieve_result_carries_score_components_in_extra(
 
 
 # ---------------------------------------------------------------------------
+# #231 — title promoted from extra to top-level on RetrieveResultRow
+# ---------------------------------------------------------------------------
+
+
+def test_retrieve_row_surfaces_top_level_title_for_curated(
+    client: TestClient,
+    api_settings: object,
+    curated: CuratedPlane,
+) -> None:
+    """Curated/concept/artifact rows carry their ``title`` as a
+    first-class top-level field on ``RetrieveResultRow``, not buried
+    inside ``extra``. Consumers with a UI (OpenClaw corpus search,
+    any future dashboard) shouldn't have to reach into ``extra`` for
+    something every plane with a title has."""
+    import hashlib as _h
+
+    from tests.api.conftest import mint_token
+
+    namespace = "eric/claude-code/curated"
+    token = mint_token(
+        api_settings,  # type: ignore[arg-type]
+        scopes=[f"{namespace}:rw"],
+    )
+    headers = {"Authorization": f"Bearer {token}"}
+
+    async def _seed() -> None:
+        body = "A curated note about restarting the livekit agent."
+        await curated.create(
+            CuratedKnowledge(
+                namespace=namespace,
+                title="LiveKit Restart Runbook",
+                content=body,
+                vault_path="curated/eric/livekit-restart.md",
+                body_hash=_h.sha256(body.encode()).hexdigest(),
+            )
+        )
+
+    asyncio.run(_seed())
+
+    r = client.post(
+        "/v1/retrieve",
+        headers=headers,
+        json={
+            "namespace": namespace,
+            "query_text": "livekit restart",
+            "mode": "fast",
+            "limit": 5,
+        },
+    )
+    assert r.status_code == 200
+    results = r.json()["results"]
+    assert results, "expected at least one hit for a seeded curated note"
+    top = results[0]
+
+    # Top-level title must be the seeded value.
+    assert top["title"] == "LiveKit Restart Runbook", (
+        f"expected top-level title; got {top!r}"
+    )
+    # And it must NOT double-live in extra — one source of truth.
+    assert "title" not in top.get("extra", {}), (
+        f"title must not be duplicated in extra; saw {top['extra']!r}"
+    )
+
+
+def test_retrieve_row_title_is_none_for_episodic(
+    client: TestClient,
+    auth: dict[str, str],
+    episodic: EpisodicPlane,
+) -> None:
+    """Episodic memories have no stable title field, so the
+    ``title`` on a retrieved episodic row is ``None``. Optional
+    top-level field; clients render a fallback from content."""
+    namespace = "eric/claude-code/episodic"
+    _seed_episodic_batch(
+        episodic,
+        namespace,
+        ["Remember to restart the livekit agent after each driver update."],
+    )
+
+    r = client.post(
+        "/v1/retrieve",
+        headers=auth,
+        json={
+            "namespace": namespace,
+            "query_text": "livekit agent",
+            "mode": "fast",
+            "limit": 5,
+        },
+    )
+    assert r.status_code == 200
+    results = r.json()["results"]
+    assert results, "expected at least one hit for a seeded episodic memory"
+    top = results[0]
+    assert "title" in top, "title must be present on every RetrieveResultRow (may be null)"
+    assert top["title"] is None, f"episodic rows should have title=None; got {top['title']!r}"
+
+
+# ---------------------------------------------------------------------------
 # #209 — 2-segment namespace cross-plane retrieve
 # ---------------------------------------------------------------------------
 

--- a/tests/api/test_api_v0_read.py
+++ b/tests/api/test_api_v0_read.py
@@ -955,9 +955,7 @@ def test_retrieve_row_surfaces_top_level_title_for_curated(
     top = results[0]
 
     # Top-level title must be the seeded value.
-    assert top["title"] == "LiveKit Restart Runbook", (
-        f"expected top-level title; got {top!r}"
-    )
+    assert top["title"] == "LiveKit Restart Runbook", f"expected top-level title; got {top!r}"
     # And it must NOT double-live in extra — one source of truth.
     assert "title" not in top.get("extra", {}), (
         f"title must not be duplicated in extra; saw {top['extra']!r}"


### PR DESCRIPTION
Closes #231.

## Summary

`RetrieveResultRow` gains an optional top-level `title: str | None` field. The router populates it from `hit.title` for curated/concept/artifact rows and leaves it `None` for episodic (no stable title on that plane). The previous `extra[\"title\"]` duplicate is removed — one source of truth for the display field.

## Why breaking is fine here

- No external consumer currently reads `extra.title`. openclaw-musubi's review (finding #39) confirmed the plugin doesn't surface the title at all today — so the breaking window is now, before v1.0 cut.
- `title` is a first-class display field for 3 of 4 planes. Burying it in `extra` forced every UI consumer to reach through a dict for something every row-with-a-title has.
- Openapi regen picks up the new field on next build; SDK clients gain `result.title` natively.

## Changes

- `src/musubi/api/responses.py` — `RetrieveResultRow.title: str | None = None` added.
- `src/musubi/api/routers/retrieve.py` — router populates top-level `title`, drops `\"title\"` from the `extra` dict.
- `tests/api/test_api_v0_read.py` — two new tests:
  - `test_retrieve_row_surfaces_top_level_title_for_curated` — seeds a curated note, asserts top-level `title` populated, asserts `extra.title` is gone.
  - `test_retrieve_row_title_is_none_for_episodic` — episodic rows have `title=None` (not absent key, not missing).

## Test plan

- [x] `make check` green (1229 passed).
- [x] New tests fail against `main` (confirmed before implementation).
- [x] Existing `test_retrieve_result_carries_score_components_in_extra` still passes (extra still carries `score_components` + `lineage`).

## Related

- Review finding #39 — covers the retrieve row case.
- GET-by-id endpoints already return top-level `title` today (plane types have required `title: str`), so no additional work on that front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)