### PR TITLE
refactor(model): agent-as-tenant namespace convention (ADR 0030)

### DIFF
--- a/docs/Musubi/03-system-design/namespaces.md
+++ b/docs/Musubi/03-system-design/namespaces.md
@@ -4,24 +4,26 @@ section: 03-system-design
 tags: [architecture, isolation, namespaces, section/system-design, status/complete, type/spec]
 type: spec
 status: complete
-updated: 2026-04-17
+updated: 2026-04-24
 up: "[[03-system-design/index]]"
 reviewed: false
 implements: ["src/musubi/api/", "tests/api/"]
 ---
 # Namespaces
 
-How Musubi partitions its data so that multiple tenants and presences coexist without leaking memory across boundaries.
+How Musubi partitions its data so that agents, channels, and system services coexist without leaking memory across boundaries.
 
 ## The namespace triple
 
 Every piece of memory lives in a namespace: `{tenant}/{presence}/{plane}`.
 
-- **tenant** — a human identity or shared household bucket. Examples: `eric`, `household`.
-- **presence** — an AI agent identity. Examples: `claude-code`, `livekit-voice`, `openclaw`.
+- **tenant** — the agent persona that owns the memory (the continuous "who" across channels). Examples: `nyla`, `aoi`, `hana`, `mizuki`. Also reserved: `system` (lifecycle worker, scheduler).
+- **presence** — the channel / client the agent is speaking through. Examples: `voice` (LiveKit), `discord`, `openclaw` (browser plugin), `mcp` (MCP adapter).
 - **plane** — one of `episodic`, `curated`, `artifact`, `concept`, `thought`.
 
-Stored as a flat string on every object: `namespace: "eric/claude-code/episodic"`.
+Stored as a flat string on every object: `namespace: "nyla/voice/episodic"`.
+
+> Historical note: pre-v1.0, an earlier convention used the human operator as the tenant (`eric/nyla/episodic`). That was flipped to agent-as-tenant in [[13-decisions/0030-agent-as-tenant|ADR 0030]] before v1.0. Example namespaces elsewhere in the vault may still show the old shape; treat this page as the source of truth until the sweep lands.
 
 ## How namespaces affect storage
 
@@ -36,12 +38,12 @@ Collections:
 - `musubi_concept`
 - `musubi_thought`
 
-Why one-collection-per-plane instead of one-per-tenant?
-- With ~5 tenants × 5 planes = 25 collections, storage overhead is manageable, but every new tenant requires a provisioning step. Keeping data in a shared collection means tenant creation is a config edit, not a Qdrant operation.
+Why one-collection-per-plane instead of one-per-agent?
+- Agent creation is a config edit (mint a token, add to the fleet), not a Qdrant operation.
 - Qdrant payload filtering on an indexed KEYWORD field is O(log n); at our scale (≤ 10M points per plane) this is negligible.
-- Snapshot/restore of a shared collection captures all tenants atomically.
+- Snapshot/restore of a shared collection captures all agents atomically.
 
-**If we outgrow this** (say, > 50M points in a plane): we split the largest collection by tenant via a zero-downtime migration using Qdrant aliases. See [[11-migration/scaling]].
+**If we outgrow this** (say, > 50M points in a plane): we split the largest collection by agent via a zero-downtime migration using Qdrant aliases. See [[11-migration/scaling]].
 
 ### Filter on every query
 
