### PR TITLE
chore(docs): v1.0 release-readiness doc audit + migration SDK rename catch

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ make install
 make check
 ```
 
-A single-box Docker Compose deploy is laid out in [`deploy/ansible/templates/docker-compose.yml.j2`](deploy/ansible/templates/docker-compose.yml.j2); a first-deploy runbook lives at [`deploy/runbooks/upgrade-image.md`](deploy/runbooks/upgrade-image.md). The published image is:
+A single-box Docker Compose deploy is laid out in [`deploy/ansible/templates/docker-compose.yml.j2`](deploy/ansible/templates/docker-compose.yml.j2); a first-deploy runbook lives at [`deploy/runbooks/upgrade-image.md`](deploy/runbooks/upgrade-image.md). Pick a version from the latest-release badge above and pull:
 
 ```
-ghcr.io/ericmey/musubi-core:v0.3.0
+ghcr.io/ericmey/musubi-core:<version>
 ```
 
 Verify the signature before pinning in production:
@@ -85,7 +85,7 @@ Verify the signature before pinning in production:
 cosign verify \
   --certificate-identity-regexp 'https://github.com/ericmey/musubi/.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  ghcr.io/ericmey/musubi-core:v0.3.0
+  ghcr.io/ericmey/musubi-core:<version>
 ```
 
 ## Repository layout
@@ -112,19 +112,23 @@ deploy/                     ansible, prometheus, grafana, docker-compose templat
 
 ## Status
 
-**v0.3.0** (released 2026-04-21) — the first public release. Feature-complete for:
+**v0.6.0 — the v1.0 release candidate.** Pre-1.0 API shape is locked; the breaking changes that were going to land before 1.0 are in. If nothing major regresses in downstream-adapter validation, v1.0 ships next.
 
-- ✅ All five lifecycle sweeps running in production (maturation, synthesis, promotion, demotion, reflection)
-- ✅ Hybrid retrieval (dense BGE-M3 + sparse SPLADE + BGE-reranker)
-- ✅ Full HTTP/gRPC API surface
-- ✅ MCP + LiveKit adapter first cuts
+What's in the v1.0-candidate surface:
+
+- ✅ All five lifecycle sweeps (maturation, synthesis, promotion, demotion, reflection) running on cron, SQLite-journaled, with a hard three-strikes rejection cap on promotion
+- ✅ Hybrid retrieval — dense BGE-M3 + sparse SPLADE + BGE-reranker + 2-segment cross-plane fanout in one call
+- ✅ Full HTTP surface (gRPC partial; lives behind an opt-in build flag)
+- ✅ Plane-aligned endpoint paths: `/v1/episodic`, `/v1/curated`, `/v1/concepts`, `/v1/artifacts`
+- ✅ `Last-Event-ID` replay on `/v1/thoughts/stream` — reconnect without losing thoughts
+- ✅ MCP + LiveKit + OpenClaw adapters (external repos), static-bearer auth model with per-agent token support
 - ✅ Supply-chain: cosign + SBOM + Trivy on every published image
-- ✅ Homelab deployment wired, containers healthy
+- ✅ Operator tooling: `musubi promote force|reject` CLI, vault large-file skip-with-warning, rate-limited vault watcher
 
 Not yet:
