### PR TITLE
fix(ci): grant contents:write so release-body append can update release

### DIFF
--- a/.github/workflows/publish-core-image.yml
+++ b/.github/workflows/publish-core-image.yml
@@ -50,7 +50,10 @@ jobs:
       # read` lets upload-sarif hit the workflow-runs API for
       # fingerprinting — without it the step fails with "Resource not
       # accessible by integration" even when SARIF itself is valid.
-      contents: read
+      # `contents: write` lets softprops/action-gh-release append the
+      # digest + ansible-pin snippet to the release body (it calls the
+      # "Update a release" REST endpoint).
+      contents: write
       packages: write
       id-token: write
       security-events: write


### PR DESCRIPTION
Closes #242.

## Summary

- Bump `permissions.contents` from `read` → `write` in [`.github/workflows/publish-core-image.yml`](.github/workflows/publish-core-image.yml) so `softprops/action-gh-release@v2` can call the "Update a release" REST endpoint.
- Added a one-line comment next to the other permission explanations documenting why it's needed.

Diagnosed in [run 24892859286](https://github.com/ericmey/musubi/actions/runs/24892859286) — the image publish, cosign signing, SBOM, and Trivy upload all succeeded; only the release-body append failed with `HttpError: Resource not accessible by integration`, so the v0.6.0 release page is missing the digest + ansible pin snippet.

No other step in the job writes repo contents, so the upgrade is scoped tightly to this one append.

## Test plan

- [ ] Next tag push (v1.0.0) — `Attach digest as release asset` step exits clean and the release body shows the `Published ghcr.io/ericmey/musubi-core …` block with the digest and ansible pin snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)