### PR TITLE
feat(ci): auto-enable auto-merge on auto-digest-bump PRs

### DIFF
--- a/.github/workflows/auto-digest-bump.yml
+++ b/.github/workflows/auto-digest-bump.yml
@@ -239,7 +239,18 @@ jobs:
           if [[ -n "${EXISTING}" ]]; then
             echo "Updating existing PR #${EXISTING}"
             gh pr edit "${EXISTING}" --title "${TITLE}" --body "${BODY}"
+            PR_NUMBER="${EXISTING}"
           else
             echo "Opening new PR"
             gh pr create --base main --head "${BRANCH}" --title "${TITLE}" --body "${BODY}"
+            PR_NUMBER=$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number')
+          fi
+
+          # Flip on auto-merge so the pin lands the moment required
+          # checks go green. Same "no human gate" policy as
+          # release-please.yml. Idempotent — calling --auto on a PR
+          # that already has auto-merge is a no-op.
+          if [[ -n "${PR_NUMBER}" ]]; then
+            echo "Enabling auto-merge on PR #${PR_NUMBER}"
+            gh pr merge "${PR_NUMBER}" --auto --squash
           fi

--- a/.github/workflows/auto-digest-bump.yml
+++ b/.github/workflows/auto-digest-bump.yml
@@ -6,9 +6,11 @@ name: Auto digest bump
 # that edits `deploy/ansible/group_vars/all.yml::musubi_core_image` to
 # the new `@sha256:<digest>`.
 #
-# The operator still reviews and merges the PR — this workflow does
-# not touch the live deploy. Ansible's `update.yml` is invoked
-# manually from the control host after merge.
+# The pin PR auto-merges once required checks pass (auto-merge is
+# enabled by this workflow on PR creation). The operator is only in
+# the loop for the deploy itself — `ansible-playbook update.yml` is
+# invoked manually from the control host after the pin has landed on
+# `main`. Deploys are a human decision; pinning the config is not.
 #
 # ## Triggers
 #
@@ -198,7 +200,11 @@ jobs:
           git push -u origin "${BRANCH}" --force
 
           # Create or update the PR. Detect existing by branch head.
-          EXISTING=$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number' || true)
+          # `// empty` coalesces a null-array (no open PR for this
+          # branch) to an empty string, so the `-n` check below
+          # correctly takes the create path instead of
+          # `gh pr edit null`.
+          EXISTING=$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number // empty' || true)
           BODY=$(cat <<EOF
           ${TITLE}
 
@@ -242,15 +248,21 @@ jobs:
             PR_NUMBER="${EXISTING}"
           else
             echo "Opening new PR"
-            gh pr create --base main --head "${BRANCH}" --title "${TITLE}" --body "${BODY}"
-            PR_NUMBER=$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number')
+            # `gh pr create` prints the PR URL on stdout; the trailing
+            # path component is the number. More reliable than
+            # re-listing immediately after create (GitHub's API can
+            # briefly return an empty list while the PR is indexing).
+            PR_URL=$(gh pr create --base main --head "${BRANCH}" --title "${TITLE}" --body "${BODY}")
+            PR_NUMBER="${PR_URL##*/}"
           fi
 
           # Flip on auto-merge so the pin lands the moment required
           # checks go green. Same "no human gate" policy as
           # release-please.yml. Idempotent — calling --auto on a PR
           # that already has auto-merge is a no-op.
-          if [[ -n "${PR_NUMBER}" ]]; then
+          if [[ -n "${PR_NUMBER}" && "${PR_NUMBER}" != "null" ]]; then
             echo "Enabling auto-merge on PR #${PR_NUMBER}"
             gh pr merge "${PR_NUMBER}" --auto --squash
+          else
+            echo "::warning::could not resolve PR number; skipping auto-merge enable."
           fi


### PR DESCRIPTION
Follow-on to #249. Same "no human gate" policy as #245 (release-please auto-merge), applied to pin PRs.

## Summary

After #249 landed, pin PRs open with CI running and reach `mergeState: CLEAN` cleanly — but they still need someone to click "Enable auto-merge". This PR flips that on automatically, matching the pattern in `release-please.yml`.

Captures `PR_NUMBER` from both the create and edit paths (the workflow re-runs on every successful publish-core-image — same branch, same digest-bump step — so the idempotency matters). `gh pr merge --auto` on an already-auto-merging PR is a no-op.

## End-state of the release chain

After this lands, from conventional commit to pinned digest is hands-off:

1. Conventional commit on `main`.
2. `release-please.yml` opens the release PR, `release-please.yml`'s auto-merge step flips it on (#245).
3. PR auto-merges on green CI → tag pushes.
4. `publish-core-image.yml` builds + signs + pushes the image.
5. `auto-digest-bump.yml` fires via `workflow_run` (#249), opens the pin PR via PAT (#249), enables auto-merge (this PR).
6. Pin PR auto-merges on green CI.

Operator still runs `ansible-playbook update.yml` from the control host after the pin lands — the deploy is a human decision, CI's job stops at the pinned config.

## Test plan

- [ ] Merge this PR.
- [ ] Next release trips the full chain with zero clicks from release-please PR merge through pin-PR merge. v1.0.0 will be the first real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)