-- ⏳ Fleet orchestration — single-node today; multi-node HA is a post-1.0 design space and will require a real ADR
-- ⏳ Auto-deploy pipeline
-- ⏳ OpenClaw adapter integration tests
+- ⏳ Fleet orchestration — single-node today; multi-node HA is a post-1.0 design space and will need its own ADR
+- ⏳ Auto-deploy pipeline (image publish is automated; host rollout is still operator-driven via ansible)
+- ⏳ gRPC transport ADR ([#98](https://github.com/ericmey/musubi/issues/98)) — priority-low, not a 1.0 blocker
 
 Roadmap detail lives in [`docs/Musubi/12-roadmap/`](docs/Musubi/12-roadmap/).
 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,13 @@ make install
 make check
 ```
 
-A single-box Docker Compose deploy is laid out in [`deploy/ansible/templates/docker-compose.yml.j2`](deploy/ansible/templates/docker-compose.yml.j2); a first-deploy runbook lives at [`deploy/runbooks/upgrade-image.md`](deploy/runbooks/upgrade-image.md). Pick a version from the latest-release badge above and pull:
+A single-box Docker Compose deploy is laid out in [`deploy/ansible/templates/docker-compose.yml.j2`](deploy/ansible/templates/docker-compose.yml.j2); a first-deploy runbook lives at [`deploy/runbooks/upgrade-image.md`](deploy/runbooks/upgrade-image.md). Pin by digest — tags are mutable, digests aren't, and the rest of the repo (ansible, CI, SECURITY.md) verifies by digest:
 
 ```
-ghcr.io/ericmey/musubi-core:<version>
+ghcr.io/ericmey/musubi-core@sha256:<digest>
 ```
+
+Find the digest for a specific release on its GitHub Release page (the `publish-core-image` workflow attaches it) or via `docker buildx imagetools inspect ghcr.io/ericmey/musubi-core:<version>`.
 
 Verify the signature before pinning in production:
 
@@ -85,7 +87,7 @@ Verify the signature before pinning in production:
 cosign verify \
   --certificate-identity-regexp 'https://github.com/ericmey/musubi/.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  ghcr.io/ericmey/musubi-core:<version>
+  ghcr.io/ericmey/musubi-core@sha256:<digest>
 ```
 
 ## Repository layout
@@ -118,7 +120,7 @@ What's in the v1.0-candidate surface:
 
 - ✅ All five lifecycle sweeps (maturation, synthesis, promotion, demotion, reflection) running on cron, SQLite-journaled, with a hard three-strikes rejection cap on promotion
 - ✅ Hybrid retrieval — dense BGE-M3 + sparse SPLADE + BGE-reranker + 2-segment cross-plane fanout in one call
-- ✅ Full HTTP surface (gRPC partial; lives behind an opt-in build flag)
+- ✅ Full HTTP surface (gRPC partial; lives behind the runtime flag `MUSUBI_GRPC`, default off)
 - ✅ Plane-aligned endpoint paths: `/v1/episodic`, `/v1/curated`, `/v1/concepts`, `/v1/artifacts`
 - ✅ `Last-Event-ID` replay on `/v1/thoughts/stream` — reconnect without losing thoughts
 - ✅ MCP + LiveKit + OpenClaw adapters (external repos), static-bearer auth model with per-agent token support

--- a/deploy/migration/poc-to-v1.py
+++ b/deploy/migration/poc-to-v1.py
@@ -150,7 +150,7 @@ def migrate_memories(
                 # Since the API drops extra fields, if we pass them to the SDK `client._json` as `json_body`,
                 # they will be ignored by `CaptureRequest`.
                 # We will send it, and if it loses `created_at`, it is an API deficiency that must be fixed in a cross-slice ticket.
-                target_client.memories.capture(
+                target_client.episodic.capture(
                     namespace=namespace,
                     content=payload.get("content", ""),
                     tags=payload.get("tags", []),

--- a/deploy/migration/poc-to-v1.py
+++ b/deploy/migration/poc-to-v1.py
@@ -144,18 +144,20 @@ def migrate_memories(
             EpisodicMemory.model_validate(new_payload)
 
             if not dry_run:
-                # The SDK capture method does NOT currently support overriding created_at.
-                # However, the SDK `_json` method allows us to send the raw validated model directly
-                # if we manually hit the Qdrant endpoint? No, we MUST use the SDK.
-                # Since the API drops extra fields, if we pass them to the SDK `client._json` as `json_body`,
-                # they will be ignored by `CaptureRequest`.
-                # We will send it, and if it loses `created_at`, it is an API deficiency that must be fixed in a cross-slice ticket.
+                # Preserve the source-truth timestamp by passing the
+                # parsed `created_at` through. The SDK's capture method
+                # supports it as an operator-only escape hatch
+                # (CaptureRequest.created_at on the server); migrations
+                # need operator scope anyway. Without this, the row
+                # would get re-stamped at ingest time and we'd lose
+                # the historical timeline from the PoC.
                 target_client.episodic.capture(
                     namespace=namespace,
                     content=payload.get("content", ""),
                     tags=payload.get("tags", []),
                     topics=[payload.get("type")] if payload.get("type") else [],
                     importance=5,
+                    created_at=_ensure_utc(created_at_str),
                     idempotency_key=_ksuid_from_uuid(
                         row_id, created_epoch
                     ),  # Deterministic ID mapping!

--- a/docs/Musubi/07-interfaces/mcp-adapter.md
+++ b/docs/Musubi/07-interfaces/mcp-adapter.md
@@ -32,15 +32,17 @@ Same core logic; different MCP server bootstrap.
 
 We expose the subset of Musubi that makes sense for a coding agent. Not everything.
 
+**Implementation status:** the current adapter (`src/musubi/adapters/mcp/tools.py`) registers `memory_capture` + `memory_recall` — enough for the v1.0 cut. The rest of the tables below is the **designed** MCP surface; unchecked rows are tracked in `[[_slices/slice-adapter-mcp]]` as follow-up work, not v1.0 scope.
+
 ### Memory
 
-| Tool | Musubi call | Notes |
-|---|---|---|
-| `memory_capture` | `client.episodic.capture()` | Capture a new episodic observation. |
-| `memory_recall` | `client.retrieve(mode="fast")` | Retrieve for just-in-time context. |
-| `memory_recent` | Filtered retrieve | Recent items in a namespace. |
-| `memory_forget` | `client.episodic.archive(id)` | Soft-archive. |
-| `memory_reflect` | Filtered retrieve + aggregation | Returns counts by tag/topic (no LLM). |
+| Tool | Status | Musubi call | Notes |
+|---|---|---|---|
+| `memory_capture` | shipped | `client.episodic.capture()` | Capture a new episodic observation. |
+| `memory_recall` | shipped | `client.retrieve(mode="fast")` | Retrieve for just-in-time context. |
+| `memory_recent` | planned | Filtered retrieve | Recent items in a namespace. |
+| `memory_forget` | planned | Raw `DELETE /v1/episodic/{id}` (SDK method TBD) | Soft-archive. No `client.episodic.archive()` on the SDK yet. |
+| `memory_reflect` | planned | Filtered retrieve + aggregation | Returns counts by tag/topic (no LLM). |
 
 ### Curated
 

--- a/docs/Musubi/07-interfaces/mcp-adapter.md
+++ b/docs/Musubi/07-interfaces/mcp-adapter.md
@@ -36,10 +36,10 @@ We expose the subset of Musubi that makes sense for a coding agent. Not everythi
 
 | Tool | Musubi call | Notes |
 |---|---|---|
-| `memory_capture` | `client.memories.capture()` | Capture a new episodic observation. |
+| `memory_capture` | `client.episodic.capture()` | Capture a new episodic observation. |
 | `memory_recall` | `client.retrieve(mode="fast")` | Retrieve for just-in-time context. |
 | `memory_recent` | Filtered retrieve | Recent items in a namespace. |
-| `memory_forget` | `client.memories.archive(id)` | Soft-archive. |
+| `memory_forget` | `client.episodic.archive(id)` | Soft-archive. |
 | `memory_reflect` | Filtered retrieve + aggregation | Returns counts by tag/topic (no LLM). |
 
 ### Curated

--- a/docs/Musubi/07-interfaces/openapi/musubi.v1.yaml
+++ b/docs/Musubi/07-interfaces/openapi/musubi.v1.yaml
@@ -85,7 +85,7 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/HitList" }
 
-  /curated-knowledge/{id}:
+  /curated/{id}:
     get:
       tags: [curated]
       operationId: getCurated
@@ -120,22 +120,9 @@ paths:
       responses:
         "202": { description: Accepted for ingestion. }
 
-  /retrieve/blended:
-    post:
-      tags: [retrieve]
-      operationId: retrieveBlended
-      summary: Deep path — hybrid + rerank across planes.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema: { $ref: "#/components/schemas/BlendedRequest" }
-      responses:
-        "200":
-          description: Ranked cross-plane hits.
-          content:
-            application/json:
-              schema: { $ref: "#/components/schemas/HitList" }
+  # Cross-plane retrieve is served by POST /retrieve with a 2-segment
+  # namespace + a `planes` array per ADR-0028. There is no separate
+  # /retrieve/blended path; earlier skeleton drafts listed one.
 
   /thoughts:
     post:

--- a/docs/Musubi/07-interfaces/sdk.md
+++ b/docs/Musubi/07-interfaces/sdk.md
@@ -169,7 +169,7 @@ One `httpx.Client` per SDK instance. Connection pool sized to max concurrency on
 
 ## Telemetry hooks
 
-The SDK emits OpenTelemetry spans (when OTel is configured in the adapter) for each call. Span name matches the method (`musubi.memories.capture`). Default attributes: `http.method`, `http.url`, `musubi.namespace`, `musubi.duration_ms`.
+The SDK emits OpenTelemetry spans (when OTel is configured in the adapter) for each call. Span name matches the method (`musubi.episodic.capture`). Default attributes: `http.method`, `http.url`, `musubi.namespace`, `musubi.duration_ms`.
 
 If the adapter sets `X-Request-Id` in the caller's context, the SDK propagates it as a header for end-to-end tracing.
 

--- a/docs/Musubi/proto/musubi/v1/musubi.proto
+++ b/docs/Musubi/proto/musubi/v1/musubi.proto
@@ -35,8 +35,10 @@ service MusubiService {
   // Artifact ingestion (note: gRPC version uses byte stream; see streaming below).
   rpc IngestArtifact  (stream IngestArtifactChunk) returns (IngestArtifactResponse);
 
-  // Retrieval — cross-plane blended.
-  rpc RetrieveBlended (BlendedRequest)         returns (HitList);
+  // Cross-plane retrieve is served by RecallEpisodic above with a
+  // 2-segment (tenant/presence) namespace plus a `planes` field in
+  // RecallRequest per ADR-0028. There is no separate RetrieveBlended
+  // RPC; earlier spec drafts listed one.
 
   // Thoughts (durable inter-presence messages).
   rpc SendThought     (SendThoughtRequest)     returns (SendThoughtResponse);

--- a/scripts/perf/seed_corpus.py
+++ b/scripts/perf/seed_corpus.py
@@ -358,7 +358,7 @@ def seed_episodic(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> 
         }
         r = post_with_backoff(
             client,
-            "/memories",
+            "/episodic",
             rng=progress_rng,
             json_body=body,
             extra_headers={"Idempotency-Key": make_idempotency_key(ns, content, ts)},
@@ -421,7 +421,7 @@ def seed_curated(client: httpx.Client, cfg: SeedConfig, rng: random.Random) -> i
             "body_hash": body_hash,
             "tags": rng.sample(_TOPICS, k=rng.randint(1, 3)),
         }
-        r = post_with_backoff(client, "/curated-knowledge", rng=backoff_rng, json_body=body)
+        r = post_with_backoff(client, "/curated", rng=backoff_rng, json_body=body)
         if r is not None and r.is_success:
             ok += 1
         elif r is not None:

--- a/src/musubi/adapters/livekit/adapter.py
+++ b/src/musubi/adapters/livekit/adapter.py
@@ -147,7 +147,7 @@ class LiveKitAdapter:
                 else:
                     # Fall back to the SDK's canonical artifacts.upload
                     # surface when it ships; until then, route through
-                    # memories.capture so the adapter is always live.
+                    # episodic.capture so the adapter is always live.
                     await self.client.episodic.capture(
                         namespace=self.namespace,
                         content=f"[transcript:{session_id}]",

--- a/src/musubi/ops/cleanup.py
+++ b/src/musubi/ops/cleanup.py
@@ -62,13 +62,13 @@ def run_cleanup(
                 if collection == "musubi_episodic":
                     sdk._json(
                         "DELETE",
-                        f"/memories/{obj_id}",
+                        f"/episodic/{obj_id}",
                         params={"namespace": namespace, "hard": "true"},
                     )
                 elif collection == "musubi_curated":
                     sdk._json(
                         "DELETE",
-                        f"/curated-knowledge/{obj_id}",
+                        f"/curated/{obj_id}",
                         params={"namespace": namespace, "hard": "true"},
                     )
                 elif collection == "musubi_concept":

--- a/src/musubi/ops/retention.py
+++ b/src/musubi/ops/retention.py
@@ -74,13 +74,13 @@ def run_retention(
                 if plane == "episodic":
                     sdk._json(
                         "DELETE",
-                        f"/memories/{obj_id}",
+                        f"/episodic/{obj_id}",
                         params={"namespace": namespace, "hard": "true"},
                     )
                 elif plane == "curated":
                     sdk._json(
                         "DELETE",
-                        f"/curated-knowledge/{obj_id}",
+                        f"/curated/{obj_id}",
                         params={"namespace": namespace, "hard": "true"},
                     )
                 elif plane == "concept":

--- a/tests/integration/test_livekit_e2e.py
+++ b/tests/integration/test_livekit_e2e.py
@@ -35,7 +35,7 @@ from tests.integration._livekit_fixtures import (
 
 pytestmark = pytest.mark.integration
 
-# Both memories.capture and thoughts.send authorise via per-namespace
+# Both episodic.capture and thoughts.send authorise via per-namespace
 # scope-strings on the operator token minted in conftest. The router
 # routes to the right Qdrant collection from the endpoint, not from
 # the namespace string — so a single namespace covers both writes
@@ -119,7 +119,7 @@ async def test_e2e_full_turn_persists_episodic_and_thought(api_client: Any) -> N
     # Episodic half: at least one capture ack with a real object_id.
     # Includes both the heuristic fact capture and the session-end
     # transcript fallback (_upload_transcript_with_retry currently
-    # routes through memories.capture until the SDK ships
+    # routes through episodic.capture until the SDK ships
     # artifacts.upload).
     assert capture_responses, "expected at least one episodic capture"
     assert all(resp.get("object_id") for resp in capture_responses)

--- a/tests/migration/test_poc_to_v1.py
+++ b/tests/migration/test_poc_to_v1.py
@@ -71,8 +71,8 @@ def test_migrator_transforms_v0_episodic_to_v1_schema(mock_qdrant: Mock, mock_mu
     )
     migrated, _skipped = migrate_memories(mock_qdrant, mock_musubi, {}, dry_run=False)
     assert migrated == 1
-    mock_musubi.memories.capture.assert_called_once()
-    kwargs = mock_musubi.memories.capture.call_args.kwargs
+    mock_musubi.episodic.capture.assert_called_once()
+    kwargs = mock_musubi.episodic.capture.call_args.kwargs
     assert kwargs["content"] == "test"
     assert kwargs["namespace"] == "eric/poc/episodic"
     assert kwargs["topics"] == ["user"]
@@ -146,7 +146,7 @@ def test_migrator_dry_run_writes_nothing(mock_qdrant: Mock, mock_musubi: Mock) -
     )
     migrated, _skipped = migrate_memories(mock_qdrant, mock_musubi, {}, dry_run=True)
     assert migrated == 1
-    mock_musubi.memories.capture.assert_not_called()
+    mock_musubi.episodic.capture.assert_not_called()
 
 
 def test_migrator_state_file_tracks_progress(mock_qdrant: Mock, mock_musubi: Mock) -> None:

--- a/tests/migration/test_poc_to_v1.py
+++ b/tests/migration/test_poc_to_v1.py
@@ -77,6 +77,11 @@ def test_migrator_transforms_v0_episodic_to_v1_schema(mock_qdrant: Mock, mock_mu
     assert kwargs["namespace"] == "eric/poc/episodic"
     assert kwargs["topics"] == ["user"]
     assert kwargs["tags"] == ["a"]
+    # Source-truth timestamp is preserved via the SDK's operator-only
+    # `created_at` escape hatch — without it the row would be re-stamped
+    # at ingest time and the PoC timeline would be lost.
+    assert kwargs["created_at"] is not None
+    assert kwargs["created_at"].isoformat().startswith("2026-04-19T00:00:00")
 
 
 @pytest.mark.skip(

--- a/tests/ops/test_cleanup.py
+++ b/tests/ops/test_cleanup.py
@@ -46,7 +46,7 @@ def test_cleanup_worker_hard_deletes_archived_older_than_ttl(
         assert metrics[c] == 1
 
     assert (
-        call("DELETE", "/memories/123", params={"namespace": "test/ns", "hard": "true"})
+        call("DELETE", "/episodic/123", params={"namespace": "test/ns", "hard": "true"})
         in mock_sdk._json.call_args_list
     )
 

--- a/tests/ops/test_perf_seed.py
+++ b/tests/ops/test_perf_seed.py
@@ -130,7 +130,7 @@ def test_post_with_backoff_returns_success_on_2xx(monkeypatch: Any) -> None:
     client = MagicMock()
     client.post.return_value = success
 
-    got = seed.post_with_backoff(client, "/memories", rng=random.Random(0), json_body={})
+    got = seed.post_with_backoff(client, "/episodic", rng=random.Random(0), json_body={})
     assert got is success
     assert client.post.call_count == 1
 
@@ -148,7 +148,7 @@ def test_post_with_backoff_retries_429_then_succeeds(monkeypatch: Any) -> None:
     client = MagicMock()
     client.post.side_effect = [r429, r429, r200]
 
-    got = seed.post_with_backoff(client, "/memories", rng=random.Random(0), json_body={})
+    got = seed.post_with_backoff(client, "/episodic", rng=random.Random(0), json_body={})
     assert got is r200
     assert client.post.call_count == 3
 
@@ -163,7 +163,7 @@ def test_post_with_backoff_gives_up_after_max_retries(monkeypatch: Any) -> None:
     client = MagicMock()
     client.post.return_value = r429
 
-    got = seed.post_with_backoff(client, "/memories", rng=random.Random(0), json_body={})
+    got = seed.post_with_backoff(client, "/episodic", rng=random.Random(0), json_body={})
     assert got is None
     assert client.post.call_count == seed.MAX_429_RETRIES
 
@@ -177,7 +177,7 @@ def test_post_with_backoff_does_not_retry_non_429(monkeypatch: Any) -> None:
     client = MagicMock()
     client.post.return_value = r500
 
-    got = seed.post_with_backoff(client, "/memories", rng=random.Random(0), json_body={})
+    got = seed.post_with_backoff(client, "/episodic", rng=random.Random(0), json_body={})
     assert got is r500
     assert client.post.call_count == 1
 
@@ -189,7 +189,7 @@ def test_post_with_backoff_returns_none_on_transport_error(monkeypatch: Any) -> 
     client = MagicMock()
     client.post.side_effect = seed.httpx.ConnectError("boom")
 
-    got = seed.post_with_backoff(client, "/memories", rng=random.Random(0), json_body={})
+    got = seed.post_with_backoff(client, "/episodic", rng=random.Random(0), json_body={})
     assert got is None
 
 


### PR DESCRIPTION
No tracking Issue: pre-v0.6.0-release sweep against residual drift from the v1.0-prep merge batch (#234 #236 #237 #238 #239).

## Round 1 findings (commit 5a51c1b)

Real bug: `deploy/migration/poc-to-v1.py:153` called `target_client.memories.capture(...)` — dead attribute after the #237 rename. Fixed + mocks aligned in `tests/migration/test_poc_to_v1.py`.

Doc drift:
- `docs/Musubi/07-interfaces/sdk.md` OTel span-name example `musubi.memories.capture` → `musubi.episodic.capture`.
- `docs/Musubi/07-interfaces/mcp-adapter.md` tool-mapping table `client.memories.*` → `client.episodic.*`.
- `README.md` pull-command + cosign-verify pinned to old `v0.3.0` → replaced with `<version>` placeholder pointing at the latest-release badge.
- `README.md` Status section rewritten to describe v0.6.0 as the v1.0 release candidate.

## Round 2 findings (commit e2b510f) — deeper sweep

**Three more runtime bugs — all would 404 against v0.6.0:**

- `src/musubi/ops/retention.py:77` — retention sweep DELETEd via `/memories/{id}` and `/curated-knowledge/{id}`. Both renamed.
- `src/musubi/ops/cleanup.py:65` — same URL-construction pattern in the ops cleanup path, same renames.
- `scripts/perf/seed_corpus.py:361,424` — perf corpus seeder POSTed to `/memories` and `/curated-knowledge`. Both renamed.

Tests aligned (the ops-cleanup + perf-seeder tests had assertions against old URLs; mocks were vacuously passing).

**Code-comment drift:** `src/musubi/adapters/livekit/adapter.py:150` and 2 sites in `tests/integration/test_livekit_e2e.py` had stale `memories.capture` in comments. Fixed.

**Spec-file drift:**
- `docs/Musubi/07-interfaces/openapi/musubi.v1.yaml` — vault's design-time openapi skeleton still had `/curated-knowledge/{id}` + a phantom `/retrieve/blended` path that was never shipped. Corrected.
- `docs/Musubi/proto/musubi/v1/musubi.proto` — had an `rpc RetrieveBlended (BlendedRequest) returns (HitList)` that doesn't exist. When gRPC ships behind #98 it'll use the unified `Retrieve` RPC with 2-seg namespace + planes per ADR-0028. Replaced with a comment.

## Intentionally preserved

ADRs, work-log entries, and resolved `_inbox` cross-slice tickets that reference pre-rename paths or the removed `thoughts:check` scope helpers are kept as historical context — not drift.

## Test plan

- [x] `make check` — 1241 passed, 196 skipped (full suite).
- [x] `make agent-check` — clean.
- [x] Grep sweep for `client.memories`, `.memories.*`, `/v1/memories`, `/v1/curated-knowledge`, `curated-knowledge/{`, `extra.title`, `thoughts:check:<presence>`, `retrieve/blended`, `RetrieveBlended` in live code, tests, deploy, scripts, docs — zero remaining hits outside ADRs + historical tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)