### PR TITLE
feat: release v1.0 — API sealed, integrations on canonical, automation hands-off

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,23 +114,27 @@ deploy/                     ansible, prometheus, grafana, docker-compose templat
 
 ## Status
 
-**v0.6.0 — the v1.0 release candidate.** Pre-1.0 API shape is locked; the breaking changes that were going to land before 1.0 are in. If nothing major regresses in downstream-adapter validation, v1.0 ships next.
+**v1.0 — released.** The API shape is sealed, agent-as-tenant namespace model is in ([ADR 0030](docs/Musubi/13-decisions/0030-agent-as-tenant.md)), both downstream integrations (openclaw-livekit, openclaw-musubi plugin) are on the canonical API, and the release chain from conventional commit through pinned-digest PR is fully hands-off.
 
-What's in the v1.0-candidate surface:
+In v1.0:
 
+- ✅ Three-plane memory (episodic / curated / concept) + artifacts + thoughts, per-plane collections, KSUID-addressed rows
 - ✅ All five lifecycle sweeps (maturation, synthesis, promotion, demotion, reflection) running on cron, SQLite-journaled, with a hard three-strikes rejection cap on promotion
 - ✅ Hybrid retrieval — dense BGE-M3 + sparse SPLADE + BGE-reranker + 2-segment cross-plane fanout in one call
 - ✅ Full HTTP surface (gRPC partial; lives behind the runtime flag `MUSUBI_GRPC`, default off)
 - ✅ Plane-aligned endpoint paths: `/v1/episodic`, `/v1/curated`, `/v1/concepts`, `/v1/artifacts`
+- ✅ Agent-as-tenant namespace model: `<agent>/<channel>/<plane>` ([ADR 0030](docs/Musubi/13-decisions/0030-agent-as-tenant.md))
 - ✅ `Last-Event-ID` replay on `/v1/thoughts/stream` — reconnect without losing thoughts
 - ✅ MCP + LiveKit + OpenClaw adapters (external repos), static-bearer auth model with per-agent token support
 - ✅ Supply-chain: cosign + SBOM + Trivy on every published image
+- ✅ Fully automated release chain — conventional commit → release PR auto-merges → tag → signed image → digest pin PR auto-merges. Operator runs `ansible-playbook update.yml` from the control host and that is the only human step.
 - ✅ Operator tooling: `musubi promote force|reject` CLI, vault large-file skip-with-warning, rate-limited vault watcher
 
-Not yet:
+Post-v1.0:
 - ⏳ Fleet orchestration — single-node today; multi-node HA is a post-1.0 design space and will need its own ADR
 - ⏳ Auto-deploy pipeline (image publish is automated; host rollout is still operator-driven via ansible)
 - ⏳ gRPC transport ADR ([#98](https://github.com/ericmey/musubi/issues/98)) — priority-low, not a 1.0 blocker
+- ⏳ Vault-wide sweep to update illustrative `eric/...` examples to agent-as-tenant (normative specs already flipped; docs carry a banner pointing at [ADR 0030](docs/Musubi/13-decisions/0030-agent-as-tenant.md))
 
 Roadmap detail lives in [`docs/Musubi/12-roadmap/`](docs/Musubi/12-roadmap/).
 


### PR DESCRIPTION
No tracking Issue: v1.0 marker — captures the "we're done with pre-release" moment. Triggers release-please to cut 1.0.0 via the `Release-As: 1.0.0` commit trailer (skipping the 0.8.x chain of CI iterations).

## What v1.0 signs off on

- **API shape sealed.** Plane-aligned endpoints, Last-Event-ID replay, 2-seg cross-plane retrieve. No breaking changes before v2.
- **Agent-as-tenant namespace model** ([ADR 0030](docs/Musubi/13-decisions/0030-agent-as-tenant.md)) — namespaces are `<agent>/<channel>/<plane>`, tenant identity is the agent persona itself, household-read glob is `*/<plane>:r`.
- **Both downstream integrations** (openclaw-livekit, openclaw-musubi plugin) on the canonical API under the agent-as-tenant model. Livekit tokens and plugin configs re-minted + validated live on `musubi.mey.house` against a freshly wiped Qdrant.
- **Fully automated release chain**, end to end: conventional commit lands on main → release-please PR opens with auto-merge → CI green → PR auto-merges → tag pushes → `publish-core-image` builds / signs / SBOMs / scans → `auto-digest-bump` opens pin PR with CI via PAT → pin PR auto-merges. The only human step is running `ansible-playbook deploy/ansible/update.yml` from the control host.
- **Supply chain**: cosign keyless OIDC signatures + CycloneDX SBOMs + Trivy CRITICAL-blocking on every image.

## What's NOT in v1.0 (intentional)

- Fleet orchestration (single-node today).
- Auto-deploy to hosts (ansible is the intentional human gate — deploy is a human decision, CI's job stops at the pinned digest).
- Vault-wide sweep to flip illustrative `eric/...` examples to the agent-as-tenant shape (normative specs already flipped + banner-pointer on older docs).

## What happens after merge

1. release-please sees `Release-As: 1.0.0` in the commit trailer, opens **chore(main): release 1.0.0** with auto-merge enabled.
2. CI green → auto-merges → v1.0.0 tag pushes.
3. publish-core-image builds the v1.0.0 image, cosign-signs, attaches SBOM, scans, publishes to GHCR.
4. auto-digest-bump (via workflow_run) opens the v1.0.0 pin PR — CI runs via PAT, auto-merges on green.
5. Main's ansible pin points at v1.0.0's signed digest. Zero manual clicks from PR merge through pin-PR merge.
6. Operator runs `ansible-playbook deploy/ansible/update.yml` from the control host to push v1.0.0 to `musubi.mey.house`.

## Test plan

- [ ] Auto-merge when the repo's required `check` workflow passes.
- [ ] Confirm release-please opens `chore(main): release 1.0.0` within ~1 min of merge.
- [ ] Confirm the full chain (release → tag → image → pin PR) finishes with no human clicks other than the final ansible invocation.
- [ ] `ansible-playbook deploy/ansible/update.yml` deploys cleanly on `musubi.mey.house`.
- [ ] `deploy/smoke/verify.sh` passes against the deployed v1.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)