### PR TITLE
chore(auth): remove dead `thoughts:check` / `thoughts:send` keyword-scope functions

### DIFF
--- a/docs/Musubi/07-interfaces/canonical-api.md
+++ b/docs/Musubi/07-interfaces/canonical-api.md
@@ -53,7 +53,8 @@ The scope matcher (see [[10-security/auth]] and `src/musubi/auth/scopes.py`) req
 | `POST /v1/retrieve` with **3-segment** namespace | body `namespace` | 3 | `r` on that one namespace |
 | `POST /v1/retrieve` with **2-segment** namespace + `planes` array | body `namespace` + `planes` | 2 (base) + strict per-plane check on each expansion | `r` on the 2-seg base **and** `r` on every `<namespace>/<plane>` target |
 | `POST /v1/thoughts/send` | body (derives `<tenant>/<presence>/thought`) | 3 | `w` |
-| `POST /v1/thoughts/check`, `/read`, `/history` | body `namespace` | 3 (`<tenant>/<presence>/thought`) | `r` |
+| `POST /v1/thoughts/read` | body `namespace` | 3 (`<tenant>/<presence>/thought`) | `w` (marking read mutates state) |
+| `POST /v1/thoughts/check`, `/history` | body `namespace` | 3 (`<tenant>/<presence>/thought`) | `r` |
 | `GET /v1/thoughts/stream` | query `namespace` | **2** (`<tenant>/<presence>`) | `r` on the 2-segment namespace |
 | `POST /v1/lifecycle/*`, `POST /v1/contradictions/resolve`, `POST /v1/ops/reindex` | n/a | operator scope | `operator` |
 | `GET /v1/namespaces[/{ns}/stats]` | n/a | operator scope for listing; own-namespace read otherwise | varies |
@@ -74,7 +75,7 @@ eric/_shared/concept:r     # read shared concepts
 
 Notes:
 
-- There is **no separate `thoughts:check:<presence>` scope**. Every thoughts endpoint checks the standard `<tenant>/<presence>/thought` 3-segment namespace — `/check`, `/read`, `/history` need `:r`; `/send` needs `:w`. Both are covered by the `<tenant>/<presence>/*:rw` wildcard.
+- There is **no separate `thoughts:check:<presence>` scope**. Every thoughts endpoint checks the standard `<tenant>/<presence>/thought` 3-segment namespace — `/check` and `/history` need `:r`; `/send` and `/read` need `:w` (the `/read` endpoint marks thoughts as read, which mutates state). All of these are covered by the `<tenant>/<presence>/*:rw` wildcard.
 - `<tenant>/_shared/curated:r` + `<tenant>/_shared/concept:r` are the cross-presence read scopes — required if the presence wants to see knowledge the Lifecycle Worker has promoted from any other presence in the same tenant. Omit them if the presence should only see its own curated/concept output.
 - For an **operator** token (admin UI, ops scripts), replace the presence-scoped entries with `operator` — that covers admin endpoints (`/v1/lifecycle/*`, `/v1/contradictions/resolve`, `/v1/ops/reindex`) and implicit broad read.
 

--- a/docs/Musubi/10-security/auth.md
+++ b/docs/Musubi/10-security/auth.md
@@ -52,11 +52,10 @@ JWT, RS256 signed:
   "exp": 1744896000,                   // 1h
   "jti": "abc-123",
   "scope": [
-    "eric/claude-code/episodic:rw",
+    "eric/claude-code:r",
+    "eric/claude-code/*:rw",
     "eric/_shared/curated:r",
-    "eric/_shared/artifact:rw",
-    "thoughts:send",
-    "thoughts:check:claude-code"
+    "eric/_shared/artifact:rw"
   ],
   "presence": "eric/claude-code"
 }
@@ -91,10 +90,15 @@ Access level:
 
 Non-namespace scopes (special):
 
-- `thoughts:send` — may send thoughts.
-- `thoughts:check:<presence>` — may check inbox for the named presence.
-- `thoughts:history:<presence>` — may search history of the named presence.
 - `operator` — admin endpoints.