@@ -56,33 +58,36 @@ Filter(
 ```
 
 where `ns_expr` is one of:
-- Exact: `"eric/claude-code/episodic"` — single-namespace query.
-- Prefix: `"eric/claude-code/"` — all planes for this presence (cross-plane blended).
-- Tenant-wide: `"eric/"` — all presences, all planes, for this tenant.
+- Exact: `"nyla/voice/episodic"` — single-namespace query.
+- 2-segment: `"nyla/voice"` — cross-plane fan (all planes Nyla has written on the voice channel). See [[13-decisions/0028-retrieve-2seg-namespace-crossplane|ADR 0028]].
+- Plane-wide via scope glob: tokens with `*/episodic:r` can read every agent's episodic rows; used by household-survey tools (see [[07-interfaces/canonical-api]]).
 
-Qdrant doesn't support prefix match on KEYWORD directly, so tenant-wide or presence-wide queries use `should` with all enumerated namespaces. Enumeration is cheap because the presence registry is ~10 entries.
+Qdrant doesn't support prefix match on KEYWORD directly, so plane-wide queries use `should` with enumerated namespaces at the router layer. Enumeration is cheap because the agent registry is ~12 entries.
 
 ### The vault
 
-Curated knowledge is partitioned under the vault filesystem:
+Curated knowledge is partitioned under the vault filesystem, one top-level directory per agent tenant:
 
 ```
 vault/
 ├── curated/
-│   ├── eric/              # tenant directory
-│   │   ├── projects/      # topic directories
+│   ├── nyla/                # agent tenant directory
+│   │   ├── projects/        # topic directories
 │   │   │   ├── musubi.md
 │   │   │   └── openclaw.md
 │   │   └── personal/
 │   │       └── preferences.md
-│   └── household/
-│       └── shared-calendar.md
-├── artifacts/             # artifact files (namespace-tagged in frontmatter, not path-partitioned)
-├── _archive/              # soft-deleted files
-└── _inbox/                # ticket / questions / locks folders
+│   ├── aoi/
+│   │   └── technical/
+│   │       └── gpu-ops.md
+│   └── _shared/             # cross-agent shared knowledge (household-read scope required)
+│       └── calendar.md
+├── artifacts/               # artifact files (namespace-tagged in frontmatter, not path-partitioned)
+├── _archive/                # soft-deleted files
+└── _inbox/                  # ticket / questions / locks folders
 ```
 
-The frontmatter in each file declares its namespace explicitly (`tenant: eric`, `plane: curated`). The filesystem structure is a convenience for humans (easy nav in Obsidian) — the namespace of record is in the frontmatter, so moving a file across tenant folders requires a frontmatter edit too.
+The frontmatter in each file declares its namespace explicitly (`tenant: nyla, presence: curated, plane: curated`). The filesystem structure is a convenience for humans (easy nav in Obsidian) — the namespace of record is in the frontmatter, so moving a file across agent folders requires a frontmatter edit too.
 
 ## Authorization maps to namespace
 
@@ -90,14 +95,15 @@ A bearer token carries claims:
 
 ```json
 {
-  "sub": "claude-code@eric",
-  "tenant": "eric",
-  "presence": "claude-code",
-  "scopes": ["memory:read", "memory:write", "curated:read"]
+  "sub": "openclaw-livekit-nyla",
+  "presence": "nyla/voice",
+  "scope": "nyla/*:rw */episodic:r */curated:r",
+  "aud": "musubi",
+  "iss": "..."
 }
 ```
 
-The auth middleware resolves this into an allowed namespace prefix and injects it into every query. A request with token for `eric/claude-code` cannot retrieve from `household/*` unless the token explicitly carries `tenant: household` as an additional allowed tenant (home-shared agents may).
+The auth middleware resolves scope globs against the request's namespace claim. A token scoped `nyla/*:rw` can write and read anywhere under the `nyla/` tenant; a token with additional `*/episodic:r` can survey every agent's episodic plane.
 
 See [[10-security/auth]] for the full token model.
 
@@ -105,34 +111,38 @@ See [[10-security/auth]] for the full token model.
 
 - **`system/lifecycle-worker/*`** — the lifecycle worker writes audit events and system-authored synthesized concepts here. Not readable to non-system tokens.
 - **`system/scheduler/*`** — scheduled-task-triggered thoughts and reflections.
-- **`{tenant}/_shared/*`** — shared across all presences of a tenant (e.g., tenant-level curated knowledge that any presence can read).
-- **`household/*`** — a tenant for multi-person shared knowledge (family calendar, home operations). Explicitly opted into by tokens.
+- **`<agent>/_shared/*`** — shared across all of an agent's channels (e.g., Nyla's canonical preferences, readable whether she's on voice or discord).
+- **`_shared/<plane>`** is not a valid namespace — use `<agent>/_shared/<plane>` for per-agent cross-channel, or grant `_shared/*:r` scope for a dedicated shared-knowledge tenant.
 
 ## Namespace rules
 
-1. **No defaulting.** Every API call must resolve a namespace. Missing namespace is a 400, not a "use current user's."
-2. **No wildcards in write paths.** Reads can query prefixes; writes must be fully qualified.
-3. **Cross-namespace relationships are allowed but logged.** A curated file in `eric/` may cite an artifact in `household/`. The audit log records the cross-namespace link.
+1. **No defaulting.** Every API call must resolve a namespace. Missing namespace is a 400, not a "use current agent's."
+2. **No wildcards in write paths.** Reads can query prefixes via scope globs; writes must be fully qualified.
+3. **Cross-namespace relationships are allowed but logged.** A curated file in `nyla/` may cite an artifact in `aoi/`. The audit log records the cross-namespace link.
 4. **Namespace strings are case-sensitive, ASCII, kebab-case.**
 5. **Namespace cannot be changed after write.** Moving a memory across namespaces is a delete + insert with new lineage.
+
+## Multi-instance note
+
+When a second human operator runs their own Musubi instance, we disambiguate by agent-name prefix or suffix (e.g. `nyla-eric` vs `nyla-lisa`) — or keep instances fully separate at the deploy layer. Until a second instance lands, agent names are flat and unique.
 
 ## Test Contract
 
 Every plane's module-level tests must include:
 
-- `test_isolation_read_enforcement` — a token for `tenant-a` cannot read `tenant-b` data at any plane.
-- `test_isolation_write_enforcement` — a token for `tenant-a` cannot write with `tenant: tenant-b` in payload.
-- `test_shared_read_ok` — a token with `tenant: eric` and `allowed_tenants: [household]` can read both.
-- `test_prefix_query_correctness` — prefix queries match all enumerated children and nothing else.
-- `test_system_namespace_not_readable_from_user_token` — a user token cannot read `system/*`.
+- `test_isolation_read_enforcement` — a token for agent `nyla` cannot read `aoi` data at any plane.
+- `test_isolation_write_enforcement` — a token for agent `nyla` cannot write with `namespace: aoi/...` in payload.
+- `test_household_read_ok` — a token with `nyla/*:rw` plus `*/episodic:r` can read both own and household episodic.
+- `test_prefix_query_correctness` — 2-seg queries match all enumerated plane children and nothing else.
+- `test_system_namespace_not_readable_from_agent_token` — an agent token cannot read `system/*`.
 
 See [[10-security/auth]] for the full auth test contract.
 
 ## Why this is load-bearing
 
 Namespaces are how we keep the small-team model sane. Get this wrong and we either:
-- Leak household memory into individual-presence retrieval (privacy / correctness).
-- Silo every presence (agents can't build on each other's context).
-- Can't ever evolve to multi-tenant because the concept isn't first-class.
+- Leak one agent's memory into another's retrieval (privacy / correctness).
+- Silo every channel (Nyla-on-voice can't build on Nyla-on-discord's context).
+- Can't evolve to multi-instance because the tenancy concept isn't first-class.
 
 Get it right and we get all three: isolation, selective sharing, and future-proof.

--- a/docs/Musubi/10-security/auth.md
+++ b/docs/Musubi/10-security/auth.md
@@ -13,6 +13,8 @@ implements: "docs/Musubi/10-security/"
 
 Authentication + authorization for Musubi. OAuth 2.1 for human/adapter flows; JWT bearer tokens validated at the edge.
 
+> **v1.0 convention note:** the token and scope examples on this page use the pre-v1.0 `eric/<agent>` shape (human-as-tenant). As of v1.0, namespaces are agent-as-tenant — `nyla/voice`, `aoi/discord`, etc. — per [[13-decisions/0030-agent-as-tenant|ADR 0030]]. The validation pipeline, scope-glob matching, and test contract on this page are still correct; only the example strings need a sweep. Read [[03-system-design/namespaces]] for the authoritative shape.
+
 ## Model
 
 Single authority. Every call carries a bearer token; every token has a scope list; every scope names a namespace glob + access level.

--- a/docs/Musubi/13-decisions/0030-agent-as-tenant.md
+++ b/docs/Musubi/13-decisions/0030-agent-as-tenant.md
@@ -1,0 +1,102 @@
+---
+title: Agent-as-tenant namespace convention
+section: 13-decisions
+tags: [adr, architecture, namespaces, auth, section/decisions, status/accepted, type/adr]
+type: adr
+status: accepted
+decided: 2026-04-24
+updated: 2026-04-24
+up: "[[13-decisions/index]]"
+supersedes:
+  - "parts of [[03-system-design/namespaces]] pre-v1.0"
+---
+# ADR 0030 — Agent-as-tenant
+
+## Context
+
+The namespace shape is `<tenant>/<presence>/<plane>` (3-seg) or `<tenant>/<presence>` (2-seg for cross-plane retrieve). Pre-v1.0 the illustrative convention used **human as tenant**: `eric/nyla/episodic`, `eric/aoi/episodic`, `eric/openclaw/episodic`.
+
+While wiring the openclaw-livekit v0.6.0 cutover and preparing the household-status tool, the human-as-tenant convention produced awkward artifacts:
+
+- Every agent writes under the same tenant prefix, so per-agent scope globs look like `eric/<agent>/*:rw` — fine, but the second-segment name carries two meanings across integrations: in livekit it's the agent identity (`eric/nyla`), in the openclaw plugin it's the bridge identity (`eric/openclaw`).
+- "What does Nyla remember?" is naturally a query about an agent, not about Eric's subset of memory under his tenant. The retrieve-side mental model pulls toward agent-as-tenant even when storage is tenant-as-human.
+- Scaling to a second instance (another human running Musubi) requires a tenant-prefix convention anyway — so `eric/` was never a universal answer.
+
+## Decision
+
+**Tenant is the agent persona.** Presence is the channel/client the agent is speaking through.
+
+```
+<agent>/<channel>/<plane>
+```
+
+Examples:
+
+- `nyla/voice/episodic` — Nyla speaking through the LiveKit voice stack.
+- `nyla/discord/episodic` — Nyla speaking through Discord text.
+- `nyla/openclaw/episodic` — Nyla answering a browser-plugin invocation.
+- `aoi/voice/episodic`, `aoi/discord/episodic`.
+- 2-seg retrieve: `nyla/voice` → fan across Nyla's voice-plane rows across every plane she's written; `nyla` alone is not a legal namespace (the model requires at least tenant + presence).
+
+Channels in scope for v1.0: `voice`, `discord`, `openclaw`. More as integrations land.
+
+## Scoping model
+
+Tokens follow the tenant-first shape. Each agent gets its own token:
+
+- **Own-write-own-read**: `<agent>/*:rw` (e.g. `nyla/*:rw`).
+- **Household-read** (agents that survey other agents, e.g. Nyla, Aoi): `*/episodic:r`, `*/curated:r`, `*/concept:r`, `*/thought:r`. The `*` tenant glob is acceptable because the Musubi instance currently hosts a single human's agent cohort.
+- **Cross-tenant write**: forbidden. An agent cannot write into another agent's namespace.
+- **Operator tokens**: scope `*:rw` (broad, short-lived, minted on demand for ops / migrations).
+
+### What about multiple humans?
+
+If a second instance lands, we disambiguate by agent-name prefix rather than by adding a tenant wrapper. Possible conventions:
+
+- Per-instance prefix: `eric-nyla`, `lisa-nyla`.
+- Per-instance suffix: `nyla-eric`, `nyla-lisa`.
+- Multi-tenancy via deploy: separate Musubi instances per human; tenant collision impossible.
+
+Revisit only when a second human actually shows up. Until then, agent-as-tenant is flat and clean.
+
+## Openclaw plugin presence
+
+The openclaw browser plugin bridges for whichever agent is active. Its token's `presence` claim is the plugin's own identity (`openclaw-<machine>`); the request's `namespace` sets `<active-agent>/openclaw/<plane>` at call time. One plugin token per machine, scope `*/openclaw/*:rw` (can write any agent's openclaw namespace) + `*/episodic:r *:r` for retrieve on the agent's behalf.
+
+## Scheduler / system namespaces
+
+`system/lifecycle-worker/*` and `system/scheduler/*` stay under a `system` tenant. Not an agent identity — a reserved slot for lifecycle infrastructure. Tokens with `system:rw` are operator-only.
+
+## Consequences
+
+### Positive
+
+- Queries read naturally: "what does Nyla know?" is `namespace=nyla/…`, not `namespace=eric/nyla/…`.
+- Per-agent isolation is first-class in the namespace, not a convention layered on top.
+- Cross-channel aggregation within an agent (voice + discord + openclaw) works via 2-seg retrieve (`nyla/`).
+- Household surveying uses clean plane-level scope globs (`*/episodic:r`) instead of enumerating 12 agent tenants.
+
+### Trade-offs
+
+- **Scope glob breadth.** `*:r` is wider than `eric/*:r`. Acceptable in a single-instance deploy; revisit if a second instance lands.
+- **Migration cost.** Pre-cutover smoke data under `eric/<agent>/*` must be wiped (it's synthetic — no loss). Legacy POC data migrates with a namespace-mapping step in `deploy/migration/poc-to-v1.py`.
+- **Vault path convention.** The on-disk vault structure in [[03-system-design/namespaces]] previously partitioned curated files under `vault/curated/<tenant>/`. Under agent-as-tenant this becomes `vault/curated/<agent>/` (Nyla's curated knowledge lives under `vault/curated/nyla/`). Documented in the v1.0 spec refresh.
+
+## Migration
+
+Executed as part of the v1.0 cutover:
+
+1. Wipe canonical Qdrant (synthetic + smoke rows).
+2. Re-mint every bearer token under the new convention.
+3. Update `AgentConfig` in `openclaw-livekit` (`musubi_v2_namespace = "nyla/voice"`, etc.).
+4. Update openclaw plugin tokens + presence defaults.
+5. Run `deploy/migration/poc-to-v1.py` with namespace mapping `legacy payload.agent → <agent>/voice/episodic`.
+6. Deploy livekit agents against the clean canonical instance.
+7. Cut v1.0.0.
+
+## Related
+
+- [[03-system-design/namespaces]] — updated to reflect the new convention.
+- [[10-security/auth]] — scope examples updated.
+- [[07-interfaces/canonical-api]] / [[07-interfaces/sdk]] / [[07-interfaces/mcp-adapter]] — example namespaces refreshed.
+- ADR [[0028-retrieve-2seg-namespace-crossplane]] — 2-seg retrieve still works unchanged; the tenant slot just contains an agent name now.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2860,8 +2860,8 @@ components:
         namespace:
           type: string
           title: Namespace
-          description: Tenant-scoped namespace prefix (e.g. 'eric/integration-test').
-            The synthesis loop operates on '<prefix>/episodic' + '<prefix>/concept'.
+          description: Agent-scoped namespace prefix (e.g. 'nyla/voice'). The synthesis
+            loop operates on '<prefix>/episodic' + '<prefix>/concept'.
         simulate_ollama_offline:
           type: boolean
           title: Simulate Ollama Offline

--- a/src/musubi/api/routers/ops.py
+++ b/src/musubi/api/routers/ops.py
@@ -107,7 +107,7 @@ class TriggerSynthesisRequest(BaseModel):
     """Debug-endpoint payload for :func:`trigger_synthesis`."""
 
     namespace: str = Field(
-        description="Tenant-scoped namespace prefix (e.g. 'eric/integration-test'). "
+        description="Agent-scoped namespace prefix (e.g. 'nyla/voice'). "
         "The synthesis loop operates on '<prefix>/episodic' + '<prefix>/concept'."
     )
     simulate_ollama_offline: bool = Field(

--- a/src/musubi/cli/promote.py
+++ b/src/musubi/cli/promote.py
@@ -30,7 +30,7 @@ promote_app = typer.Typer(help="Concept promotion and rejection.", no_args_is_he
 def force_promote(
     concept_id: str = typer.Argument(..., help="KSUID of the synthesized concept to promote."),
     namespace: str = typer.Option(
-        ..., "--namespace", help="Concept's namespace (eg. `eric/shared/concept`)."
+        ..., "--namespace", help="Concept's namespace (eg. `nyla/voice/concept`)."
     ),
     curated_id: str = typer.Option(
         ...,

--- a/uv.lock
+++ b/uv.lock
@@ -732,7 +732,7 @@ wheels = [
 
 [[package]]
 name = "musubi"
-version = "0.5.1"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Foundational convention flip before v1.0 seals: namespace tenant slot moves from human operator (`eric/<agent>`) to agent persona (`<agent>/<channel>`).

No tracking Issue: foundational decision executed directly before v1.0; ADR 0030 captures the rationale.

## Why now

Pre-v1.0 the tenant was the human and the presence was the agent. During the openclaw-livekit cutover two months of wiring it revealed the shape was fighting us:

- Per-agent scope globs (`eric/<agent>/*:rw`) worked, but the second segment carried two meanings — agent identity in livekit (`eric/nyla`), bridge identity in openclaw (`eric/openclaw`).
- "What does Nyla remember?" is naturally a query about an agent, not about Eric's subset of data under his tenant.

Flipping before v1.0 makes the namespace load-bearing for the agent-identity semantics it was supposed to carry. After v1.0 seals, the cost of this flip scales with accumulated data + downstream integrations.

## What's in this PR

**ADR** — [`docs/Musubi/13-decisions/0030-agent-as-tenant.md`](docs/Musubi/13-decisions/0030-agent-as-tenant.md) captures the decision, scope-glob implications, openclaw plugin presence shape, and the multi-instance story.

**Normative spec** — [`docs/Musubi/03-system-design/namespaces.md`](docs/Musubi/03-system-design/namespaces.md) rewritten. Examples updated throughout; structural sections (Qdrant strategy, auth mapping, vault layout, rules, test contract) preserved — only the illustrative strings changed.

**Source docstrings** — updated the two example-carrying docstrings in production code:
- [`src/musubi/api/routers/ops.py`](src/musubi/api/routers/ops.py) — `TriggerSynthesisRequest.namespace`
- [`src/musubi/cli/promote.py`](src/musubi/cli/promote.py) — `force_promote --namespace`

**OpenAPI** — regenerated description for `TriggerSynthesisRequest`. Description-only change to an existing field (additive / non-breaking), but flagging since `openapi.yaml` is frozen-per-version.

**Auth doc** — [`docs/Musubi/10-security/auth.md`](docs/Musubi/10-security/auth.md) got a v1.0 convention banner with a pointer to the ADR and the namespace spec. The page's full example sweep is a follow-up — non-blocking since the validation pipeline, scope-glob matching, and test contract are all string-agnostic.

**Incidental** — `uv.lock` sync 0.5.1 → 0.8.0 (stale since release-please version bumps skipped the lock refresh; `make check` picked it up).

## What did NOT change

- Production code in `src/musubi/**`: audit found zero hardcoded `"eric"` strings, tenant-value validations, or shape enforcements. The namespace regex, scope-glob matching, and blended-retrieve fanout are all tenant-string-agnostic.
- Tests: 380+ fixture references to `eric/...` continue to work — none assert that the tenant must be literally `"eric"`.
- Broader vault: ~150 `eric/` references across 33 files remain; all illustrative and not contradicted by the ADR. Vault-wide sweep queued as a follow-up (separate PR, cosmetic).

## Migration (handled out-of-band as part of the v1.0 cutover)

1. Wipe canonical Qdrant (synthetic + smoke rows).
2. Re-mint bearer tokens under the new convention.
3. Re-map namespaces in `deploy/migration/poc-to-v1.py`.
4. Update `AgentConfig` in `openclaw-livekit`.
5. Update openclaw plugin presence defaults (per-machine token).

## Test plan

- [x] `make check` green (1241 passed, 196 skipped — per repo DoD).
- [ ] Merge this PR. release-please will bundle into the next release (likely 0.9.0 given the `refactor:` type).
- [ ] After v0.9.0 image + pin land: run the cutover migration per ADR 0030, Migration section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)