### PR TITLE
docs(api): clarify include_archived mode-scope; harden state_filter test

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2305,8 +2305,11 @@ components:
             `('matured', 'promoted')` — the v1.0/v1.1 default. Set to
             `['provisional', 'matured', 'promoted']` for explicit recall
             of fresh deliberate stores before maturation has run.
-            `include_archived: true` is a separate axis for archive-side
-            states (`demoted`, `archived`, `superseded`).
+            In `mode='fast'`, `include_archived: true` augments the default
+            with `('demoted', 'archived', 'superseded')`. In `mode='deep'`
+            and `mode='blended'` `include_archived` is currently ignored —
+            pass `state_filter` explicitly when those modes need
+            archive-side states.
       type: object
       required:
       - namespace

--- a/src/musubi/api/routers/retrieve.py
+++ b/src/musubi/api/routers/retrieve.py
@@ -82,8 +82,11 @@ class RetrieveQuery(BaseModel):
             "`['provisional', 'matured', 'promoted']` for explicit recall "
             "where you want fresh deliberate `memory_store` rows visible "
             "before they age through the maturation cron. "
-            "`include_archived: true` is a separate axis that adds the "
-            "archive-side states (`demoted`, `archived`, `superseded`)."
+            "Note: in `mode='fast'`, `include_archived: true` augments the "
+            "default by adding `('demoted', 'archived', 'superseded')`. "
+            "In `mode='deep'` and `mode='blended'`, `include_archived` is "
+            "currently ignored — pass `state_filter` explicitly when those "
+            "modes need archive-side states."
         ),
     )
 

--- a/tests/api/test_retrieve_wildcards.py
+++ b/tests/api/test_retrieve_wildcards.py
@@ -546,13 +546,13 @@ def test_retrieve_state_filter_default_omitted_preserves_v1_0_behaviour(
 ) -> None:
     """`state_filter` field is optional; when omitted, the orchestrator
     falls back to its existing default (`('matured', 'promoted')`).
-    Locks that omission still resolves to the same query body as
-    before this field existed (no surprise behaviour for v1.1.0
-    callers upgrading to v1.2.0)."""
+    Locks that omission still surfaces matured rows AND that the
+    response is well-formed (object_id, namespace, score on every row
+    regardless of state-filter path)."""
     from tests.api.conftest import mint_token
 
     async def _seed() -> None:
-        m = EpisodicMemory(namespace="nyla/voice/episodic", content="matured-row")
+        m = EpisodicMemory(namespace="nyla/voice/episodic", content="matured-row content")
         saved = await episodic.create(m)
         await episodic.transition(
             namespace="nyla/voice/episodic",
@@ -572,6 +572,16 @@ def test_retrieve_state_filter_default_omitted_preserves_v1_0_behaviour(
         json={"namespace": "nyla/*/episodic", "query_text": "matured", "mode": "fast", "limit": 5},
     )
     assert r.status_code == 200, r.text
+    rows = r.json()["results"]
+    # The matured row is visible under the default state filter.
+    assert any(row["content"] == "matured-row content" for row in rows), rows
+    # Response shape: every row carries object_id + concrete 3-seg
+    # namespace + numeric score. Wire shape is the same as v1.1.0.
+    for row in rows:
+        assert isinstance(row.get("object_id"), str) and len(row["object_id"]) == 27
+        assert "*" not in row["namespace"]
+        assert row["namespace"].count("/") == 2
+        assert isinstance(row.get("score"), int | float)
 
 
 def test_retrieve_with_state_filter_provisional_surfaces_fresh_rows(

--- a/uv.lock
+++ b/uv.lock
@@ -732,7 +732,7 @@ wheels = [
 
 [[package]]
 name = "musubi"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Follow-up addressing Copilot comments on #271 (merged). No behaviour change — docstring/OpenAPI clarification + semantic test assertions.