### PR TITLE
chore(deploy): pin musubi-core to v1.2.3 signed digest

### DIFF
--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -38,7 +38,7 @@ musubi_core_port: 8100
 # For what's in a given version, see CHANGELOG.md (authoritative)
 # rather than a comment here — version-specific notes rot; the
 # changelog is the source of truth.
-musubi_core_image: "ghcr.io/ericmey/musubi-core@sha256:21d7a93548541d1ea5a1d56b2d118c50a4b90fe3eee0b564fe6dad57ec8e2944"
+musubi_core_image: "ghcr.io/ericmey/musubi-core@sha256:8c6e0dbbd1397ec200a7c97000b2e2dd4479b4861384fdf7c76b68b0bb5add4f"
 musubi_qdrant_image: "qdrant/qdrant:v1.17.1"
 # TEI image tag = <compute-capability>-<version>. RTX 3080 is Ampere,
 # compute 8.6 → `86-*`. Other GPUs: `turing-*` (RTX 20xx), `89-*` (RTX 40xx),


### PR DESCRIPTION
chore(deploy): pin musubi-core to v1.2.3 signed digest

Automated by `.github/workflows/auto-digest-bump.yml` in response to the [v1.2.3](https://github.com/ericmey/musubi/releases/tag/v1.2.3) release.

## Supply-chain attestations
- cosign keyless signature via GitHub OIDC
- CycloneDX SBOM attached as a cosign attestation
- Trivy vulnerability scan — 0 CRITICAL (gate in `publish-core-image.yml`)

## Verify before deploy

```bash
cosign verify \
  --certificate-identity-regexp 'https://github.com/ericmey/musubi/.*' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  ghcr.io/ericmey/musubi-core@sha256:8c6e0dbbd1397ec200a7c97000b2e2dd4479b4861384fdf7c76b68b0bb5add4f
```

## After merge

```bash
# From the ansible control host:
cd ~/musubi
git pull origin main
ANSIBLE_VAULT_PASSWORD_FILE=~/ansible/.vault_pass \
  ansible-playbook \
    -i deploy/ansible/inventory.yml \
    -e @~/.musubi-secrets/inventory-vars.yml \
    -e @~/.musubi-secrets/vault.yml \
    -e 'changed_services=["core","lifecycle-worker"]' \
    deploy/ansible/update.yml
```

No tracking Issue: auto-generated release digest pin.