### PR TITLE
docs(interfaces): canonical agent-tools surface + ADR 0032

### DIFF
--- a/docs/Musubi/07-interfaces/agent-tools.md
+++ b/docs/Musubi/07-interfaces/agent-tools.md
@@ -1,0 +1,254 @@
+---
+title: Agent Tools — Canonical Surface
+section: 07-interfaces
+tags: [adapter, agent-tools, interfaces, section/interfaces, status/proposed, type/spec]
+type: spec
+status: proposed
+updated: 2026-04-29
+up: "[[07-interfaces/index]]"
+reviewed: false
+---
+# Agent Tools — Canonical Surface
+
+The five tools every Musubi adapter exposes to the agents it hosts. Same names. Same parameter shapes. Same response semantics. Different transports, identical contract.
+
+## Why this exists
+
+Aoi runs across modalities — phone, voice, Discord, Claude Code. The user expects "Aoi, what was I just working on?" to behave the same way regardless of which surface answers. Today it doesn't, because every adapter (`openclaw-musubi`, `openclaw-livekit`, `musubi/adapters/mcp/`) has independently implemented its own agent-tool surface — different names (`musubi_recall` vs `musubi_search` vs `memory_recall`), different parameter shapes, different planes covered. Three implementations, none in sync.
+
+The decision behind this spec is captured in [[13-decisions/0032-agent-tools-canonical-surface]]. This file is the contract every adapter implements.
+
+## The five tools
+
+| Tool | Purpose | Cross-modal by default? |
+|---|---|---|
+| `musubi_recent` | "What's recent in my world?" — recency-ordered, no query | yes |
+| `musubi_search` | "Have I seen X before?" — hybrid + rerank semantic search | yes |
+| `musubi_get` | "Tell me more about that one" — fetch a single object's full content by id | n/a (caller-specified) |
+| `musubi_remember` | "Save this" — explicit episodic capture | no (writes to caller's presence) |
+| `musubi_think` | "Tell my other self" — presence-to-presence message | n/a (caller specifies recipient) |
+
+Adapters MAY also expose lower-level granular tools (per-plane `curated_get`, `thought_history`, etc.) where the surface needs them — but the five above are required and use exactly the names below.
+
+## Naming and shape rules
+
+- **Tool names are canonical.** `musubi_recent`, `musubi_search`, `musubi_get`, `musubi_remember`, `musubi_think`. Adapters do not rename them.
+- **Parameter names are canonical** in `snake_case` at the wire/contract layer. Language-idiomatic adapters MAY translate (e.g. `object_id` → `objectId` in TypeScript) but the spec name is the snake_case form.
+- **Response is unstructured text** that an LLM reads. A formatted multi-line string, not JSON. Each tool defines a stable layout (header line + body) so model behavior is comparable across adapters.
+- **Errors come back as tool errors**, not exceptions. Implementations set the adapter's "tool error" flag (e.g. MCP `isError: true`, OpenClaw plugin `ToolResult.isError`, LiveKit `function_tool` returning the error string).
+- **Defaults match.** When two adapters are given the same logical input, they call the same SDK methods with the same flags.
+
+## Tool contracts
+
+### `musubi_recent`
+
+Recent activity in the calling presence's scope. No query. Default scope is **cross-modal** — fans out across every modality the presence has touched (`<tenant>/*/episodic` per [[13-decisions/0031-retrieve-wildcard-namespace]]).
+
+**Parameters**
+
+| Name | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `limit` | integer | no | 10 | 1–50. Max results to return. |
+| `scope` | enum | no | `cross_modal` | `cross_modal` (`<tenant>/*/episodic`), `presence` (`<tenant>/<presence>/episodic`), `current_modality` (`<tenant>/<presence>/<this-modality>/episodic` if the adapter knows its modality, else falls back to `presence`). |
+| `since` | ISO-8601 timestamp | no | none | Inclusive lower bound. Absent = "newest items, ignoring time." |
+| `tags` | array of strings | no | none | Filter to rows whose `tags` contains every listed tag. |
+
+**SDK call**: `client.retrieve(namespace=<scope-resolved>, mode="recent", limit=…, since=…, tags=…)` — depends on backend `mode=recent` (see `[[_slices/slice-retrieve-recent]]`). Until that lands, adapters MAY implement a fallback via `client.list_episodic(...)` paginated; the fallback's behavior must match the contract (recency-ordered) and is documented in the adapter spec.
+
+**Response shape**
+
+```
+Recent activity ({scope_label}, last {N}):
+
+[{modality}] {created_at} — {one-line content}
+[{modality}] {created_at} — {one-line content}
+…
+```
+
+`{modality}` comes from the row's namespace (segment 2 of `tenant/presence/<modality>/...` if 4-segment; otherwise the presence segment). Empty result returns `No recent activity in {scope_label}.`
+
+**Errors**: backend unavailable → `Couldn't reach memory right now — continuing without it.` (degraded — agent continues).
+
+### `musubi_search`
+
+Hybrid + rerank semantic search across one or more planes. Default scope is **cross-modal episodic** plus **shared curated/concept**. The deep-path tool — slower than the passive prompt supplement, used when the supplement missed.
+
+**Parameters**
+
+| Name | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `query` | string | yes | — | Natural-language query. Min 1 char. |
+| `limit` | integer | no | 5 | 1–20. |
+| `planes` | array of enum | no | `["episodic", "curated", "concept"]` | Subset of `curated`, `concept`, `episodic`, `artifact`. |
+| `scope` | enum | no | `cross_modal` | Same options as `musubi_recent.scope`. |
+
+**SDK call**: `client.retrieve(namespace=<scope-resolved>, query_text=query, mode="deep", planes=…, limit=…)`. Implementations fan out per-plane when needed, dedup by `object_id`, sort by score, slice to `limit`.
+
+**Response shape**
+
+```
+{N} result(s) for "{query}":
+
+[{plane}] (score {score}) {namespace}/{object_id} — {title-or-snippet}
+{content}
+
+[{plane}] (score {score}) {namespace}/{object_id} — {title-or-snippet}
+{content}
+
+…
+```
+
+Empty result returns `No memories matched "{query}".`
+
+**Errors**: same degradation message as `musubi_recent`.
+
+### `musubi_get`
+
+Fetch one object's full content + metadata by id. Companion to `musubi_search` — the agent copies `(plane, namespace, object_id)` straight from a result row.
+
+**Parameters**
+
+| Name | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `plane` | enum | yes | — | One of `curated`, `concept`, `episodic`, `artifact`. |
+| `namespace` | string | yes | — | The namespace from a `musubi_search` row. |
+| `object_id` | string | yes | — | The object id from a `musubi_search` row. |
+
+**SDK call**: `client.{plane}.get(namespace=…, object_id=…)`. Plane → endpoint mapping is hard-coded per [[07-interfaces/canonical-api]] (`/v1/curated/{id}`, `/v1/concepts/{id}`, `/v1/episodic/{id}`, `/v1/artifacts/{id}`).
+
+**Response shape**
+
+```
+[{plane}] {namespace}/{object_id}
+
+{key}: {value}
+{key}: {value}
+…
+
+{content-or-body-or-summary}
+```
+
+The metadata block prints whichever canonical fields are present (`title`, `state`, `importance`, `event_at`, `vault_path`, `topics`, `tags`, `participants`) — adapters do not need a per-plane schema, just a stable rendering of present fields.
+
+**Errors**: 404 → tool error `Musubi has no {plane} object {id} in namespace {ns}.` Other errors → tool error `Musubi get failed: {message}`.
+
+### `musubi_remember`
+
+Explicit episodic capture into the caller's presence. Higher importance than the passive capture mirror's default (5) so deliberate calls outweigh ambient writes.
+
+**Parameters**
+
+| Name | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `content` | string | yes | — | Min 1 char. The thing worth remembering. One fact/observation per call. |
+| `importance` | integer | no | 7 | 1–10. |
+| `topics` | array of strings | no | `[]` | Topic tags for later filtering. |
+| `idempotency_key` | string | no | auto-generated | Override only when the agent has a stable client-side id. |
+
+**SDK call**: `client.episodic.capture(namespace=<presence>/episodic, content=…, importance=…, tags=topics+[<adapter-tag>], idempotency_key=…)`. Adapters MUST add their own modality tag to `tags` (e.g. `src:openclaw-agent-remember`, `src:livekit-voice-remember`) so a downstream `musubi_recent --tags=src:livekit-voice-remember` can filter to a specific modality.
+
+**Response shape**: `Remembered in Musubi episodic ({namespace}) — id {object_id}.`
+
+**Errors**: typed error subclass message (auth/transient/client). Each surfaces a specific user-facing string per the SDK error taxonomy.
+
+### `musubi_think`
+
+Presence-to-presence message. The agent saying "tell my other self that X" — a thought lands in the recipient presence's stream and surfaces in their next turn as inbound context.
+
+**Parameters**
+
+| Name | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `to_presence` | string | yes | — | Recipient. Either the canonical `<owner>/<presence>` form or a short alias the adapter resolves (e.g. `aoi` → `eric/aoi`). `all` broadcasts. |
+| `content` | string | yes | — | Min 1 char. |
+| `channel` | string | no | `default` | Channel within the recipient's inbox. Use `scheduler` for time-boxed reminders. |
+| `importance` | integer | no | 5 | 1–10. Priority hint. |
+
+**SDK call**: `client.thoughts.send(namespace=<sender>/thought, from_presence=…, to_presence=…, content=…, channel=…, importance=…)`.
+
+**Response shape**: `Sent to {to_presence}. (id={object_id})`
+
+**Errors**: same taxonomy as `musubi_remember`.
+
+## Cross-cutting requirements
+
+### Presence resolution
+
+Every tool resolves the calling presence the same way: from the adapter's runtime context (OpenClaw `agentId`, LiveKit `AgentConfig`, MCP `session_key` once supported). The presence resolver maps that to `<owner>/<presence>` and the conventional namespaces:
+
+- `<owner>/<presence>/episodic` for episodic reads/writes
+- `<owner>/<presence>/thought` for thought sends
+- `<owner>/<presence>/artifact` for artifacts
+- `<owner>/_shared/curated` and `<owner>/_shared/concept` for shared knowledge reads (also `<owner>/<presence>/curated` for presence-specific curated, when present)
+
+Adapters fail loud (presence-resolution error → tool error) rather than silently using a default namespace.
+
+### Modality tagging
+
+Every `musubi_remember` capture carries a `src:<adapter>-<verb>` tag so `musubi_recent` and `musubi_search` can filter or label by source modality. Required tags:
+
+| Adapter | `src:` tag |
+|---|---|
+| OpenClaw plugin | `src:openclaw-agent-remember` |
+| LiveKit voice | `src:livekit-voice-remember` |
+| MCP | `src:mcp-agent-remember` |
+| Capture mirror (passive) | `src:openclaw-capture-mirror` (etc.) |
+
+The capture mirror's tag is per-modality; this is how `musubi_recent --tags=src:openclaw-capture-mirror` finds passive captures from a specific surface.
+
+### Cross-modal default
+
+`musubi_recent` and `musubi_search` default to the wildcard tenant scope (`<tenant>/*/episodic`) so an agent on the phone says "what was I just working on?" and gets answers from every modality, not just phone history. Per-modality narrowing is opt-in via `scope=current_modality` or `scope=presence`.
+
+This is the load-bearing behavioral choice: cross-modality is the *expected* default for an agent that exists across modalities. Restricting scope is the deliberate exception.
+
+### Aliases during deprecation
+
+Each adapter ships the existing pre-canonical names as aliases for **one minor release** after canonical lands. The aliases:
+
+- log a deprecation warning (`canonical name musubi_X has superseded legacy name Y`)
+- forward to the canonical implementation
+- do not appear in tool advertisements
+
+Concretely:
+
+| Legacy name | Canonical | Adapter |
+|---|---|---|
+| `musubi_recall` | `musubi_search` | openclaw-musubi, livekit-v2-dormant |
+| `memory_recall` | `musubi_search` | mcp-adapter |
+| `memory_capture` | `musubi_remember` | mcp-adapter |
+
+## Test contract
+
+Every adapter runs the canonical agent-tools contract suite (extends [[07-interfaces/contract-tests]]). A reference implementation lives in `tests/contract/agent_tools/` once shipped. Required cases (one per tool unless noted):
+
+- [ ] **`musubi_recent` — basic.** Capture three rows in three different modality namespaces (`<tenant>/<p>/episodic`, `<tenant>/<p2>/episodic`, …). Call `musubi_recent` with `scope=cross_modal`. All three rows surface, newest-first.
+- [ ] **`musubi_recent` — scope narrowing.** Same setup, call with `scope=presence`. Only the rows from the calling presence's namespace surface.
+- [ ] **`musubi_recent` — tag filter.** Capture rows with and without `src:adapter-foo`. Call with `tags=["src:adapter-foo"]`. Only tagged rows surface.
+- [ ] **`musubi_search` — cross-modal.** Capture a distinctive phrase in `<tenant>/<other-presence>/episodic`. Call `musubi_search` with `scope=cross_modal` and the phrase. Row surfaces.
+- [ ] **`musubi_search` — plane filter.** With curated and episodic both holding the query term, `planes=["episodic"]` returns only the episodic row.
+- [ ] **`musubi_get` — round-trip.** Capture a row via `musubi_remember`. Call `musubi_search` to get the id. Call `musubi_get` with that `(plane, namespace, object_id)`. Returned content matches the captured content exactly.
+- [ ] **`musubi_get` — 404.** Call with an unknown `object_id`. Tool error returned, message names the missing id and namespace.
+- [ ] **`musubi_remember` — modality tagging.** Captured row's `tags` contain the adapter's `src:` tag.
+- [ ] **`musubi_remember` — idempotency.** Two calls with the same `idempotency_key` and content store one row.
+- [ ] **`musubi_think` — round-trip.** Send a thought from presence A to presence B. The thought appears on B's inbound stream within the contract-test timeout.
+- [ ] **Degraded mode.** Backend unavailable. Each tool returns a tool error with a user-readable message; the adapter does not raise.
+- [ ] **Presence-resolution failure.** Tool called without resolvable presence. Each tool returns a tool error naming the resolution problem.
+
+## Implementation status
+
+| Adapter | Tracking slice | Status |
+|---|---|---|
+| MCP | `[[_slices/slice-mcp-canonical-tools]]` | proposed |
+| OpenClaw plugin | `[[_slices/slice-openclaw-canonical-tools]]` | proposed (extends openclaw-musubi PR #24) |
+| LiveKit | `[[_slices/slice-livekit-canonical-tools]]` | proposed |
+| Backend `mode=recent` | `[[_slices/slice-retrieve-recent]]` | proposed |
+
+## Related
+
+- [[13-decisions/0032-agent-tools-canonical-surface]] — the decision behind this spec.
+- [[07-interfaces/canonical-api]] — the underlying API surface every tool calls.
+- [[07-interfaces/mcp-adapter]] — MCP-specific transport notes.
+- [[07-interfaces/livekit-adapter]] — LiveKit-specific transport notes.
+- [[07-interfaces/openclaw-adapter]] — OpenClaw-specific transport notes.
+- [[13-decisions/0031-retrieve-wildcard-namespace]] — the wildcard-namespace primitive that makes cross-modal default possible.

--- a/docs/Musubi/07-interfaces/agent-tools.md
+++ b/docs/Musubi/07-interfaces/agent-tools.md
@@ -22,10 +22,10 @@ The decision behind this spec is captured in [[13-decisions/0032-agent-tools-can
 
 | Tool | Purpose | Cross-modal by default? |
 |---|---|---|
-| `musubi_recent` | "What's recent in my world?" — recency-ordered, no query | yes |
-| `musubi_search` | "Have I seen X before?" — hybrid + rerank semantic search | yes |
+| `musubi_recent` | "What's recent in my world?" — recency-ordered, no query | yes (cross-channel) |
+| `musubi_search` | "Have I seen X before?" — hybrid + rerank semantic search | yes (cross-channel) |
 | `musubi_get` | "Tell me more about that one" — fetch a single object's full content by id | n/a (caller-specified) |
-| `musubi_remember` | "Save this" — explicit episodic capture | no (writes to caller's presence) |
+| `musubi_remember` | "Save this" — explicit episodic capture | no (writes to the calling agent's own channel) |
 | `musubi_think` | "Tell my other self" — presence-to-presence message | n/a (caller specifies recipient) |
 
 Adapters MAY also expose lower-level granular tools (per-plane `curated_get`, `thought_history`, etc.) where the surface needs them — but the five above are required and use exactly the names below.
@@ -42,30 +42,30 @@ Adapters MAY also expose lower-level granular tools (per-plane `curated_get`, `t
 
 ### `musubi_recent`
 
-Recent activity in the calling presence's scope. No query. Default scope is **cross-modal** — fans out across every modality the presence has touched (`<tenant>/*/episodic` per [[13-decisions/0031-retrieve-wildcard-namespace]]).
+Recent activity in the calling agent's scope. No query. Default scope is **cross-channel** — fans out across every channel/modality the agent has touched (`<agent>/*/episodic` per [[13-decisions/0030-agent-as-tenant]] + [[13-decisions/0031-retrieve-wildcard-namespace]]).
 
 **Parameters**
 
 | Name | Type | Required | Default | Notes |
 |---|---|---|---|---|
 | `limit` | integer | no | 10 | 1–50. Max results to return. |
-| `scope` | enum | no | `cross_modal` | `cross_modal` (`<tenant>/*/episodic`), `presence` (`<tenant>/<presence>/episodic`), `current_modality` (`<tenant>/<presence>/<this-modality>/episodic` if the adapter knows its modality, else falls back to `presence`). |
+| `scope` | enum | no | `cross_channel` | `cross_channel` (`<agent>/*/episodic` — every channel the agent has captured to), `current_channel` (`<agent>/<channel>/episodic` — only the calling adapter's channel). Channels per ADR 0030: `voice`, `discord`, `openclaw`, etc. |
 | `since` | ISO-8601 timestamp | no | none | Inclusive lower bound. Absent = "newest items, ignoring time." |
 | `tags` | array of strings | no | none | Filter to rows whose `tags` contains every listed tag. |
 
-**SDK call**: `client.retrieve(namespace=<scope-resolved>, mode="recent", limit=…, since=…, tags=…)` — depends on backend `mode=recent` (see `[[_slices/slice-retrieve-recent]]`). Until that lands, adapters MAY implement a fallback via `client.list_episodic(...)` paginated; the fallback's behavior must match the contract (recency-ordered) and is documented in the adapter spec.
+**SDK call**: the canonical landing is `client.retrieve(namespace=<scope-resolved>, mode="recent", limit=…)` once `mode=recent` ships (see [[_slices/slice-retrieve-recent]]). The exact request shape — including how `since` and `tags` are wired (top-level vs. inside a `filters` object) — is defined by that slice; the agent-facing parameter names above are stable, the over-the-wire mapping is the slice author's call. Until `mode=recent` lands, adapters MAY paginate `GET /v1/episodic?namespace=…&limit=…` and sort client-side by event timestamp; the fallback is documented per adapter and is presence-scoped only (cross-channel needs the wildcards primitive).
 
 **Response shape**
 
 ```
 Recent activity ({scope_label}, last {N}):
 
-[{modality}] {created_at} — {one-line content}
-[{modality}] {created_at} — {one-line content}
+[{channel}] {event_at} — {one-line content}
+[{channel}] {event_at} — {one-line content}
 …
 ```
 
-`{modality}` comes from the row's namespace (segment 2 of `tenant/presence/<modality>/...` if 4-segment; otherwise the presence segment). Empty result returns `No recent activity in {scope_label}.`
+`{channel}` is segment 2 of the row's stored namespace (`<agent>/<channel>/<plane>` — channel = the modality the row was captured on). Empty result returns `No recent activity in {scope_label}.`
 
 **Errors**: backend unavailable → `Couldn't reach memory right now — continuing without it.` (degraded — agent continues).
 
@@ -80,7 +80,7 @@ Hybrid + rerank semantic search across one or more planes. Default scope is **cr
 | `query` | string | yes | — | Natural-language query. Min 1 char. |
 | `limit` | integer | no | 5 | 1–20. |
 | `planes` | array of enum | no | `["episodic", "curated", "concept"]` | Subset of `curated`, `concept`, `episodic`, `artifact`. |
-| `scope` | enum | no | `cross_modal` | Same options as `musubi_recent.scope`. |
+| `scope` | enum | no | `cross_channel` | Same options as `musubi_recent.scope`. |
 
 **SDK call**: `client.retrieve(namespace=<scope-resolved>, query_text=query, mode="deep", planes=…, limit=…)`. Implementations fan out per-plane when needed, dedup by `object_id`, sort by score, slice to `limit`.
 
@@ -114,7 +114,14 @@ Fetch one object's full content + metadata by id. Companion to `musubi_search` �
 | `namespace` | string | yes | — | The namespace from a `musubi_search` row. |
 | `object_id` | string | yes | — | The object id from a `musubi_search` row. |
 
-**SDK call**: `client.{plane}.get(namespace=…, object_id=…)`. Plane → endpoint mapping is hard-coded per [[07-interfaces/canonical-api]] (`/v1/curated/{id}`, `/v1/concepts/{id}`, `/v1/episodic/{id}`, `/v1/artifacts/{id}`).
+**SDK call**: explicit plane → SDK accessor + endpoint mapping below. The Python SDK uses singular accessors for `episodic` and `curated`, plural for `concepts` and `artifacts` (matching the canonical-API path prefixes). Adapter implementations hard-code this mapping so the agent never deals with the pluralization rule:
+
+| Tool param `plane` | Python SDK accessor | API path |
+|---|---|---|
+| `curated` | `client.curated.get()` | `GET /v1/curated/{id}` |
+| `concept` | `client.concepts.get()` | `GET /v1/concepts/{id}` |
+| `episodic` | `client.episodic.get()` | `GET /v1/episodic/{id}` |
+| `artifact` | `client.artifacts.get()` | `GET /v1/artifacts/{id}` |
 
 **Response shape**
 
@@ -145,7 +152,7 @@ Explicit episodic capture into the caller's presence. Higher importance than the
 | `topics` | array of strings | no | `[]` | Topic tags for later filtering. |
 | `idempotency_key` | string | no | auto-generated | Override only when the agent has a stable client-side id. |
 
-**SDK call**: `client.episodic.capture(namespace=<presence>/episodic, content=…, importance=…, tags=topics+[<adapter-tag>], idempotency_key=…)`. Adapters MUST add their own modality tag to `tags` (e.g. `src:openclaw-agent-remember`, `src:livekit-voice-remember`) so a downstream `musubi_recent --tags=src:livekit-voice-remember` can filter to a specific modality.
+**SDK call**: `client.episodic.capture(namespace="<agent>/<channel>/episodic", content=…, importance=…, tags=…, idempotency_key=…)`. The canonical `CaptureRequest` body has no separate `topics` field — the adapter folds the agent-supplied `topics` array into `tags`, then appends the required modality tag (`src:openclaw-agent-remember`, `src:livekit-voice-remember`, `src:mcp-agent-remember`) so a downstream `musubi_recent --tags=src:livekit-voice-remember` can filter to a specific channel. Namespace is the calling agent's 3-segment episodic namespace (`<agent>/<channel>/episodic`) per [[13-decisions/0030-agent-as-tenant]].
 
 **Response shape**: `Remembered in Musubi episodic ({namespace}) — id {object_id}.`
 
@@ -159,12 +166,12 @@ Presence-to-presence message. The agent saying "tell my other self that X" — a
 
 | Name | Type | Required | Default | Notes |
 |---|---|---|---|---|
-| `to_presence` | string | yes | — | Recipient. Either the canonical `<owner>/<presence>` form or a short alias the adapter resolves (e.g. `aoi` → `eric/aoi`). `all` broadcasts. |
+| `to_presence` | string | yes | — | Recipient. Either the canonical `<agent>/<channel>` form (e.g. `aoi/voice`, `nyla/discord`) or a bare `<agent>` alias the adapter resolves to its default channel. `all` broadcasts. |
 | `content` | string | yes | — | Min 1 char. |
 | `channel` | string | no | `default` | Channel within the recipient's inbox. Use `scheduler` for time-boxed reminders. |
 | `importance` | integer | no | 5 | 1–10. Priority hint. |
 
-**SDK call**: `client.thoughts.send(namespace=<sender>/thought, from_presence=…, to_presence=…, content=…, channel=…, importance=…)`.
+**SDK call**: `client.thoughts.send(namespace="<sender-agent>/<sender-channel>/thought", from_presence=…, to_presence=…, content=…, channel=…, importance=…)`. Namespace is the sender's 3-segment thought namespace per [[13-decisions/0030-agent-as-tenant]].
 
 **Response shape**: `Sent to {to_presence}. (id={object_id})`
 
@@ -174,14 +181,15 @@ Presence-to-presence message. The agent saying "tell my other self that X" — a
 
 ### Presence resolution
 
-Every tool resolves the calling presence the same way: from the adapter's runtime context (OpenClaw `agentId`, LiveKit `AgentConfig`, MCP `session_key` once supported). The presence resolver maps that to `<owner>/<presence>` and the conventional namespaces:
+Every tool resolves the calling agent + channel the same way: from the adapter's runtime context (OpenClaw `agentId`, LiveKit `AgentConfig`, MCP session context). The resolver maps that to a 3-segment namespace per [[13-decisions/0030-agent-as-tenant]]:
 
-- `<owner>/<presence>/episodic` for episodic reads/writes
-- `<owner>/<presence>/thought` for thought sends
-- `<owner>/<presence>/artifact` for artifacts
-- `<owner>/_shared/curated` and `<owner>/_shared/concept` for shared knowledge reads (also `<owner>/<presence>/curated` for presence-specific curated, when present)
+- `<agent>/<channel>/episodic` for episodic reads/writes
+- `<agent>/<channel>/thought` for thought sends
+- `<agent>/<channel>/artifact` for artifacts
+- `<agent>/<channel>/curated` for the agent's own curated notes
+- Cross-channel reads use the 2-seg or wildcard form: `<agent>/<channel>` (cross-plane) or `<agent>/*/episodic` (cross-channel within an agent)
 
-Adapters fail loud (presence-resolution error → tool error) rather than silently using a default namespace.
+Where channels are the v1.0 set: `voice`, `discord`, `openclaw`, with more added as integrations land. Adapters fail loud (presence-resolution error → tool error) rather than silently using a default namespace.
 
 ### Modality tagging
 
@@ -196,11 +204,11 @@ Every `musubi_remember` capture carries a `src:<adapter>-<verb>` tag so `musubi_
 
 The capture mirror's tag is per-modality; this is how `musubi_recent --tags=src:openclaw-capture-mirror` finds passive captures from a specific surface.
 
-### Cross-modal default
+### Cross-channel default
 
-`musubi_recent` and `musubi_search` default to the wildcard tenant scope (`<tenant>/*/episodic`) so an agent on the phone says "what was I just working on?" and gets answers from every modality, not just phone history. Per-modality narrowing is opt-in via `scope=current_modality` or `scope=presence`.
+`musubi_recent` and `musubi_search` default to the wildcard channel scope (`<agent>/*/episodic`) so an agent on the phone (voice channel) says "what was I just working on?" and gets answers from every channel that agent has captured to (voice + discord + openclaw + …), not just voice history. Per-channel narrowing is opt-in via `scope=current_channel`.
 
-This is the load-bearing behavioral choice: cross-modality is the *expected* default for an agent that exists across modalities. Restricting scope is the deliberate exception.
+This is the load-bearing behavioral choice: cross-channel continuity is the *expected* default for an agent that exists across channels. Restricting scope is the deliberate exception.
 
 ### Aliases during deprecation
 
@@ -222,10 +230,10 @@ Concretely:
 
 Every adapter runs the canonical agent-tools contract suite (extends [[07-interfaces/contract-tests]]). A reference implementation lives in `tests/contract/agent_tools/` once shipped. Required cases (one per tool unless noted):
 
-- [ ] **`musubi_recent` — basic.** Capture three rows in three different modality namespaces (`<tenant>/<p>/episodic`, `<tenant>/<p2>/episodic`, …). Call `musubi_recent` with `scope=cross_modal`. All three rows surface, newest-first.
-- [ ] **`musubi_recent` — scope narrowing.** Same setup, call with `scope=presence`. Only the rows from the calling presence's namespace surface.
+- [ ] **`musubi_recent` — basic.** Capture three rows in three different channel namespaces of the same agent (`<agent>/voice/episodic`, `<agent>/discord/episodic`, `<agent>/openclaw/episodic`). Call `musubi_recent` with `scope=cross_channel`. All three rows surface, newest-first.
+- [ ] **`musubi_recent` — scope narrowing.** Same setup, call with `scope=current_channel`. Only the rows from the calling adapter's channel surface.
 - [ ] **`musubi_recent` — tag filter.** Capture rows with and without `src:adapter-foo`. Call with `tags=["src:adapter-foo"]`. Only tagged rows surface.
-- [ ] **`musubi_search` — cross-modal.** Capture a distinctive phrase in `<tenant>/<other-presence>/episodic`. Call `musubi_search` with `scope=cross_modal` and the phrase. Row surfaces.
+- [ ] **`musubi_search` — cross-channel.** Capture a distinctive phrase in `<agent>/<other-channel>/episodic`. Call `musubi_search` with `scope=cross_channel` and the phrase. Row surfaces.
 - [ ] **`musubi_search` — plane filter.** With curated and episodic both holding the query term, `planes=["episodic"]` returns only the episodic row.
 - [ ] **`musubi_get` — round-trip.** Capture a row via `musubi_remember`. Call `musubi_search` to get the id. Call `musubi_get` with that `(plane, namespace, object_id)`. Returned content matches the captured content exactly.
 - [ ] **`musubi_get` — 404.** Call with an unknown `object_id`. Tool error returned, message names the missing id and namespace.

--- a/docs/Musubi/07-interfaces/index.md
+++ b/docs/Musubi/07-interfaces/index.md
@@ -16,6 +16,7 @@ How the world reaches Musubi. One canonical API at the core; one SDK that speaks
 
 - [[07-interfaces/canonical-api]] — The authoritative interface contract. All surfaces derive from this.
 - [[07-interfaces/sdk]] — The Python SDK. Adapters consume it; Musubi ships it.
+- [[07-interfaces/agent-tools]] — Canonical five-tool surface (`musubi_recent`, `musubi_search`, `musubi_get`, `musubi_remember`, `musubi_think`) every adapter exposes to its agents. Backed by [[13-decisions/0032-agent-tools-canonical-surface]].
 - [[07-interfaces/mcp-adapter]] — Maps Musubi SDK to the Model Context Protocol (OAuth 2.1 finalized June 2025). Independent repo.
 - [[07-interfaces/livekit-adapter]] — Maps Musubi SDK to LiveKit voice agents (Slow Thinker / Fast Talker). Independent repo.
 - [[07-interfaces/openclaw-adapter]] — Maps Musubi SDK to the OpenClaw browser-extension agent. Independent repo.

--- a/docs/Musubi/07-interfaces/mcp-adapter.md
+++ b/docs/Musubi/07-interfaces/mcp-adapter.md
@@ -30,44 +30,33 @@ Same core logic; different MCP server bootstrap.
 
 ## Tools exposed
 
-We expose the subset of Musubi that makes sense for a coding agent. Not everything.
+The MCP adapter exposes the **canonical agent-tools surface** ([[07-interfaces/agent-tools]]) — five tools, identical names + parameter shapes across every adapter, backed by [[13-decisions/0032-agent-tools-canonical-surface]].
 
-**Implementation status:** the current adapter (`src/musubi/adapters/mcp/tools.py`) registers `memory_capture` + `memory_recall` — enough for the v1.0 cut. The rest of the tables below is the **designed** MCP surface; unchecked rows are tracked in `[[_slices/slice-adapter-mcp]]` as follow-up work, not v1.0 scope.
+| Canonical tool | Status | Musubi call |
+|---|---|---|
+| `musubi_recent` | tracked in [[_slices/slice-mcp-canonical-tools]] | `client.retrieve(mode="recent")` (depends on [[_slices/slice-retrieve-recent]]) |
+| `musubi_search` | tracked in [[_slices/slice-mcp-canonical-tools]] | `client.retrieve(mode="deep")` |
+| `musubi_get` | tracked in [[_slices/slice-mcp-canonical-tools]] | `client.{plane}.get()` |
+| `musubi_remember` | tracked in [[_slices/slice-mcp-canonical-tools]] | `client.episodic.capture()` |
+| `musubi_think` | tracked in [[_slices/slice-mcp-canonical-tools]] | `client.thoughts.send()` |
 
-### Memory
+**Implementation status (April 2026):** the current adapter (`src/musubi/adapters/mcp/tools.py`) registers only `memory_capture` + `memory_recall` — pre-canonical names from the v1.0 cut. ADR 0032 supersedes those; the canonical surface lands via [[_slices/slice-mcp-canonical-tools]], which keeps `memory_capture` + `memory_recall` as deprecated aliases for one minor release before removal.
 
-| Tool | Status | Musubi call | Notes |
-|---|---|---|---|
-| `memory_capture` | shipped | `client.episodic.capture()` | Capture a new episodic observation. |
-| `memory_recall` | shipped | `client.retrieve(mode="fast")` | Retrieve for just-in-time context. |
-| `memory_recent` | planned | Filtered retrieve | Recent items in a namespace. |
-| `memory_forget` | planned | Raw `DELETE /v1/episodic/{id}` (SDK method TBD) | Soft-archive. No `client.episodic.archive()` on the SDK yet. |
-| `memory_reflect` | planned | Filtered retrieve + aggregation | Returns counts by tag/topic (no LLM). |
+### Granular plane tools (optional, not required by the canonical surface)
 
-### Curated
+The MCP adapter MAY expose finer-grained per-plane tools for power-use scenarios that the agent-level surface doesn't cover. These are **optional** and tracked in [[_slices/slice-adapter-mcp]] as follow-up work — not v1.0 scope, not required for canonical conformance.
 
 | Tool | Musubi call | Notes |
 |---|---|---|
-| `curated_search` | Retrieve with `planes=["curated"]` | |
-| `curated_get` | `client.curated.get(id)` | Full body on demand. |
 | `curated_link_topics` | (future) | Bulk re-tag. Post-v1. |
-
-### Thoughts
-
-| Tool | Musubi call | Notes |
-|---|---|---|
-| `thought_send` | `client.thoughts.send()` | |
-| `thought_check` | `client.thoughts.check()` | |
-| `thought_read` | `client.thoughts.read()` | |
-| `thought_history` | `client.thoughts.history()` | |
-
-### Artifacts
-
-| Tool | Musubi call | Notes |
-|---|---|---|
+| `thought_check` | `client.thoughts.check()` | Inbox poll, agent-side polling pattern. |
+| `thought_history` | `client.thoughts.history()` | Backfill on `X-Musubi-Replay-Truncated`. |
 | `artifact_upload` | `client.artifacts.upload()` | File stays in memory on MCP side; streamed. |
-| `artifact_get` | `client.artifacts.get()` | |
-| `artifact_chunks` | `client.artifacts.chunks()` | |
+| `artifact_chunks` | `client.artifacts.chunks()` | Direct chunk access for large artifacts. |
+| `memory_forget` | Raw `DELETE /v1/episodic/{id}` (SDK method TBD) | Soft-archive. Power-use only. |
+| `memory_reflect` | Filtered retrieve + aggregation | Returns counts by tag/topic (no LLM). |
+
+`musubi_get` covers single-object retrieval across every plane (curated, concept, episodic, artifact) — no separate `curated_get` / `artifact_get` needed at the agent layer.
 
 ### Not exposed via MCP
 
@@ -78,12 +67,16 @@ We expose the subset of Musubi that makes sense for a coding agent. Not everythi
 
 This restriction is important — an agent should not be able to delete a curated file, reject a concept, or reconcile the vault. Read + write-new + soft-delete is the appropriate scope.
 
-## Tool definitions (snippet)
+## Tool definitions
+
+Canonical tool input/output schemas live in [[07-interfaces/agent-tools]]. The MCP adapter renders each schema into MCP `inputSchema` form — JSON-schema-flavored — at registration time. Tool descriptions adapt the canonical text for an MCP audience but never rename the tool or change its parameter names.
+
+The legacy snippet below is the v1.0 `memory_capture` shape, kept here only as a reference for the deprecation alias path. Once aliases drop after one minor release, this block goes too.
 
 ```json
 {
   "name": "memory_capture",
-  "description": "Capture a new episodic memory observation in Musubi.",
+  "description": "[DEPRECATED] Use musubi_remember. Capture a new episodic memory observation in Musubi.",
   "inputSchema": {
     "type": "object",
     "required": ["content", "namespace"],
@@ -94,19 +87,9 @@ This restriction is important — an agent should not be able to delete a curate
       "topics": {"type": "array", "items": {"type": "string"}},
       "importance": {"type": "integer", "minimum": 1, "maximum": 10}
     }
-  },
-  "outputSchema": {
-    "type": "object",
-    "properties": {
-      "object_id": {"type": "string"},
-      "state": {"type": "string"},
-      "dedup": {"type": ["object", "null"]}
-    }
   }
 }
 ```
-
-Tool definitions mirror the canonical API shapes — they're auto-generated from the pydantic models (see `musubi-mcp-adapter/codegen/`).
 
 ## Resources
 

--- a/docs/Musubi/07-interfaces/openclaw-adapter.md
+++ b/docs/Musubi/07-interfaces/openclaw-adapter.md
@@ -29,7 +29,19 @@ Every episodic event emitted by an OpenClaw agent — user messages, agent respo
 
 ### Prompt + corpus supplement
 
-On each agent turn, the plugin asks Musubi for curated + concept hits relevant to the in-flight context and blends them into the prompt as an authority-labeled supplement ("from your durable memory…"). Corpus search is available as a tool (`musubi_recall`) for explicit lookup.
+On each agent turn, the plugin asks Musubi for curated + concept hits relevant to the in-flight context and blends them into the prompt as an authority-labeled supplement ("from your durable memory…"). Explicit search and drill-into-source are available as tools — see the canonical agent-tools surface (next section).
+
+### Canonical agent tools
+
+The plugin exposes the **canonical agent-tools surface** ([[07-interfaces/agent-tools]]) — five tools shared with every other Musubi adapter (MCP, LiveKit). Per [[13-decisions/0032-agent-tools-canonical-surface]]:
+
+- `musubi_recent` — recent activity, cross-modal by default.
+- `musubi_search` — hybrid + rerank semantic search.
+- `musubi_get` — fetch one object's full content by id.
+- `musubi_remember` — explicit episodic capture.
+- `musubi_think` — presence-to-presence message.
+
+Migration tracker: openclaw-musubi PR #24 lands `musubi_get` + the alias path `musubi_recall` → `musubi_search` and adds `musubi_recent`. After one minor release, `musubi_recall` drops.
 
 ### Thoughts
 
@@ -146,7 +158,7 @@ Idempotency is **header-only** — `Idempotency-Key`. There is no `client_id` bo
 
 ## Lifecycle
 
-- **Plugin start** → validate config → resolve presences → open one SSE subscription per presence → register tools (`musubi_recall`, `musubi_remember`, `musubi_think`).
+- **Plugin start** → validate config → resolve presences → open one SSE subscription per presence → register canonical tools (`musubi_recent`, `musubi_search`, `musubi_get`, `musubi_remember`, `musubi_think`) per [[07-interfaces/agent-tools]] + the deprecated `musubi_recall` alias for one minor release.
 - **Plugin unload** → close SSE subscriptions → drain in-flight captures → release tokens. Leaking the SSE listener or the capture retry loop will keep the Node.js process alive past unload.
 - **Error taxonomy** — `401` → token invalid (re-auth); `403` → scope insufficient (surface to user, don't retry); `422` → payload invalid (bug in plugin, log + drop); `503` → backend down, honor `Retry-After`.
 

--- a/docs/Musubi/13-decisions/0032-agent-tools-canonical-surface.md
+++ b/docs/Musubi/13-decisions/0032-agent-tools-canonical-surface.md
@@ -4,6 +4,8 @@ section: 13-decisions
 tags: [adapters, adr, agent-tools, architecture, section/decisions, status/proposed, type/adr]
 type: adr
 status: proposed
+date: 2026-04-29
+deciders: [Eric]
 updated: 2026-04-29
 up: "[[13-decisions/index]]"
 reviewed: false

--- a/docs/Musubi/13-decisions/0032-agent-tools-canonical-surface.md
+++ b/docs/Musubi/13-decisions/0032-agent-tools-canonical-surface.md
@@ -1,0 +1,152 @@
+---
+title: "ADR 0032: Canonical Agent-Tools Surface"
+section: 13-decisions
+tags: [adapters, adr, agent-tools, architecture, section/decisions, status/proposed, type/adr]
+type: adr
+status: proposed
+updated: 2026-04-29
+up: "[[13-decisions/index]]"
+reviewed: false
+---
+# ADR 0032: Canonical Agent-Tools Surface
+
+**Status:** proposed
+**Date:** 2026-04-29
+**Deciders:** Eric
+
+## Context
+
+Musubi exists across modalities. The same logical agent — Aoi — runs on the phone (OpenClaw), in voice calls (LiveKit), in OpenClaw chat sessions, and (eventually, when wired) in Claude Code (MCP). The user expects that saying "Aoi, what was I just working on?" behaves identically regardless of which modality answers, because to the user there is one Aoi.
+
+This is not how it works today. Each adapter has independently defined its agent-tool surface:
+
+| Adapter | Implements | Tools exposed |
+|---|---|---|
+| `openclaw-musubi` (TS) | OpenClaw plugin | `musubi_recall`, `musubi_remember`, `musubi_think` |
+| `openclaw-livekit` (Python, **active path**) | LiveKit voice | `musubi_recent`, `musubi_search`, `musubi_remember` |
+| `openclaw-livekit` (Python, **dormant v2 path**) | LiveKit voice | `musubi_recall`, `musubi_remember`, `musubi_think` |
+| `musubi/adapters/mcp/` (Python) | MCP server | `memory_capture`, `memory_recall` |
+
+Three observations about the current state:
+
+1. **Tool names diverge.** "Search" is `musubi_recall` in two surfaces, `musubi_search` in one, `memory_recall` in another. "Write" is `musubi_remember` in three surfaces, `memory_capture` in one. Same intent, four different tool calls.
+2. **Tool sets diverge.** The voice agent has `musubi_recent` (recency-anchored). No other adapter does. The OpenClaw plugin has `musubi_think`. The MCP adapter has neither. Aoi Phone literally cannot answer "what was I just doing on Claude Code" because the cross-modal recent tool doesn't exist on her side.
+3. **A comment in `memory.py:307` already documents this fragility:** _"Tool name + parameter shape match the openclaw-musubi plugin's `musubi_remember` so saves on either surface look the same in traces and to the model."_ The team has been keeping parity by hand. That doesn't scale.
+
+The user-facing symptom is real: when Aoi Phone was asked about "recent activity across modalities," she truthfully reported that her recent-tool only sees phone history. When she was asked to drill into a search snippet, she truthfully reported that her tools only return summaries. Both gaps are functions of which tools her adapter happened to wire.
+
+## Decision
+
+**Define a canonical agent-tools surface — five tools — that every Musubi adapter implements identically.** The contract lives at [[07-interfaces/agent-tools]].
+
+The five tools:
+
+1. `musubi_recent` — recent activity, recency-ordered, **cross-modal by default**.
+2. `musubi_search` — hybrid + rerank semantic search, **cross-modal by default**.
+3. `musubi_get` — fetch one object's full content + metadata by id.
+4. `musubi_remember` — explicit episodic capture into the calling presence.
+5. `musubi_think` — presence-to-presence message.
+
+Adapters MAY also expose lower-level granular tools (per-plane writes, ops introspection, etc.) where the surface needs them — but the five above are required, named exactly as specified, and parameter-compatible across adapters.
+
+The contract is written once in the spec; every adapter passes a shared contract test suite that exercises the surface. A new tool starts with a spec change and an ADR amendment, not an adapter PR.
+
+### Cross-modal as default
+
+`musubi_recent` and `musubi_search` default to scope `cross_modal` — `<tenant>/*/episodic` per [[13-decisions/0031-retrieve-wildcard-namespace]]. Per-modality narrowing is opt-in via `scope=presence` or `scope=current_modality`. This is the load-bearing behavioral choice: an agent that exists across modalities should answer "what was I doing" by *looking everywhere*. Restricting scope is the deliberate exception.
+
+### Naming choice — `musubi_search`, not `musubi_recall`
+
+"Recall" implies the agent (or character) is the subject doing the remembering. The character Aoi recalls; the system she runs on searches a database. `musubi_search` names the actual mechanism. The voice-active path already uses this naming; openclaw-musubi's `musubi_recall` is the legacy that diverged first.
+
+### Naming choice — `musubi_*`, not `memory_*`
+
+The MCP adapter's existing `memory_capture` / `memory_recall` use a shorter prefix. We unify on `musubi_*` because:
+
+- Every other surface already uses `musubi_*`. Reversing all of them is more churn than reversing the MCP adapter.
+- The prefix tells the agent which memory store the call goes to, which matters when adapters might compose multiple tool sources (e.g. a `memory_*` tool from a different MCP server).
+
+### Deprecation path, not breaking change
+
+Each adapter keeps the old names as aliases for **one minor release** after canonical lands. Aliases:
+
+- log a deprecation warning on each invocation
+- forward to the canonical implementation
+- do not appear in tool advertisements
+
+After one release, aliases drop. Concrete mapping table is in the spec.
+
+## Alternatives considered
+
+### Alternative 1: Define tools at the SDK level, generate adapters
+
+A code-generation pipeline that takes a single tool definition (params, behavior) and emits MCP, OpenClaw, and LiveKit registrations. Tempting because it would prevent drift mechanically.
+
+**Rejected** for now. Three blockers:
+
+- Each adapter SDK has different ergonomics — MCP's `@mcp.tool` decorator, OpenClaw's `registerTool` factory, LiveKit's `@function_tool` — that don't map to a single template without losing surface-specific behavior (auth context, structured returns, run-time injection).
+- Code generation is one more pipeline to maintain. The contract is small (5 tools) and changes slowly.
+- A specification-and-contract-tests approach catches drift just as effectively without the build complexity.
+
+If the tool count grows past ~15 or drift becomes recurring, revisit.
+
+### Alternative 2: Keep modality-specific tool sets; document the divergence
+
+Accept that voice has `musubi_search`, plugin has `musubi_recall`, MCP has `memory_recall` — they're functionally equivalent and agents adapt. Document the mapping prominently.
+
+**Rejected.** Three problems:
+
+- Every system prompt has to teach Aoi which tool name applies on each modality. Prompts then drift modality-by-modality.
+- "Functionally equivalent" is not actually true today: parameter shapes differ, default scopes differ, response formats differ. Calling them equivalent papers over real bugs.
+- Cross-modal continuity (the user's actual goal) requires the model to recognize that "what I told voice-Aoi" and "what plugin-Aoi captured" live in the same memory. A common tool surface makes that obvious; divergent surfaces hide it.
+
+### Alternative 3: Adopt MCP as the canonical wire for every adapter
+
+Run a Musubi MCP server, point every adapter at it, drop the per-adapter tool implementations. One transport, one surface.
+
+**Rejected.** MCP is a coding-agent protocol; LiveKit voice agents and OpenClaw plugins have their own runtime contracts (low-latency `@function_tool`, browser-side `registerTool`) that MCP doesn't replace. MCP can be *one* of the adapters — it already is — but it can't subsume the others without dragging MCP transport overhead into voice and browser-extension contexts.
+
+### Alternative 4: Eight-to-fifteen tools, more granular
+
+Keep finer-grained tools (per-plane `curated_get`, `concept_search`, `thought_history`, `artifact_get`, `episodic_archive`, etc.) — closer to the existing planned MCP surface in [[07-interfaces/mcp-adapter]].
+
+**Rejected as the canonical agent surface.** The agent doesn't typically need plane-level granularity; it needs to *find* and *use* memory. Five high-level tools (`recent`, `search`, `get`, `remember`, `think`) cover ≥95% of what an agent does. Granular per-plane tools are a power-user surface that adapters MAY expose alongside the canonical five — they're optional, not required.
+
+## Consequences
+
+### Good
+
+- **Cross-modal continuity becomes default.** "Aoi, what was I just doing?" works on every modality.
+- **One mental model for the user, one mental model for the LLM.** Same tool names everywhere; same behavior. System prompts simplify.
+- **Drift becomes a contract-test failure**, not a guess-when-it-breaks. Adding a tool to one adapter without updating the others fails CI.
+- **Closes the explicit gaps** users have hit: cross-modal `musubi_recent`, drill-into-source `musubi_get`.
+- **Documents the design philosophy** — adapter agnostic, contract-driven — so future adapters (Discord agent, Slack bot, mobile client) start from the same baseline.
+
+### Bad
+
+- **One-time migration cost** across three adapters. Roughly 5 PRs (1 spec + ADR, 1 backend slice for `mode=recent`, 3 adapter slices). Authoring + review effort is real.
+- **Existing system prompts** mentioning `musubi_recall` or `memory_recall` need updating. Aliases buffer this for one release; after that, prompts must use the canonical names.
+- **External integrations** (if any third-party agent has been built against `memory_recall`) break after the deprecation window. Acceptable: those tools are alpha-grade.
+- **The MCP adapter spec ([[07-interfaces/mcp-adapter]]) shifts shape** — granular per-plane tools that were "planned" now mostly aren't. We replace those tables with a reference to the canonical surface and call out the granular tools as optional/future.
+
+### Neutral
+
+- **`musubi_get` parameter requires `plane` explicitly** rather than inferring it from the namespace. Slightly more verbose in calls, but unambiguous and never depends on namespace shape — agents copy the triple from a `musubi_search` row that already shows it.
+- **Cross-modal default for `musubi_recent`** widens scope vs the current voice-only `musubi_recent` behavior. Side effect: a voice agent now sees plugin + Discord + Claude-Code captures by default. That's the intended behavior for the cross-modal vision; agents that *want* voice-only can pass `scope=current_modality`.
+
+## Implementation order
+
+1. **This ADR + the spec** ([[07-interfaces/agent-tools]]) — gates everything below.
+2. **Backend slice `mode=recent`** ([[_slices/slice-retrieve-recent]]) — required by `musubi_recent` cross-modal. Adapters can ship the canonical names with a fallback recency path until this lands; the fallback is documented per adapter.
+3. **MCP adapter slice** ([[_slices/slice-mcp-canonical-tools]]) — adds the five canonical tools, deprecates `memory_capture` / `memory_recall`. Includes registering the MCP server with Claude Code.
+4. **OpenClaw plugin extension** — extends the in-flight openclaw-musubi PR (`#24`) to add `musubi_recent` + alias `musubi_recall` → `musubi_search`.
+5. **LiveKit collapse** ([[_slices/slice-livekit-canonical-tools]]) — single canonical mixin, widens `musubi_recent` to cross-modal, drops the dormant v2 mixin.
+
+## Related
+
+- [[07-interfaces/agent-tools]] — the contract this ADR backs.
+- [[07-interfaces/mcp-adapter]] — affected; granular per-plane tables become future/optional.
+- [[07-interfaces/livekit-adapter]] — affected.
+- [[07-interfaces/openclaw-adapter]] — affected.
+- [[13-decisions/0011-canonical-api-and-adapters]] — the broader interface-discipline ADR this builds on.
+- [[13-decisions/0031-retrieve-wildcard-namespace]] — provides the wildcard namespace primitive cross-modal scope depends on.

--- a/docs/Musubi/13-decisions/index.md
+++ b/docs/Musubi/13-decisions/index.md
@@ -65,6 +65,7 @@ SORT file.name ASC
 - [[13-decisions/0024-kong-deferred-for-musubi-v1]] — Kong integration deferred for v1; first deploy is VLAN-internal only. 0014 remains the forward target.
 - [[13-decisions/0025-lifecycle-runner-without-apscheduler]] — Lifecycle worker ships as an asyncio tick-loop instead of pulling in APScheduler; revisit when we need persisted-jobstore or sub-minute cron semantics.
 - [[13-decisions/0026-release-please-for-versioning]] — release-please drives version bumps + tag cutting from conventional commits on `v2`; tag push triggers the signed GHCR publish.
+- [[13-decisions/0032-agent-tools-canonical-surface]] — Five-tool canonical agent surface (`musubi_recent`, `musubi_search`, `musubi_get`, `musubi_remember`, `musubi_think`) every adapter implements identically; cross-modal default for recent/search.
 - [[13-decisions/sources]] — Public sources that informed these decisions.
 - [[13-decisions/template-weights-change]] — Template ADR for retrieval scoring weight changes.
 

--- a/docs/Musubi/_slices/slice-livekit-canonical-tools.md
+++ b/docs/Musubi/_slices/slice-livekit-canonical-tools.md
@@ -1,0 +1,68 @@
+---
+title: "Slice: LiveKit voice — canonical agent tools"
+slice_id: slice-livekit-canonical-tools
+section: _slices
+type: slice
+status: blocked
+phase: "8 Post-1.0"
+tags: [section/slices, status/blocked, type/slice, adapter, livekit, voice, agent-tools]
+updated: 2026-04-29
+reviewed: false
+depends-on: ["[[_slices/slice-retrieve-recent]]"]
+blocks: []
+---
+
+# Slice: LiveKit voice — canonical agent tools
+
+> Collapse the two voice mixins (`MemoryToolsMixin` active path + `MusubiVoiceToolsMixin` dormant v2 path) into a single canonical mixin that conforms to [[07-interfaces/agent-tools]]. Widen `musubi_recent` from voice-only to cross-modal default.
+
+**Phase:** 8 Post-1.0 · **Status:** `blocked` (on [[_slices/slice-retrieve-recent]] for full cross-modal canonical surface; voice has its own existing recency fallback so the slice MAY pick up early)
+
+## Implementation lives in a sibling repo
+
+`github.com/ericmey/openclaw-livekit` — the standalone voice agent monorepo. This slice is the **tracking artifact** for the work in that repo, mirroring the pattern used for [[_slices/slice-adapter-openclaw]]. Code/tests/PR happen there; the contract this slice satisfies is [[07-interfaces/agent-tools]] in this vault.
+
+## Why this slice exists
+
+The voice agent has two parallel implementations today:
+
+- `tools/src/tools/memory.py` — `MemoryToolsMixin`, the live path. Exposes `musubi_recent`, `musubi_search`, `musubi_remember`. `musubi_recent` is **voice-channel only** — Aoi-on-the-phone cannot answer "what was I doing on Claude Code?".
+- `tools/src/tools/musubi_voice.py` — `MusubiVoiceToolsMixin`, dormant v2 path. Exposes `musubi_recall`, `musubi_remember`, `musubi_think`. Awaits a "v2 cutover" that ADR 0032 obsoletes.
+
+Per [[13-decisions/0032-agent-tools-canonical-surface]] the canonical surface is one set of names with cross-modal defaults. Two mixins is one too many.
+
+## Specs to implement
+
+- [[07-interfaces/agent-tools]] (the contract)
+
+## Owned paths (in `openclaw-livekit`, not this repo)
+
+- `tools/src/tools/musubi.py` (new) — single canonical mixin implementing all five tools per spec
+- `tools/src/tools/memory.py` (modified) — wrap deprecated names as one-release aliases that delegate to the canonical mixin
+- `tools/src/tools/musubi_voice.py` (deleted) — superseded; the dormant v2 path is replaced by the canonical mixin
+- `agents/{aoi,nyla,party}/agent.py` — switch MRO to the canonical mixin
+- `tools/tests/test_*.py` — contract test cases per [[07-interfaces/agent-tools#test-contract]]
+
+## Forbidden paths
+
+- `sdk/musubi_v2_client.py` — no client changes; consumes existing methods. SDK extensions for `mode=recent` are tracked by [[_slices/slice-retrieve-recent]].
+
+## Depends on
+
+- [[_slices/slice-retrieve-recent]] — `musubi_recent` cross-modal needs `mode=recent` on the backend. Until that lands, voice MAY keep its current `_scroll_episodic_recent` fallback and migrate when the backend mode ships.
+
+## Unblocks
+
+- _(none in this vault — downstream is operator/agent-config work in openclaw-livekit)_
+
+## Test Contract
+
+Same canonical contract suite as [[_slices/slice-mcp-canonical-tools]]; modality tag for `musubi_remember` is `src:livekit-voice-remember`. Adapter-specific addition:
+
+- [ ] **MRO collapse.** Each agent (aoi, nyla, party) has a single `MusubiToolsMixin` in its MRO; `MusubiVoiceToolsMixin` and `MemoryToolsMixin` are gone (or are aliasing-only wrappers).
+- [ ] **Legacy tool aliases.** `musubi_recall` (the voice-dormant name) and any divergent `musubi_search` parameter shape resolve to the canonical surface for one minor release with deprecation logging.
+- [ ] **Greeting hook.** The on-enter prefetch (`fetch_recent_context`) now consumes `musubi_recent` semantics — cross-modal scope, recency-ordered. Voice greeting includes recent activity from other modalities.
+
+## Definition of Done
+
+![[00-index/definition-of-done]] (adapted: code/tests/PR live in `openclaw-livekit`; this slice flips to `done` when the openclaw-livekit PR merges and an integration test confirms cross-modal recent works)

--- a/docs/Musubi/_slices/slice-mcp-canonical-tools.md
+++ b/docs/Musubi/_slices/slice-mcp-canonical-tools.md
@@ -1,0 +1,82 @@
+---
+title: "Slice: MCP adapter — canonical agent tools"
+slice_id: slice-mcp-canonical-tools
+section: _slices
+type: slice
+status: blocked
+phase: "8 Post-1.0"
+tags: [section/slices, status/blocked, type/slice, adapter, mcp, agent-tools]
+updated: 2026-04-29
+reviewed: false
+depends-on: ["[[_slices/slice-adapter-mcp]]", "[[_slices/slice-retrieve-recent]]"]
+blocks: []
+---
+
+# Slice: MCP adapter — canonical agent tools
+
+> Implement the canonical agent-tools surface in `src/musubi/adapters/mcp/`. Five tools — `musubi_recent`, `musubi_search`, `musubi_get`, `musubi_remember`, `musubi_think` — replacing the v1.0 `memory_capture` / `memory_recall`. Includes registering the MCP server with Claude Code so coding agents have the tools.
+
+**Phase:** 8 Post-1.0 · **Status:** `blocked` (on [[_slices/slice-retrieve-recent]] for full canonical surface; MAY pick up early with the documented fallback path for `musubi_recent`)
+
+## Why this slice exists
+
+Per [[13-decisions/0032-agent-tools-canonical-surface]], every adapter exposes the same five canonical tools. The MCP adapter currently exposes only the legacy `memory_capture` + `memory_recall`. This slice brings it onto the canonical contract so Claude Code (and any other MCP client) gets the same surface as Aoi's voice and OpenClaw modalities.
+
+## Specs to implement
+
+- [[07-interfaces/agent-tools]] (the contract; every tool in this slice conforms to it)
+- [[07-interfaces/mcp-adapter]] (spec-update trailer: legacy table → canonical table, already done in PR for [[13-decisions/0032-agent-tools-canonical-surface]])
+
+## Owned paths (you MAY write here)
+
+- `src/musubi/adapters/mcp/tools.py` — register all five canonical tools + alias path for `memory_capture`/`memory_recall`
+- `src/musubi/adapters/mcp/server.py` — minor: ensure new tools are attached
+- `tests/adapters/test_mcp.py` — contract tests per [[07-interfaces/agent-tools#test-contract]] §
+- `tests/adapters/test_mcp_canonical_tools.py` — new file, dedicated suite for the canonical surface
+
+## Forbidden paths
+
+- `src/musubi/sdk/` — no SDK changes; this slice consumes existing SDK methods
+- `src/musubi/api/` — canonical API frozen per ADR/CLAUDE rules; backend changes for `mode=recent` are owned by [[_slices/slice-retrieve-recent]]
+- `src/musubi/types/` — no new types
+
+## Depends on
+
+- [[_slices/slice-adapter-mcp]] — base MCP adapter infrastructure (status: done)
+- [[_slices/slice-retrieve-recent]] — `musubi_recent` requires `mode=recent`. Until that lands, this slice MAY ship `musubi_recent` with a fallback (`client.list_episodic` paginated) and migrate when the backend mode lands. The fallback is documented in the adapter spec.
+
+## Unblocks
+
+- _(no downstream slices)_ — once shipped, Claude Code has parity with voice + OpenClaw modalities.
+
+## Test Contract
+
+Implements the canonical contract test suite from [[07-interfaces/agent-tools#test-contract]]. All cases below run against an in-process Musubi (or a contract-test fixture):
+
+- [ ] `musubi_recent` — basic. Three rows in three modality namespaces. `scope=cross_modal` returns all three, newest-first.
+- [ ] `musubi_recent` — scope narrowing. `scope=presence` returns only the calling presence's rows.
+- [ ] `musubi_recent` — tag filter. `tags=["src:foo"]` filters to tagged rows.
+- [ ] `musubi_search` — cross-modal. Distinctive phrase in another modality's episodic surfaces.
+- [ ] `musubi_search` — plane filter. `planes=["episodic"]` excludes curated even when curated has the term.
+- [ ] `musubi_get` — round-trip. `musubi_remember` → `musubi_search` → `musubi_get` returns the original content exactly.
+- [ ] `musubi_get` — 404. Unknown id returns tool error naming the missing id + namespace.
+- [ ] `musubi_remember` — modality tagging. Captured row has `src:mcp-agent-remember` in tags.
+- [ ] `musubi_remember` — idempotency. Same idempotency_key + content stores one row.
+- [ ] `musubi_think` — round-trip. Thought from A to B appears on B's stream within timeout.
+- [ ] **Aliases.** `memory_capture` invocation forwards to `musubi_remember` with a deprecation warning. `memory_recall` → `musubi_search` likewise. Both emit a deprecation log line.
+- [ ] **Degraded mode.** Backend unavailable. Each tool returns a tool error string; no exception escapes the tool boundary.
+- [ ] **Presence-resolution failure.** Tool called without resolvable presence. Tool error names the resolution problem.
+
+## Wiring with Claude Code (operator step, not code)
+
+After the slice merges, the operator runs:
+
+```bash
+claude mcp add -s user musubi -- python -m musubi.adapters.mcp serve
+```
+
+(or whatever the canonical `musubi mcp serve` invocation is at the time). This is documented in the [[07-interfaces/mcp-adapter]] adapter spec under "Local install". Not code in this slice's commits, but listed here so the slice is genuinely "done" only after Claude Code can call the new tools.
+
+## Definition of Done
+
+![[00-index/definition-of-done]]

--- a/docs/Musubi/_slices/slice-openclaw-canonical-tools.md
+++ b/docs/Musubi/_slices/slice-openclaw-canonical-tools.md
@@ -1,0 +1,64 @@
+---
+title: "Slice: OpenClaw plugin — canonical agent tools"
+slice_id: slice-openclaw-canonical-tools
+section: _slices
+type: slice
+status: blocked
+phase: "8 Post-1.0"
+tags: [section/slices, status/blocked, type/slice, adapter, openclaw, agent-tools]
+updated: 2026-04-29
+reviewed: false
+depends-on: ["[[_slices/slice-retrieve-recent]]"]
+blocks: []
+---
+
+# Slice: OpenClaw plugin — canonical agent tools
+
+> Bring the openclaw-musubi plugin onto the canonical agent-tools surface. Add `musubi_recent`, alias `musubi_recall` → `musubi_search` for one release, drop the alias afterward. `musubi_get` already lands in `openclaw-musubi#24`.
+
+**Phase:** 8 Post-1.0 · **Status:** `blocked` (on [[_slices/slice-retrieve-recent]] for full canonical surface; MAY pick up early with the documented fallback path for `musubi_recent`)
+
+## Implementation lives in a sibling repo
+
+`github.com/ericmey/openclaw-musubi` — the OpenClaw plugin (TypeScript). This slice is the tracking artifact, mirroring [[_slices/slice-adapter-openclaw]]. PR `#24` already adds `musubi_get` per the canonical contract; this slice extends that work to bring the rest of the plugin onto the canonical surface.
+
+## Why this slice exists
+
+Per [[13-decisions/0032-agent-tools-canonical-surface]] the canonical search tool is `musubi_search`. The OpenClaw plugin currently registers `musubi_recall`. The plugin is also missing `musubi_recent` — Aoi-via-OpenClaw cannot answer "what was I doing across modalities?" without going through the voice surface.
+
+## Specs to implement
+
+- [[07-interfaces/agent-tools]] (the contract)
+- The corresponding doc updates in `openclaw-musubi/docs/architecture/overview.md`, `wiring.md`, `README.md`, etc. — same pattern PR `#24` already established for `musubi_get`.
+
+## Owned paths (in `openclaw-musubi`, not this repo)
+
+- `src/tools/recent.ts` (new) — canonical `musubi_recent`
+- `src/tools/search.ts` (new) — canonical `musubi_search` body; `recall.ts` becomes a deprecation alias that delegates here
+- `src/tools/parameters.ts` — add `RecentParameters`, `SearchParameters`; keep `RecallParameters` for the alias
+- `src/plugin/bootstrap.ts` — register the canonical four (recall stays for one release as alias)
+- `tests/tools/*.test.ts` — contract suite cases per spec
+- `tests/plugin/bootstrap.test.ts` — update tool-count + registration order
+
+## Forbidden paths
+
+- The Musubi backend (this repo) — no API changes; `mode=recent` is owned by [[_slices/slice-retrieve-recent]]. Until that ships, `musubi_recent` MAY paginate `GET /v1/episodic` as a fallback and migrate when the backend mode lands.
+
+## Depends on
+
+- [[_slices/slice-retrieve-recent]] — for `musubi_recent` cross-modal default. Fallback path acceptable until it lands.
+
+## Unblocks
+
+- _(no downstream slices in this vault)_
+
+## Test Contract
+
+Same contract suite as [[_slices/slice-mcp-canonical-tools]]; modality tag for `musubi_remember` is `src:openclaw-agent-remember`. Plus:
+
+- [ ] **Alias path.** `musubi_recall` invocation forwards to `musubi_search` and emits a deprecation log line. After one minor release, `musubi_recall` is removed from `bootstrap.ts` registration.
+- [ ] **Five-tool registration order.** The bootstrap integration test expects `musubi_recall` (alias) + the five canonical tools = 6 total during the deprecation window; 5 after.
+
+## Definition of Done
+
+![[00-index/definition-of-done]] (adapted: code/tests/PR live in `openclaw-musubi`; this slice flips to `done` when both `#24` (already in flight) and the follow-up PR for `musubi_recent` + `musubi_search` rename merge)

--- a/docs/Musubi/_slices/slice-openclaw-canonical-tools.md
+++ b/docs/Musubi/_slices/slice-openclaw-canonical-tools.md
@@ -36,7 +36,7 @@ Per [[13-decisions/0032-agent-tools-canonical-surface]] the canonical search too
 - `src/tools/recent.ts` (new) — canonical `musubi_recent`
 - `src/tools/search.ts` (new) — canonical `musubi_search` body; `recall.ts` becomes a deprecation alias that delegates here
 - `src/tools/parameters.ts` — add `RecentParameters`, `SearchParameters`; keep `RecallParameters` for the alias
-- `src/plugin/bootstrap.ts` — register the canonical four (recall stays for one release as alias)
+- `src/plugin/bootstrap.ts` — register the canonical five (`musubi_search`, `musubi_recent`, `musubi_get`, `musubi_remember`, `musubi_think`); `musubi_recall` stays for one release as a deprecation alias
 - `tests/tools/*.test.ts` — contract suite cases per spec
 - `tests/plugin/bootstrap.test.ts` — update tool-count + registration order
 

--- a/docs/Musubi/_slices/slice-retrieve-recent.md
+++ b/docs/Musubi/_slices/slice-retrieve-recent.md
@@ -1,0 +1,92 @@
+---
+title: "Slice: Retrieve mode=recent"
+slice_id: slice-retrieve-recent
+section: _slices
+type: slice
+status: blocked
+phase: "8 Post-1.0"
+tags: [section/slices, status/blocked, type/slice, api, retrieve, recency]
+updated: 2026-04-29
+reviewed: false
+depends-on: ["[[_slices/slice-api-v0-read]]", "[[_slices/slice-api-retrieve-wildcards]]"]
+blocks: ["[[_slices/slice-mcp-canonical-tools]]", "[[_slices/slice-livekit-canonical-tools]]", "[[_slices/slice-openclaw-canonical-tools]]"]
+---
+
+# Slice: Retrieve mode=recent
+
+> Add `mode=recent` to `POST /v1/retrieve` — query-less, time-ordered scroll across the namespace fanout. Required by the canonical `musubi_recent` agent tool ([[07-interfaces/agent-tools]]) so an agent can answer "what was I just doing?" without a query string.
+
+**Phase:** 8 Post-1.0 · **Status:** `blocked` (on [[_slices/slice-api-retrieve-wildcards]])
+
+## Why this slice exists
+
+Today's retrieve modes (`fast`, `deep`, `blended`) all require `query_text` and rank by similarity-with-recency-weight. They cannot answer "give me the last N items, no query" — recency-only retrieval has no path. The voice-active path (`openclaw-livekit`) works around this by paginating `GET /v1/episodic`, but that surface is per-namespace and Qdrant-scroll-ordered (not strictly newest-first) and cannot fan out across modalities the way `POST /v1/retrieve` can with wildcard namespaces ([[13-decisions/0031-retrieve-wildcard-namespace]]).
+
+The canonical agent-tools surface ([[13-decisions/0032-agent-tools-canonical-surface]]) makes `musubi_recent` cross-modal by default. That requires a backend recency endpoint that fans out across `<tenant>/*/episodic`. This slice adds it.
+
+## Specs to implement
+
+- [[07-interfaces/agent-tools]] (the consumer; defines the contract `musubi_recent` must satisfy)
+- [[07-interfaces/canonical-api]] (spec-update trailer: extend §Retrieve modes table to include `recent`)
+- [[13-decisions/0031-retrieve-wildcard-namespace]] (no change; relied on for cross-modal fanout)
+- [[13-decisions/0032-agent-tools-canonical-surface]] (the decision motivating this slice)
+
+## Owned paths
+
+This slice is `blocked` on [[_slices/slice-api-retrieve-wildcards]] (currently `in-progress`). The files this slice will touch are mostly owned by that active slice and **MUST NOT** be claimed here while it is in flight — see the "Anticipated paths at pickup" section below. When this slice transitions to `in-progress`, the slice author moves the anticipated-paths list into this section.
+
+For now, this slice claims **no active paths** — it's a tracking spec, not a worker.
+
+## Anticipated paths at pickup
+
+The slice author who claims this slice (after [[_slices/slice-api-retrieve-wildcards]] merges) will add these into ## Owned paths:
+
+Owned outright:
+
+- src/musubi/retrieve/orchestration.py
+- tests/retrieve/test_orchestration.py
+- openapi.yaml
+- docs/Musubi/07-interfaces/canonical-api.md
+
+Released by [[_slices/slice-api-retrieve-wildcards]] when it merges:
+
+- src/musubi/api/routers/retrieve.py
+- src/musubi/sdk/async_client.py
+- src/musubi/sdk/client.py
+- tests/api/test_retrieve_router.py
+- tests/sdk/test_async_client.py
+
+## Forbidden paths
+
+- `src/musubi/types/` — no new types needed; existing `RetrieveQuery` extends additively
+- `src/musubi/embedding/` — recent mode does not invoke embedders
+- `src/musubi/retrieve/scoring.py` — recency weight already exists; no scoring change
+
+## Depends on
+
+- [[_slices/slice-api-v0-read]] — base retrieve infrastructure
+- [[_slices/slice-api-retrieve-wildcards]] — provides the `<tenant>/*/episodic` fanout `musubi_recent` consumes
+
+## Unblocks
+
+- [[_slices/slice-mcp-canonical-tools]]
+- [[_slices/slice-livekit-canonical-tools]]
+- [[_slices/slice-openclaw-canonical-tools]]
+
+## Test Contract
+
+- [ ] `POST /v1/retrieve` with `mode="recent"` and no `query_text` returns 200 (today returns 422).
+- [ ] Results are ordered by `created_at` descending. The first row is the most recently captured.
+- [ ] `since` filters to rows with `created_at >= since`. Rows older than `since` are excluded.
+- [ ] `tags` filter (already on retrieve) composes with `mode=recent` — only rows whose `tags` contain every listed tag are returned.
+- [ ] Cross-modal fanout: with `<tenant>/*/episodic` namespace, results include rows from every modality the tenant has written to. Each row's response carries its concrete stored namespace.
+- [ ] Plane filter narrows: `planes=["episodic"]` (default) returns episodic only. Reasonable extension to `["artifact"]` for future use.
+- [ ] Limit cap: `limit > 50` is clamped to 50 (or the existing global cap).
+- [ ] `mode="recent"` + `query_text` → either accept-and-ignore or 422 — TBD by reviewer; spec the choice.
+- [ ] No embedder call. Tracing/observability counters confirm zero embed-cache traffic per request.
+- [ ] No rerank call. Same observability check.
+- [ ] Latency budget: `mode=recent` p99 ≤ 200ms on a populated dev namespace.
+
+## Definition of Done
+
+![[00-index/definition-of-done]]


### PR DESCRIPTION
No tracking Issue: this PR authors the canonical contract + ADR + four tracking slice notes; it doesn't claim any single slice. Issues #285–#288 were created by `bootstrap_slice_issues.py` for the four tracking slices and are intentionally unassigned.

## Summary

Authors the canonical five-tool agent surface every Musubi adapter implements identically. Resolves the three-way drift between OpenClaw plugin (`musubi_recall` / `musubi_remember` / `musubi_think`), LiveKit voice (`musubi_recent` / `musubi_search` / `musubi_remember` on the live path; a parallel dormant v2 mixin), and the in-monorepo MCP adapter (`memory_capture` / `memory_recall`).

The user-facing motivation is cross-modal continuity. "Aoi, what was I just doing?" should behave identically on phone, voice, Discord, and Claude Code. It doesn't today because each adapter independently picked its tool surface and the surfaces drifted by name, parameter shape, default scope, and tool count. ADR 0032 fixes the contract; the four tracking slices fix the implementation.

## What landed

**Spec** — [`docs/Musubi/07-interfaces/agent-tools.md`](docs/Musubi/07-interfaces/agent-tools.md)

The canonical contract. Five tools, identical names + parameter shapes across every adapter:

| Tool | Purpose | Cross-modal by default? |
|---|---|---|
| `musubi_recent` | "What's recent in my world?" — recency-ordered, no query | ✓ |
| `musubi_search` | "Have I seen X before?" — hybrid + rerank semantic search | ✓ |
| `musubi_get` | "Tell me more about that one" — fetch one object by id | n/a |
| `musubi_remember` | "Save this" — explicit episodic capture | n/a |
| `musubi_think` | "Tell my other self" — presence-to-presence message | n/a |

Includes presence resolution rules, required modality tags (`src:openclaw-agent-remember` etc.), deprecation alias path (one minor release), and the canonical contract test suite.

**ADR 0032** — [`docs/Musubi/13-decisions/0032-agent-tools-canonical-surface.md`](docs/Musubi/13-decisions/0032-agent-tools-canonical-surface.md)

Records the decision and rejected alternatives:
- Codegen pipeline (rejected: not enough tools to justify the build complexity)
- Keep modality-specific surfaces, document the divergence (rejected: papers over real bugs)
- Adopt MCP as the canonical wire for every adapter (rejected: doesn't fit voice/browser runtime contracts)
- Finer-grained 8–15 tools (rejected as the canonical surface; granular per-plane tools remain optional power-use surface)

**Spec updates to existing adapter docs**

- `07-interfaces/mcp-adapter.md` — replaces the v1.0 granular tool tables with a reference to the canonical surface; legacy `memory_capture`/`memory_recall` documented as deprecated aliases.
- `07-interfaces/openclaw-adapter.md` — references the canonical surface; bootstrap registration line updated.
- `07-interfaces/index.md` and `13-decisions/index.md` — add the new docs to the static indexes.

**Tracking slices** (status: `blocked`; GH Issues created by `bootstrap_slice_issues.py`)

| Slice | Issue | Blocked on |
|---|---|---|
| `slice-retrieve-recent` | #288 | `slice-api-retrieve-wildcards` (in-progress) |
| `slice-mcp-canonical-tools` | #286 | `slice-retrieve-recent` |
| `slice-openclaw-canonical-tools` | #287 | `slice-retrieve-recent` |
| `slice-livekit-canonical-tools` | #285 | `slice-retrieve-recent` |

`slice-retrieve-recent` adds `mode=recent` to `POST /v1/retrieve` so `musubi_recent` can fan out cross-modally via wildcard namespace. The three adapter slices MAY pick up early using documented fallback paths (`GET /v1/episodic` paginated) and migrate when the backend mode lands.

## Test plan

- [x] `make agent-check` — 0 errors. Remaining 10 warnings are pre-existing (stale lock, depends-on asymmetry on `slice-api-retrieve-wildcards`, historical owns_paths overlap from done slices) plus 4 from this PR (3 depends-on asymmetry on upstream slices that don't list us in `blocks`; 1 path-overlap with the done `slice-adapter-mcp`). All warnings, none errors.
- [x] All `[[wikilinks]]` in new docs resolve.
- [x] ADR numbering — next sequential (0032, after the existing 0031).
- [x] Frontmatter conforms to vault conventions: `title`, `section`, `tags`, `type`, `status`, `updated`, `up`, `reviewed`, plus slice-specific (`slice_id`, `phase`, `depends-on`, `blocks`).
- [ ] Reviewer pass — vault hygiene + naming choice (`musubi_search` vs `musubi_recall`, `musubi_*` vs `memory_*`).

## Follow-up sequence

1. This PR (spec + ADR + tracking slices) → merge.
2. `slice-api-retrieve-wildcards` (#266, in-progress, separate work) → merge. Unblocks #288.
3. `slice-retrieve-recent` (#288) → claim + ship the backend mode.
4. In parallel after step 3: `slice-mcp-canonical-tools` (#286), `slice-openclaw-canonical-tools` (#287), `slice-livekit-canonical-tools` (#285). Three adapter PRs in three repos.
5. After all adapters ship: drop the deprecation aliases in the next minor release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)