+
+**Thoughts scopes** — there is **no** separate `thoughts:send` / `thoughts:check:<presence>` / `thoughts:history:<presence>` keyword scope. Every thoughts endpoint (send, check, read, history, stream) checks against the standard namespace-scope form. See [[07-interfaces/canonical-api#scope-by-endpoint]] for the full table; the short version:
+
+- `POST /v1/thoughts/send` → 3-segment `<tenant>/<presence>/thought:w`
+- `POST /v1/thoughts/check` / `/read` / `/history` → 3-segment `<tenant>/<presence>/thought:r`
+- `GET /v1/thoughts/stream` → 2-segment `<tenant>/<presence>:r`
+
+A token with `<tenant>/<presence>:r` + `<tenant>/<presence>/*:rw` covers every thoughts flow for that presence.
 
 ## Signing key
 
@@ -132,29 +136,27 @@ clients:
     redirect_uris: ["chrome-extension://<ext-id>/oauth/callback",
                     "http://localhost:<port>/oauth/callback"]
     allowed_scopes:
-      - eric/claude-code/episodic:rw
+      - eric/claude-code:r
+      - eric/claude-code/*:rw
       - eric/_shared/curated:r
-      - thoughts:send
-      - thoughts:check:claude-code
     public: true    # PKCE only, no client secret
 
   - client_id: musubi-livekit
     redirect_uris: ["http://localhost:8200/oauth/callback"]
     allowed_scopes:
-      - eric/livekit-voice/episodic:rw
-      - eric/_shared/blended:r
+      - eric/livekit-voice:r
+      - eric/livekit-voice/*:rw
+      - eric/_shared/curated:r
+      - eric/_shared/concept:r
       - eric/_shared/artifact:rw
-      - thoughts:send
-      - thoughts:check:livekit-voice
     public: true
 
   - client_id: musubi-openclaw
     redirect_uris: ["chrome-extension://<ext-id>/oauth/callback"]
     allowed_scopes:
-      - eric/openclaw/episodic:rw
+      - eric/openclaw:r
+      - eric/openclaw/*:rw
       - eric/_shared/curated:r
-      - thoughts:send
-      - thoughts:check:openclaw
     public: true
 ```
 
@@ -172,8 +174,9 @@ On each request Core:
 6. Per-endpoint scope check:
    - Capture → `<namespace>:w`.
    - Retrieve → `<namespace>:r` (or read any of the planes named in the query).
-   - Thought send → `thoughts:send` + recipient must be a known presence.
-   - Thought check → `thoughts:check:<my_presence>`.
+   - Thought send → `<tenant>/<presence>/thought:w` + recipient must be a known presence.
+   - Thought check / read / history → `<tenant>/<presence>/thought:r`.
+   - Thought stream (SSE) → `<tenant>/<presence>:r` (2-segment).
    - Operator endpoint → `operator`.
 7. If check fails, 403 with structured error.
 
@@ -249,7 +252,7 @@ Authorization: Bearer <token with scope eric/claude-code/episodic:rw>
 
 ```
 POST /v1/thoughts/check
-Authorization: Bearer <token with presence=claude-code, scope thoughts:check:claude-code>
+Authorization: Bearer <token with presence=claude-code, scope eric/claude-code/thought:r>
 
 {"my_presence": "livekit-voice"}
 ```

--- a/docs/Musubi/10-security/auth.md
+++ b/docs/Musubi/10-security/auth.md
@@ -95,7 +95,8 @@ Non-namespace scopes (special):
 **Thoughts scopes** — there is **no** separate `thoughts:send` / `thoughts:check:<presence>` / `thoughts:history:<presence>` keyword scope. Every thoughts endpoint (send, check, read, history, stream) checks against the standard namespace-scope form. See [[07-interfaces/canonical-api#scope-by-endpoint]] for the full table; the short version:
 
 - `POST /v1/thoughts/send` → 3-segment `<tenant>/<presence>/thought:w`
-- `POST /v1/thoughts/check` / `/read` / `/history` → 3-segment `<tenant>/<presence>/thought:r`
+- `POST /v1/thoughts/read` → 3-segment `<tenant>/<presence>/thought:w` (marking read mutates state)
+- `POST /v1/thoughts/check` / `/history` → 3-segment `<tenant>/<presence>/thought:r`
 - `GET /v1/thoughts/stream` → 2-segment `<tenant>/<presence>:r`
 
 A token with `<tenant>/<presence>:r` + `<tenant>/<presence>/*:rw` covers every thoughts flow for that presence.
@@ -175,7 +176,8 @@ On each request Core:
    - Capture → `<namespace>:w`.
    - Retrieve → `<namespace>:r` (or read any of the planes named in the query).
    - Thought send → `<tenant>/<presence>/thought:w` + recipient must be a known presence.
-   - Thought check / read / history → `<tenant>/<presence>/thought:r`.
+   - Thought read (mark as read) → `<tenant>/<presence>/thought:w` (state mutation).
+   - Thought check / history → `<tenant>/<presence>/thought:r`.
    - Thought stream (SSE) → `<tenant>/<presence>:r` (2-segment).
    - Operator endpoint → `operator`.
 7. If check fails, 403 with structured error.
@@ -248,16 +250,16 @@ Authorization: Bearer <token with scope eric/claude-code/episodic:rw>
 }
 ```
 
-## Example: thought inbox check mismatch
+## Example: thought inbox namespace mismatch
 
 ```
 POST /v1/thoughts/check
-Authorization: Bearer <token with presence=claude-code, scope eric/claude-code/thought:r>
+Authorization: Bearer <token with presence=eric/claude-code, scope eric/claude-code/thought:r>
 
-{"my_presence": "livekit-voice"}
+{"namespace": "eric/livekit-voice/thought", "presence": "livekit-voice"}
 ```
 
-→ 403. Tokens can only check their own presence's inbox.
+→ 403. The request body's `namespace` is `eric/livekit-voice/thought` but the token's scope only grants `eric/claude-code/thought:r`. The scope matcher compares the requested namespace against the token's scope list verbatim — no implicit presence-of-token check.
 
 ## Auditing
 
@@ -287,11 +289,10 @@ Denials have `event: auth.deny` + `reason: ...`. 30-day retention; operator-only
 4. `test_scope_match_grants_access`
 5. `test_scope_mismatch_returns_403_with_detail`
 6. `test_operator_scope_required_for_admin_endpoints`
-7. `test_thought_check_scope_is_presence_specific`
-8. `test_blended_query_expands_and_checks_plane_scopes`
-9. `test_pkce_flow_end_to_end` (integration)
-10. `test_refresh_token_rotation_issues_new_refresh`
-11. `test_revocation_invalidates_token_within_60s_cache`
-12. `test_signing_key_rotation_dual_verify_period`
-13. `test_every_auth_decision_emits_audit_line`
-14. `test_operator_issued_only_via_cli`
+7. `test_blended_query_expands_and_checks_plane_scopes`
+8. `test_pkce_flow_end_to_end` (integration)
+9. `test_refresh_token_rotation_issues_new_refresh`
+10. `test_revocation_invalidates_token_within_60s_cache`
+11. `test_signing_key_rotation_dual_verify_period`
+12. `test_every_auth_decision_emits_audit_line`
+13. `test_operator_issued_only_via_cli`

--- a/src/musubi/auth/scopes.py
+++ b/src/musubi/auth/scopes.py
@@ -116,60 +116,6 @@ def require_operator_scope(context: AuthContext) -> Result[ScopeGrant, ScopeErro
     return Err(error=ScopeError(detail=detail))
 
 
-def require_thought_check_scope(
-    context: AuthContext,
-    *,
-    presence: str,
-) -> Result[ScopeGrant, ScopeError]:
-    """Require ``thoughts:check:<presence>`` for the presence's inbox."""
-
-    requested_presence = presence.rsplit("/", maxsplit=1)[-1]
-    token_presence = context.presence.rsplit("/", maxsplit=1)[-1]
-    expected_scope = f"thoughts:check:{requested_presence}"
-
-    if requested_presence == token_presence and expected_scope in context.scopes:
-        _audit(
-            "auth.allow", context, namespace=expected_scope, scope_used=expected_scope, access="r"
-        )
-        return Ok(
-            value=ScopeGrant(
-                subject=context.subject,
-                namespace=expected_scope,
-                access="r",
-                scope_used=expected_scope,
-            )
-        )
-
-    detail = f"thought check scope for {presence!r} not in token scope"
-    _audit(
-        "auth.deny", context, namespace=expected_scope, scope_used=None, access="r", reason=detail
-    )
-    return Err(error=ScopeError(detail=detail))
-
-
-def require_thought_send_scope(context: AuthContext) -> Result[ScopeGrant, ScopeError]:
-    """Require ``thoughts:send`` for thought send endpoints."""
-
-    if "thoughts:send" in context.scopes:
-        _audit(
-            "auth.allow", context, namespace="thoughts:send", scope_used="thoughts:send", access="w"
-        )
-        return Ok(
-            value=ScopeGrant(
-                subject=context.subject,
-                namespace="thoughts:send",
-                access="w",
-                scope_used="thoughts:send",
-            )
-        )
-
-    detail = "thoughts:send scope required"
-    _audit(
-        "auth.deny", context, namespace="thoughts:send", scope_used=None, access="w", reason=detail
-    )
-    return Err(error=ScopeError(detail=detail))
-
-
 def _namespace_scope_allows(scope: str, namespace: str, access: AccessLevel) -> bool:
     parsed = _parse_namespace_scope(scope)
     if parsed is None:
@@ -233,8 +179,6 @@ __all__ = [
     "ScopeError",
     "ScopeGrant",
     "require_operator_scope",
-    "require_thought_check_scope",
-    "require_thought_send_scope",
     "resolve_blended_query_scope",
     "resolve_namespace_scope",
 ]

--- a/tests/auth/test_auth.py
+++ b/tests/auth/test_auth.py
@@ -20,8 +20,6 @@ from musubi.auth.middleware import AuthRequirement, authenticate_request
 from musubi.auth.scopes import (
     ScopeError,
     require_operator_scope,
-    require_thought_check_scope,
-    require_thought_send_scope,
     resolve_blended_query_scope,
     resolve_namespace_scope,
 )
@@ -83,9 +81,7 @@ def _payload(
         "iat": int(now.timestamp()),
         "exp": int((now + expires_delta).timestamp()),
         "jti": "token-123",
-        "scope": scopes
-        if scopes is not None
-        else ["eric/claude-code/episodic:rw", "thoughts:check:claude-code"],
+        "scope": scopes if scopes is not None else ["eric/claude-code/episodic:rw"],
         "presence": presence,
     }
 
@@ -214,25 +210,6 @@ def test_operator_scope_required_for_admin_endpoints() -> None:
     assert isinstance(denied.error, ScopeError)
     assert denied.error.status_code == 403
     assert allowed.is_ok()
-
-
-def test_thought_check_scope_is_presence_specific() -> None:
-    context = AuthContext(
-        subject="eric-claude-code",
-        issuer="https://auth.example.test",
-        audience="musubi",
-        scopes=("thoughts:check:claude-code",),
-        presence="eric/claude-code",
-        token_id="token-123",
-    )
-
-    own_inbox = require_thought_check_scope(context, presence="claude-code")
-    other_inbox = require_thought_check_scope(context, presence="livekit-voice")
-
-    assert own_inbox.is_ok()
-    assert other_inbox.is_err()
-    assert isinstance(other_inbox, Err)
-    assert "livekit-voice" in other_inbox.error.detail
 
 
 def test_blended_query_expands_and_checks_plane_scopes() -> None:
@@ -374,7 +351,7 @@ def test_validate_token_rejects_bad_signature_and_claim_shapes(
         _hs_token(auth_settings, invalid_jti_payload), settings=auth_settings
     )
     scope_string_payload = _payload(scopes=None)
-    scope_string_payload["scope"] = "eric/*/episodic:r thoughts:send"
+    scope_string_payload["scope"] = "eric/*/episodic:r eric/_shared/curated:r"
     scope_string = validate_token(
         _hs_token(auth_settings, scope_string_payload), settings=auth_settings
     )
@@ -387,7 +364,7 @@ def test_validate_token_rejects_bad_signature_and_claim_shapes(
     assert isinstance(invalid_jti, Err)
     assert "JWT ID" in invalid_jti.error.detail
     assert isinstance(scope_string, Ok)
-    assert scope_string.value.scopes == ("eric/*/episodic:r", "thoughts:send")
+    assert scope_string.value.scopes == ("eric/*/episodic:r", "eric/_shared/curated:r")
 
 
 def test_rs256_validation_handles_jwks_failures(
@@ -499,20 +476,10 @@ def test_special_glob_and_invalid_namespace_scopes() -> None:
         issuer="https://auth.example.test",
         audience="musubi",
         scopes=(
-            "thoughts:send",
             "**:r",
             "eric/*/episodic:w",
             "malformed",
-            "thoughts:check:claude-code",
         ),
-        presence="eric/claude-code",
-        token_id="token-123",
-    )
-    no_send_context = AuthContext(
-        subject="eric-claude-code",
-        issuer="https://auth.example.test",
-        audience="musubi",
-        scopes=("eric/claude-code/episodic:r",),
         presence="eric/claude-code",
         token_id="token-123",
     )
@@ -525,8 +492,6 @@ def test_special_glob_and_invalid_namespace_scopes() -> None:
         token_id="token-123",
     )
 
-    send_allowed = require_thought_send_scope(context)
-    send_denied = require_thought_send_scope(no_send_context)
     operator_read = resolve_namespace_scope(context, namespace="any/namespace/here", access="r")
     wildcard_write = resolve_namespace_scope(
         context,
@@ -539,8 +504,6 @@ def test_special_glob_and_invalid_namespace_scopes() -> None:
         access="r",
     )
 
-    assert isinstance(send_allowed, Ok)
-    assert isinstance(send_denied, Err)
     assert isinstance(operator_read, Ok)
     assert operator_read.value.scope_used == "**:r"
     assert isinstance(wildcard_write, Ok)


### PR DESCRIPTION
Closes #235.

## Summary

`require_thought_check_scope` and `require_thought_send_scope` in `src/musubi/auth/scopes.py` were defined, exported, and tested but had **zero production callers**. Every live thoughts endpoint uses the namespace-based `AuthRequirement(namespace=<ns>, access=<r|w>)` pattern instead. The canonical-api.md scope table already documents this — this PR just makes the code match.

## Code changes

- `src/musubi/auth/scopes.py` — deleted both functions + their entries in `__all__`.
- `tests/auth/test_auth.py`:
  - Removed the imports.
  - Deleted `test_thought_check_scope_is_presence_specific` (the only dedicated test).
  - Trimmed `test_special_glob_and_invalid_namespace_scopes` — removed the `send_allowed` / `send_denied` assertions and the now-dead `thoughts:send` / `thoughts:check:claude-code` entries from the context scopes tuple.
  - `_payload()` test helper default: dropped `thoughts:check:claude-code` from the default scopes.
  - Scope-string-parser test: swapped the `thoughts:send` test value for `eric/_shared/curated:r` so the space-split parsing assertion still covers what it's meant to.

## Docs updates (`docs/Musubi/10-security/auth.md`)

- Example JWT scope list updated to the 2-seg + 3-seg wildcard form per the v1.0 scope convention.
- "Non-namespace scopes (special)" section now states explicitly that there is **no** separate `thoughts:send` / `thoughts:check:<presence>` / `thoughts:history:<presence>` scope, with a short table mapping thoughts endpoints to their namespace-scope requirements.
- OAuth client-registry examples (`musubi-mcp`, `musubi-livekit`, `musubi-openclaw`) flipped to the new scope shape.
- Validation-pipeline bullets updated.
- Example "thought inbox check mismatch" uses the namespace-form scope.

## Test plan

- [x] `make check` — 1241 passed, 196 skipped.
- [x] `make agent-check` — clean.
- [x] `pytest tests/integration/ -m integration --collect-only` — clean (17 tests collect).
- [x] No remaining live references to `require_thought_check_scope`, `require_thought_send_scope`, `thoughts:check:<presence>`, or `thoughts:send` in `src/`, `tests/`, or `docs/` (confirmed via grep). The only remaining matches are the existing `canonical-api.md` disclaimer (says the scopes don't exist) and the historical design note in `slice-api-thoughts-stream.md`.

## Why pre-v1.0

Dead code was misleading anyone reading `auth/scopes.py`. With v1.0 imminent, the last window to delete it cleanly (no consumers, no deprecation window needed). The canonical-api.md scope-by-endpoint table already established the namespace-form as the single authority; this commit puts the code in the same state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)