### PR TITLE
chore(deploy): pin musubi-core to v0.8.0 signed digest

### DIFF
--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -44,7 +44,7 @@ musubi_core_port: 8100
 # digest from the Actions run summary, not from the release page.
 #
 # Bump this after every release via `deploy/runbooks/upgrade-image.md`.
-musubi_core_image: "ghcr.io/ericmey/musubi-core@sha256:c053ac530c56a9258eb72c479860169fbb717c4ef0b8568a551f9fc32dbfdae5"
+musubi_core_image: "ghcr.io/ericmey/musubi-core@sha256:57865c99a02271760ce62a6d2a3682cd543c8feb94071294fe4462580231cb78"
 musubi_qdrant_image: "qdrant/qdrant:v1.17.1"
 # TEI image tag = <compute-capability>-<version>. RTX 3080 is Ampere,
 # compute 8.6 → `86-*`. Other GPUs: `turing-*` (RTX 20xx), `89-*` (RTX 40xx),


### PR DESCRIPTION
chore(deploy): pin musubi-core to v0.8.0 signed digest

Automated by `.github/workflows/auto-digest-bump.yml` in response to the [v0.8.0](https://github.com/ericmey/musubi/releases/tag/v0.8.0) release.

## Supply-chain attestations
- cosign keyless signature via GitHub OIDC
- CycloneDX SBOM attached as a cosign attestation
- Trivy vulnerability scan — 0 CRITICAL (gate in `publish-core-image.yml`)

## Verify before deploy

```bash
cosign verify \
  --certificate-identity-regexp 'https://github.com/ericmey/musubi/.*' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  ghcr.io/ericmey/musubi-core@sha256:57865c99a02271760ce62a6d2a3682cd543c8feb94071294fe4462580231cb78
```

## After merge

```bash
# From the ansible control host:
cd ~/musubi
git pull origin main
ANSIBLE_VAULT_PASSWORD_FILE=~/ansible/.vault_pass \
  ansible-playbook \
    -i deploy/ansible/inventory.yml \
    -e @~/.musubi-secrets/inventory-vars.yml \
    -e @~/.musubi-secrets/vault.yml \
    -e 'changed_services=["core","lifecycle-worker"]' \
    deploy/ansible/update.yml
```

No tracking Issue: auto-generated release digest pin.