### PR TITLE
feat(adapters/mcp): slice-mcp-canonical-tools — canonical 5-tool surface

### DIFF
--- a/docs/Musubi/_slices/slice-mcp-canonical-tools.md
+++ b/docs/Musubi/_slices/slice-mcp-canonical-tools.md
@@ -3,10 +3,10 @@ title: "Slice: MCP adapter — canonical agent tools"
 slice_id: slice-mcp-canonical-tools
 section: _slices
 type: slice
-status: in-progress
+status: done
 owner: aoi-claude-opus
 phase: "8 Post-1.0"
-tags: [section/slices, status/in-progress, type/slice, adapter, mcp, agent-tools]
+tags: [section/slices, status/done, type/slice, adapter, mcp, agent-tools]
 updated: 2026-04-29
 reviewed: false
 depends-on: ["[[_slices/slice-adapter-mcp]]", "[[_slices/slice-retrieve-recent]]"]
@@ -17,7 +17,7 @@ blocks: []
 
 > Implement the canonical agent-tools surface in `src/musubi/adapters/mcp/`. Five tools — `musubi_recent`, `musubi_search`, `musubi_get`, `musubi_remember`, `musubi_think` — replacing the v1.0 `memory_capture` / `memory_recall`. Includes registering the MCP server with Claude Code so coding agents have the tools.
 
-**Phase:** 8 Post-1.0 · **Status:** `in-progress` (claimed early per the documented fallback path; full cross-modal `musubi_recent` lands when [[_slices/slice-retrieve-recent]] ships) · **Owner:** `aoi-claude-opus`
+**Phase:** 8 Post-1.0 · **Status:** `done` (canonical 4 tools + 2 deprecation aliases shipped; `musubi_recent` is a clearly-deferred stub awaiting [[_slices/slice-retrieve-recent]]) · **Owner:** `aoi-claude-opus`
 
 ## Why this slice exists
 

--- a/docs/Musubi/_slices/slice-mcp-canonical-tools.md
+++ b/docs/Musubi/_slices/slice-mcp-canonical-tools.md
@@ -3,9 +3,10 @@ title: "Slice: MCP adapter — canonical agent tools"
 slice_id: slice-mcp-canonical-tools
 section: _slices
 type: slice
-status: blocked
+status: in-progress
+owner: aoi-claude-opus
 phase: "8 Post-1.0"
-tags: [section/slices, status/blocked, type/slice, adapter, mcp, agent-tools]
+tags: [section/slices, status/in-progress, type/slice, adapter, mcp, agent-tools]
 updated: 2026-04-29
 reviewed: false
 depends-on: ["[[_slices/slice-adapter-mcp]]", "[[_slices/slice-retrieve-recent]]"]
@@ -16,7 +17,7 @@ blocks: []
 
 > Implement the canonical agent-tools surface in `src/musubi/adapters/mcp/`. Five tools — `musubi_recent`, `musubi_search`, `musubi_get`, `musubi_remember`, `musubi_think` — replacing the v1.0 `memory_capture` / `memory_recall`. Includes registering the MCP server with Claude Code so coding agents have the tools.
 
-**Phase:** 8 Post-1.0 · **Status:** `blocked` (on [[_slices/slice-retrieve-recent]] for full canonical surface; MAY pick up early with the documented fallback path for `musubi_recent`)
+**Phase:** 8 Post-1.0 · **Status:** `in-progress` (claimed early per the documented fallback path; full cross-modal `musubi_recent` lands when [[_slices/slice-retrieve-recent]] ships) · **Owner:** `aoi-claude-opus`
 
 ## Why this slice exists
 

--- a/docs/Musubi/_tools/tc_coverage.py
+++ b/docs/Musubi/_tools/tc_coverage.py
@@ -42,7 +42,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[3]
-VAULT = ROOT / "docs" / "architecture"
+VAULT = ROOT / "docs" / "Musubi"
 TESTS_DIR = ROOT / "tests"
 
 _WIKILINK_RE = re.compile(r"\[\[([^\]|#]+)")

--- a/src/musubi/adapters/mcp/tools.py
+++ b/src/musubi/adapters/mcp/tools.py
@@ -1,11 +1,29 @@
 """MCP tool implementations for Musubi.
 
-These maps a flat tool signature to the correct Musubi SDK call.
+Implements the **canonical agent-tools surface** ([[07-interfaces/agent-
+tools]]) — five tools, identical names + parameter shapes across every
+adapter, backed by [[13-decisions/0032-agent-tools-canonical-surface]].
+
+Tools registered:
+
+- ``musubi_search`` — hybrid + rerank semantic search (deep mode)
+- ``musubi_get`` — fetch one object's full content + metadata by id
+- ``musubi_remember`` — explicit episodic capture
+- ``musubi_think`` — presence-to-presence message
+- ``musubi_recent`` — recency-ordered scroll
+  (currently a deferred stub — depends on [[_slices/slice-retrieve-
+  recent]] / Musubi #288 for ``mode=recent``)
+
+Plus two deprecation aliases for one minor release:
+
+- ``memory_capture`` → ``musubi_remember`` + WARNING log
+- ``memory_recall``  → ``musubi_search``  + WARNING log
 """
 
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 
@@ -13,43 +31,338 @@ from musubi.sdk.async_client import AsyncMusubiClient
 
 logger = logging.getLogger(__name__)
 
-# To use these cleanly without passing `client` into every tool manually
-# (which MCP wouldn't know how to inject at runtime automatically),
-# the MCP setup needs to bind them or use a closure.
-# For simplicity with FastMCP, we'll construct the FastMCP instance in a
-# factory function that has the client in scope.
+
+#: Modality tag every ``musubi_remember`` capture from this adapter
+#: carries — lets ``musubi_recent --tags=src:mcp-agent-remember`` filter
+#: writes that came specifically from an MCP coding-agent session.
+_MCP_MODALITY_TAG = "src:mcp-agent-remember"
+
+#: Plane → SDK accessor mapping for ``musubi_get``. Hard-coded so the
+#: agent never has to know the canonical-API pluralization rule.
+_PLANE_ATTR: dict[str, str] = {
+    "curated": "curated",
+    "concept": "concept",
+    "episodic": "episodic",
+    "artifact": "artifact",
+}
 
 
 def attach_tools(mcp: FastMCP, client: AsyncMusubiClient) -> None:
-    """Register all Musubi tools on the given FastMCP server."""
+    """Register every canonical agent tool on the given FastMCP server.
 
-    @mcp.tool(name="memory_capture", description="Capture a new episodic observation.")
-    async def memory_capture(
-        namespace: str, content: str, importance: int = 5, tags: list[str] | None = None
+    Tool implementations are bound via closure over ``client`` so each
+    invocation talks to the same underlying SDK instance — matching the
+    pattern in :func:`musubi.adapters.mcp.server.create_mcp_server`.
+    """
+
+    # ------------------------------------------------------------------
+    # musubi_search — hybrid + rerank semantic search
+    # ------------------------------------------------------------------
+
+    @mcp.tool(
+        name="musubi_search",
+        description=(
+            "Hybrid + rerank semantic search across Musubi. Use when the "
+            "passive memory supplement didn't surface what you need. "
+            "Returns ranked results with [plane], score, and content snippet."
+        ),
+    )
+    async def musubi_search(
+        namespace: str,
+        query: str,
+        limit: int = 5,
+        planes: list[str] | None = None,
     ) -> str:
+        return await _do_search(
+            client, namespace=namespace, query=query, limit=limit, planes=planes
+        )
+
+    # ------------------------------------------------------------------
+    # musubi_get — fetch one object's full content by id
+    # ------------------------------------------------------------------
+
+    @mcp.tool(
+        name="musubi_get",
+        description=(
+            "Fetch one Musubi object's full content + metadata by id. "
+            "Use after `musubi_search` when a snippet looks load-bearing "
+            "and you need the underlying source. Pass `plane`, `namespace`, "
+            "and `object_id` straight from a search result row."
+        ),
+    )
+    async def musubi_get(
+        plane: str,
+        namespace: str,
+        object_id: str,
+    ) -> str:
+        if plane not in _PLANE_ATTR:
+            return f"Error: unknown plane {plane!r} — must be one of {sorted(_PLANE_ATTR)}."
+        plane_client = getattr(client, _PLANE_ATTR[plane])
+        try:
+            row = await plane_client.get(namespace=namespace, object_id=object_id)
+        except Exception as e:
+            return f"Error: {e}"
+        return _format_object(plane=plane, namespace=namespace, object_id=object_id, row=row)
+
+    # ------------------------------------------------------------------
+    # musubi_remember — explicit episodic capture
+    # ------------------------------------------------------------------
+
+    @mcp.tool(
+        name="musubi_remember",
+        description=(
+            "Capture something into Musubi episodic memory. Use for things "
+            "you judge load-bearing — decisions, facts, commitments. "
+            "Default importance is 7 (above the passive-capture baseline of 5)."
+        ),
+    )
+    async def musubi_remember(
+        namespace: str,
+        content: str,
+        importance: int = 7,
+        topics: list[str] | None = None,
+    ) -> str:
+        # Adapter modality tag is auto-added so cross-modality recent / search
+        # can filter by source per [[07-interfaces/agent-tools#modality-tagging]].
+        tags = list(topics or [])
+        if _MCP_MODALITY_TAG not in tags:
+            tags.append(_MCP_MODALITY_TAG)
         try:
             res = await client.episodic.capture(
                 namespace=namespace,
                 content=content,
                 importance=importance,
-                tags=tags or [],
+                tags=tags,
             )
-            return f"Captured successfully with id {res['object_id']}"
         except Exception as e:
             return f"Error: {e}"
+        return f"Remembered in Musubi episodic ({namespace}) — id {res['object_id']}."
 
-    @mcp.tool(name="memory_recall", description="Retrieve recent memories for context.")
-    async def memory_recall(namespace: str, query: str, limit: int = 10) -> str:
+    # ------------------------------------------------------------------
+    # musubi_think — presence-to-presence message
+    # ------------------------------------------------------------------
+
+    @mcp.tool(
+        name="musubi_think",
+        description=(
+            "Send a presence-to-presence thought. The recipient's next turn "
+            "sees the message as inbound context. Use when the user wants you "
+            "to tell another agent (Aoi, Nyla, voice, …) something."
+        ),
+    )
+    async def musubi_think(
+        namespace: str,
+        from_presence: str,
+        to_presence: str,
+        content: str,
+        channel: str = "default",
+        importance: int = 5,
+    ) -> str:
         try:
-            res = await client.retrieve(
+            res = await client.thoughts.send(
                 namespace=namespace,
-                query_text=query,
-                mode="fast",
-                limit=limit,
+                from_presence=from_presence,
+                to_presence=to_presence,
+                content=content,
+                channel=channel,
+                importance=importance,
             )
-            lines = []
-            for hit in res["results"]:
-                lines.append(f"[{hit['plane']}] {hit['object_id']}: {hit['snippet']}")
-            return "\n".join(lines) if lines else "No relevant memories found."
         except Exception as e:
             return f"Error: {e}"
+        return f"Sent to {to_presence}. (id={res['object_id']})"
+
+    # ------------------------------------------------------------------
+    # musubi_recent — deferred stub (#288 / slice-retrieve-recent)
+    # ------------------------------------------------------------------
+
+    @mcp.tool(
+        name="musubi_recent",
+        description=(
+            "Recent activity, recency-ordered, no query needed. NOT YET "
+            "WIRED — depends on slice-retrieve-recent (Musubi #288). The "
+            "tool registers so its name is reserved at the canonical "
+            "surface; calls return a clear deferred message until the "
+            "backend ships."
+        ),
+    )
+    async def musubi_recent(
+        namespace: str,
+        limit: int = 10,
+    ) -> str:
+        # Per [[CLAUDE#prohibited-patterns]]: ADR-punted dependencies fail
+        # loud. This tool's contract is canonical, but the backend it needs
+        # (`mode=recent`) is on the way. We return a clearly user-readable
+        # message rather than silently no-op, and we log at WARNING so the
+        # operator notices repeated calls in degraded mode.
+        logger.warning(
+            "musubi_recent invoked but is not yet available "
+            "(deferred to slice-retrieve-recent / Musubi #288)"
+        )
+        return (
+            "musubi_recent is not yet available — its backend dependency "
+            "(slice-retrieve-recent, Musubi #288) hasn't shipped. Until it does, "
+            "use `musubi_search` with a date- or recency-flavored query as a "
+            "workaround. Tracking issue: "
+            "https://github.com/ericmey/musubi/issues/288"
+        )
+
+    # ------------------------------------------------------------------
+    # Deprecation aliases — one minor release, then drop
+    # ------------------------------------------------------------------
+
+    @mcp.tool(
+        name="memory_capture",
+        description=(
+            "[DEPRECATED] Use `musubi_remember`. "
+            "Capture a new episodic memory observation in Musubi."
+        ),
+    )
+    async def memory_capture(
+        namespace: str,
+        content: str,
+        importance: int = 5,
+        tags: list[str] | None = None,
+    ) -> str:
+        logger.warning(
+            "memory_capture is deprecated; use musubi_remember (canonical name "
+            "per ADR 0032 / agent-tools spec). The alias drops in the next minor release."
+        )
+        # Forward through the canonical body. Existing memory_capture
+        # default importance was 5; preserve it on the alias path so
+        # behavior doesn't change for legacy callers.
+        normalized_tags = list(tags or [])
+        if _MCP_MODALITY_TAG not in normalized_tags:
+            normalized_tags.append(_MCP_MODALITY_TAG)
+        try:
+            res = await client.episodic.capture(
+                namespace=namespace,
+                content=content,
+                importance=importance,
+                tags=normalized_tags,
+            )
+        except Exception as e:
+            return f"Error: {e}"
+        return f"Captured successfully with id {res['object_id']}"
+
+    @mcp.tool(
+        name="memory_recall",
+        description=("[DEPRECATED] Use `musubi_search`. Retrieve memories matching a query."),
+    )
+    async def memory_recall(
+        namespace: str,
+        query: str,
+        limit: int = 10,
+    ) -> str:
+        logger.warning(
+            "memory_recall is deprecated; use musubi_search (canonical name "
+            "per ADR 0032 / agent-tools spec). The alias drops in the next minor release."
+        )
+        return await _do_search(client, namespace=namespace, query=query, limit=limit, planes=None)
+
+
+# ----------------------------------------------------------------------
+# Shared bodies — invoked from both canonical tools and aliases
+# ----------------------------------------------------------------------
+
+
+async def _do_search(
+    client: AsyncMusubiClient,
+    *,
+    namespace: str,
+    query: str,
+    limit: int,
+    planes: list[str] | None,
+) -> str:
+    """Backing implementation for ``musubi_search`` and ``memory_recall``."""
+    try:
+        res = await client.retrieve(
+            namespace=namespace,
+            query_text=query,
+            mode="deep",
+            limit=limit,
+            planes=planes,
+        )
+    except Exception as e:
+        return f"Error: {e}"
+    rows: list[dict[str, Any]] = res.get("results") or []
+    if not rows:
+        return f"No memories matched {query!r}."
+    lines: list[str] = [f"{len(rows)} result(s) for {query!r}:", ""]
+    for hit in rows:
+        plane = hit.get("plane") or "memory"
+        score = hit.get("score")
+        score_str = f" (score {score:.2f})" if isinstance(score, (int, float)) else ""
+        oid = hit.get("object_id") or "<no-id>"
+        ns = hit.get("namespace") or namespace
+        title_or_oid = hit.get("title") or f"{ns}/{oid}"
+        lines.append(f"[{plane}]{score_str} {title_or_oid}")
+        content = (hit.get("content") or hit.get("snippet") or "").strip()
+        if content:
+            lines.append(content)
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def _format_object(
+    *,
+    plane: str,
+    namespace: str,
+    object_id: str,
+    row: dict[str, Any],
+) -> str:
+    """Render a fetched object for the agent — stable header + canonical
+    metadata + body. Same shape as the openclaw-musubi `musubi_get` so
+    the rendering is identical across adapters."""
+    lines: list[str] = [f"[{plane}] {namespace}/{object_id}", ""]
+    header_keys = (
+        "title",
+        "state",
+        "importance",
+        "event_at",
+        "ingested_at",
+        "created_at",
+        "updated_at",
+        "modality",
+        "source_context",
+        "vault_path",
+        "topics",
+        "tags",
+        "participants",
+    )
+    seen: set[str] = {"namespace", "object_id", "content", "summary", "body"}
+    for key in header_keys:
+        if key not in row:
+            continue
+        seen.add(key)
+        value = row[key]
+        if value in (None, []):
+            continue
+        lines.append(f"{key}: {_render_value(value)}")
+    for key in sorted(set(row.keys()) - seen):
+        value = row[key]
+        if value in (None, []):
+            continue
+        lines.append(f"{key}: {_render_value(value)}")
+    body = _pick_content(row)
+    if body is not None:
+        lines.append("")
+        lines.append(body)
+    return "\n".join(lines).rstrip()
+
+
+def _pick_content(row: dict[str, Any]) -> str | None:
+    for key in ("content", "body", "summary"):
+        value = row.get(key)
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def _render_value(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    if isinstance(value, list):
+        return ", ".join(_render_value(v) for v in value)
+    return str(value)

--- a/src/musubi/adapters/mcp/tools.py
+++ b/src/musubi/adapters/mcp/tools.py
@@ -38,12 +38,17 @@ logger = logging.getLogger(__name__)
 _MCP_MODALITY_TAG = "src:mcp-agent-remember"
 
 #: Plane → SDK accessor mapping for ``musubi_get``. Hard-coded so the
-#: agent never has to know the canonical-API pluralization rule.
+#: agent never has to know the canonical-API pluralization rule. Note:
+#: the SDK uses singular ``episodic``/``curated`` and plural
+#: ``concepts``/``artifacts`` (matching the canonical-API path prefixes
+#: ``/v1/episodic``, ``/v1/curated``, ``/v1/concepts``, ``/v1/artifacts``).
+#: Single source of truth for that mapping per
+#: [[07-interfaces/agent-tools#musubi_get]].
 _PLANE_ATTR: dict[str, str] = {
     "curated": "curated",
-    "concept": "concept",
+    "concept": "concepts",
     "episodic": "episodic",
-    "artifact": "artifact",
+    "artifact": "artifacts",
 }
 
 

--- a/tests/adapters/test_mcp_canonical_tools.py
+++ b/tests/adapters/test_mcp_canonical_tools.py
@@ -1,0 +1,441 @@
+"""Test contract for slice-mcp-canonical-tools.
+
+Implements the canonical agent-tools contract from
+[[07-interfaces/agent-tools]] for the MCP adapter. The five canonical
+tools (`musubi_recent`, `musubi_search`, `musubi_get`, `musubi_remember`,
+`musubi_think`) are exercised directly against a stub `AsyncMusubiClient`
+so the tool wiring is verified without spinning up the real backend.
+
+`musubi_recent` ships as a clearly-deferred stub in this slice — its
+backend dependency (`mode=recent`, [[_slices/slice-retrieve-recent]])
+is blocked. The stub test asserts the deferred-message shape; the
+contract's full recency semantics test moves into the slice that
+finishes the wiring once the backend mode lands.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from musubi.adapters.mcp.tools import attach_tools
+from mcp.server.fastmcp import FastMCP
+
+
+# --------------------------------------------------------------------------
+# Fakes
+# --------------------------------------------------------------------------
+
+
+class _PlaneStub:
+    def __init__(self, *, name: str, store: dict[str, dict[str, Any]] | None = None) -> None:
+        self.name = name
+        self.store = store if store is not None else {}
+        self.captured: list[dict[str, Any]] = []
+
+    async def capture(
+        self,
+        *,
+        namespace: str,
+        content: str,
+        importance: int = 5,
+        tags: list[str] | None = None,
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        oid = f"obj-{len(self.captured) + 1}"
+        record = {
+            "object_id": oid,
+            "namespace": namespace,
+            "content": content,
+            "importance": importance,
+            "tags": list(tags or []),
+            "idempotency_key": idempotency_key,
+        }
+        self.captured.append(record)
+        self.store[oid] = record
+        return {"object_id": oid, "state": "provisional"}
+
+    async def get(self, *, namespace: str, object_id: str) -> dict[str, Any]:
+        if object_id not in self.store:
+            from musubi.sdk.exceptions import MusubiError
+
+            raise MusubiError(f"not found: {object_id} in {namespace}")
+        return self.store[object_id]
+
+
+class _ThoughtsStub:
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
+
+    async def send(
+        self,
+        *,
+        namespace: str,
+        from_presence: str,
+        to_presence: str,
+        content: str,
+        channel: str = "default",
+        importance: int = 5,
+    ) -> dict[str, Any]:
+        oid = f"thought-{len(self.sent) + 1}"
+        self.sent.append(
+            {
+                "object_id": oid,
+                "namespace": namespace,
+                "from_presence": from_presence,
+                "to_presence": to_presence,
+                "content": content,
+                "channel": channel,
+                "importance": importance,
+            }
+        )
+        return {"object_id": oid}
+
+
+class _ClientStub:
+    """Mimics the surface of `AsyncMusubiClient` the MCP adapter uses."""
+
+    def __init__(self) -> None:
+        self.episodic = _PlaneStub(name="episodic")
+        self.curated = _PlaneStub(name="curated")
+        self.concept = _PlaneStub(name="concept")
+        self.artifact = _PlaneStub(name="artifact")
+        self.thoughts = _ThoughtsStub()
+        self._retrieve_calls: list[dict[str, Any]] = []
+        self._retrieve_response: dict[str, Any] = {"results": []}
+        self._retrieve_raise: Exception | None = None
+
+    async def retrieve(
+        self,
+        *,
+        namespace: str,
+        query_text: str,
+        mode: str = "fast",
+        limit: int = 10,
+        planes: list[str] | None = None,
+    ) -> dict[str, Any]:
+        self._retrieve_calls.append(
+            {
+                "namespace": namespace,
+                "query_text": query_text,
+                "mode": mode,
+                "limit": limit,
+                "planes": planes,
+            }
+        )
+        if self._retrieve_raise is not None:
+            raise self._retrieve_raise
+        return self._retrieve_response
+
+
+# --------------------------------------------------------------------------
+# Helper — invoke a registered tool by name
+# --------------------------------------------------------------------------
+
+
+def _invoke(mcp: FastMCP, name: str, **kwargs: Any) -> Any:
+    """Call a tool registered on the FastMCP instance directly.
+
+    FastMCP keeps the registered functions in a ``_tool_manager`` registry
+    keyed by name (private impl detail). We dig in rather than going
+    through the JSON-RPC transport for these unit tests.
+    """
+    tool_manager = mcp._tool_manager  # noqa: SLF001 — test access
+    tool = tool_manager._tools[name]  # noqa: SLF001
+    return tool.fn(**kwargs)
+
+
+def _make_server() -> tuple[FastMCP, _ClientStub]:
+    client = _ClientStub()
+    mcp = FastMCP("musubi-test")
+    attach_tools(mcp, client)  # type: ignore[arg-type]
+    return mcp, client
+
+
+# --------------------------------------------------------------------------
+# musubi_search
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_invokes_retrieve_deep_mode() -> None:
+    mcp, client = _make_server()
+    client._retrieve_response = {
+        "results": [
+            {
+                "plane": "episodic",
+                "object_id": "ep-1",
+                "namespace": "eric/claude-code/episodic",
+                "score": 0.92,
+                "content": "Eric was working on the canonical agent-tools spec.",
+                "title": None,
+            }
+        ]
+    }
+    result = await _invoke(
+        mcp,
+        "musubi_search",
+        namespace="eric/claude-code",
+        query="canonical agent tools spec",
+        limit=5,
+    )
+
+    assert client._retrieve_calls, "retrieve was not invoked"
+    call = client._retrieve_calls[0]
+    assert call["namespace"] == "eric/claude-code"
+    assert call["query_text"] == "canonical agent tools spec"
+    assert call["mode"] == "deep"
+    assert call["limit"] == 5
+    assert "Eric was working on" in result
+    assert "[episodic]" in result
+
+
+@pytest.mark.asyncio
+async def test_search_passes_planes_filter() -> None:
+    mcp, client = _make_server()
+    client._retrieve_response = {"results": []}
+    await _invoke(
+        mcp,
+        "musubi_search",
+        namespace="eric/claude-code",
+        query="x",
+        planes=["episodic", "curated"],
+    )
+    assert client._retrieve_calls[0]["planes"] == ["episodic", "curated"]
+
+
+@pytest.mark.asyncio
+async def test_search_no_results_returns_clear_message() -> None:
+    mcp, _ = _make_server()
+    result = await _invoke(mcp, "musubi_search", namespace="eric/claude-code", query="nothing")
+    assert "No memories matched" in result
+    assert "nothing" in result
+
+
+@pytest.mark.asyncio
+async def test_search_backend_error_returns_tool_error_string() -> None:
+    mcp, client = _make_server()
+    client._retrieve_raise = RuntimeError("backend down")
+    result = await _invoke(mcp, "musubi_search", namespace="eric/claude-code", query="x")
+    assert isinstance(result, str)
+    assert "backend down" in result or "couldn't" in result.lower()
+
+
+# --------------------------------------------------------------------------
+# musubi_get
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_round_trip_episodic() -> None:
+    mcp, client = _make_server()
+    client.episodic.store["ep-1"] = {
+        "object_id": "ep-1",
+        "namespace": "eric/claude-code/episodic",
+        "content": "Full episodic body — the source the agent will cite.",
+        "importance": 7,
+        "title": None,
+    }
+    result = await _invoke(
+        mcp,
+        "musubi_get",
+        plane="episodic",
+        namespace="eric/claude-code/episodic",
+        object_id="ep-1",
+    )
+    assert "Full episodic body" in result
+    assert "[episodic]" in result
+    assert "eric/claude-code/episodic/ep-1" in result
+
+
+@pytest.mark.asyncio
+async def test_get_routes_each_plane_to_its_stub() -> None:
+    mcp, client = _make_server()
+    client.curated.store["cur-1"] = {"object_id": "cur-1", "content": "curated body"}
+    client.concept.store["con-1"] = {"object_id": "con-1", "content": "concept body"}
+    client.artifact.store["art-1"] = {"object_id": "art-1", "content": "artifact body"}
+
+    for plane, oid, expected in [
+        ("curated", "cur-1", "curated body"),
+        ("concept", "con-1", "concept body"),
+        ("artifact", "art-1", "artifact body"),
+    ]:
+        result = await _invoke(
+            mcp,
+            "musubi_get",
+            plane=plane,
+            namespace=f"eric/_shared/{plane}",
+            object_id=oid,
+        )
+        assert expected in result, f"{plane} routing wrong"
+
+
+@pytest.mark.asyncio
+async def test_get_unknown_id_returns_tool_error_with_id_and_namespace() -> None:
+    mcp, _ = _make_server()
+    result = await _invoke(
+        mcp,
+        "musubi_get",
+        plane="episodic",
+        namespace="eric/claude-code/episodic",
+        object_id="missing-xyz",
+    )
+    assert "missing-xyz" in result
+    assert "eric/claude-code/episodic" in result
+
+
+# --------------------------------------------------------------------------
+# musubi_remember
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remember_writes_to_episodic_with_modality_tag() -> None:
+    mcp, client = _make_server()
+    result = await _invoke(
+        mcp,
+        "musubi_remember",
+        namespace="eric/claude-code/episodic",
+        content="Eric decided to ship the spec PR before the slice PR.",
+        importance=8,
+        topics=["spec", "ship-order"],
+    )
+    assert client.episodic.captured, "episodic.capture was not called"
+    write = client.episodic.captured[0]
+    assert write["namespace"] == "eric/claude-code/episodic"
+    assert write["content"].startswith("Eric decided")
+    assert write["importance"] == 8
+    assert "spec" in write["tags"]
+    assert "ship-order" in write["tags"]
+    # Required modality tag per [[07-interfaces/agent-tools#modality-tagging]]
+    assert "src:mcp-agent-remember" in write["tags"]
+    # Returns a confirmation string with the new id
+    assert "obj-1" in result
+
+
+@pytest.mark.asyncio
+async def test_remember_default_importance_is_seven() -> None:
+    mcp, client = _make_server()
+    await _invoke(
+        mcp,
+        "musubi_remember",
+        namespace="eric/claude-code/episodic",
+        content="x",
+    )
+    assert client.episodic.captured[0]["importance"] == 7
+
+
+# --------------------------------------------------------------------------
+# musubi_think
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_think_sends_thought_to_recipient_presence() -> None:
+    mcp, client = _make_server()
+    result = await _invoke(
+        mcp,
+        "musubi_think",
+        namespace="eric/claude-code/thought",
+        from_presence="eric/claude-code",
+        to_presence="eric/aoi",
+        content="Heads up: I shipped the canonical spec PR.",
+        channel="default",
+    )
+    assert client.thoughts.sent, "thoughts.send was not called"
+    sent = client.thoughts.sent[0]
+    assert sent["from_presence"] == "eric/claude-code"
+    assert sent["to_presence"] == "eric/aoi"
+    assert "canonical spec PR" in sent["content"]
+    assert "thought-1" in result
+
+
+# --------------------------------------------------------------------------
+# musubi_recent — deferred stub
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recent_returns_deferred_message_until_backend_lands() -> None:
+    """`musubi_recent` is the canonical-contract tool; its full implementation
+    waits on slice-retrieve-recent (Musubi #288). The stub must return a
+    clearly user-readable deferred message, not silently no-op or 500."""
+    mcp, _ = _make_server()
+    result = await _invoke(
+        mcp,
+        "musubi_recent",
+        namespace="eric/claude-code",
+        limit=10,
+    )
+    assert "not yet available" in result.lower() or "deferred" in result.lower()
+    assert "slice-retrieve-recent" in result or "#288" in result
+
+
+# --------------------------------------------------------------------------
+# Deprecation aliases
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_memory_capture_alias_forwards_to_remember_and_logs_deprecation(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mcp, client = _make_server()
+    caplog.set_level(logging.WARNING, logger="musubi.adapters.mcp.tools")
+    await _invoke(
+        mcp,
+        "memory_capture",
+        namespace="eric/claude-code/episodic",
+        content="test",
+        importance=5,
+    )
+    assert client.episodic.captured, "alias did not forward to canonical impl"
+    assert any(
+        "memory_capture" in rec.message.lower() and "deprecated" in rec.message.lower()
+        for rec in caplog.records
+    ), "no deprecation warning logged for memory_capture alias"
+
+
+@pytest.mark.asyncio
+async def test_memory_recall_alias_forwards_to_search_and_logs_deprecation(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mcp, client = _make_server()
+    caplog.set_level(logging.WARNING, logger="musubi.adapters.mcp.tools")
+    client._retrieve_response = {"results": []}
+    await _invoke(
+        mcp,
+        "memory_recall",
+        namespace="eric/claude-code",
+        query="x",
+        limit=5,
+    )
+    assert client._retrieve_calls, "alias did not forward to canonical impl"
+    assert any(
+        "memory_recall" in rec.message.lower() and "deprecated" in rec.message.lower()
+        for rec in caplog.records
+    ), "no deprecation warning logged for memory_recall alias"
+
+
+# --------------------------------------------------------------------------
+# Tool registration completeness
+# --------------------------------------------------------------------------
+
+
+def test_attach_tools_registers_all_canonical_plus_aliases() -> None:
+    mcp, _ = _make_server()
+    tools = mcp._tool_manager._tools  # noqa: SLF001
+    # Five canonical tools per [[07-interfaces/agent-tools]]
+    for name in (
+        "musubi_recent",
+        "musubi_search",
+        "musubi_get",
+        "musubi_remember",
+        "musubi_think",
+    ):
+        assert name in tools, f"canonical tool {name!r} not registered"
+    # Two deprecation aliases for one minor release
+    for name in ("memory_capture", "memory_recall"):
+        assert name in tools, f"deprecated alias {name!r} missing"

--- a/tests/adapters/test_mcp_canonical_tools.py
+++ b/tests/adapters/test_mcp_canonical_tools.py
@@ -101,10 +101,15 @@ class _ClientStub:
     """Mimics the surface of `AsyncMusubiClient` the MCP adapter uses."""
 
     def __init__(self) -> None:
+        # Mirror the real `AsyncMusubiClient` accessor names exactly:
+        # singular `episodic`/`curated`, plural `concepts`/`artifacts`
+        # (matching the canonical-API path prefixes). Stub names
+        # diverging from real names was the trap behind the original
+        # PLANE_ATTR pluralization bug — keep them locked in step.
         self.episodic = _PlaneStub(name="episodic")
         self.curated = _PlaneStub(name="curated")
-        self.concept = _PlaneStub(name="concept")
-        self.artifact = _PlaneStub(name="artifact")
+        self.concepts = _PlaneStub(name="concepts")
+        self.artifacts = _PlaneStub(name="artifacts")
         self.thoughts = _ThoughtsStub()
         self._retrieve_calls: list[dict[str, Any]] = []
         self._retrieve_response: dict[str, Any] = {"results": []}
@@ -257,8 +262,8 @@ async def test_get_round_trip_episodic() -> None:
 async def test_get_routes_each_plane_to_its_stub() -> None:
     mcp, client = _make_server()
     client.curated.store["cur-1"] = {"object_id": "cur-1", "content": "curated body"}
-    client.concept.store["con-1"] = {"object_id": "con-1", "content": "concept body"}
-    client.artifact.store["art-1"] = {"object_id": "art-1", "content": "artifact body"}
+    client.concepts.store["con-1"] = {"object_id": "con-1", "content": "concept body"}
+    client.artifacts.store["art-1"] = {"object_id": "art-1", "content": "artifact body"}
 
     for plane, oid, expected in [
         ("curated", "cur-1", "curated body"),
@@ -442,3 +447,39 @@ def test_attach_tools_registers_all_canonical_plus_aliases() -> None:
     # Two deprecation aliases for one minor release
     for name in ("memory_capture", "memory_recall"):
         assert name in tools, f"deprecated alias {name!r} missing"
+
+
+def test_plane_attr_map_targets_match_real_sdk_accessors() -> None:
+    """Regression test for the original PLANE_ATTR bug.
+
+    The Python SDK uses singular `episodic`/`curated` and plural
+    `concepts`/`artifacts`. An earlier draft had the map's *values*
+    in singular form (`"concept"`/`"artifact"`), which passed every
+    stub-based test but would `AttributeError` against the real
+    `AsyncMusubiClient` in production. Lock the map's values to the
+    real SDK class's attributes so this can't regress.
+    """
+    from musubi.adapters.mcp.tools import _PLANE_ATTR
+    from musubi.sdk.async_client import AsyncMusubiClient
+
+    # Construct a real client to introspect — base_url + token are
+    # required by the constructor but no I/O happens at __init__.
+    client = AsyncMusubiClient(base_url="https://musubi.test", token="t")
+    try:
+        for plane, attr in _PLANE_ATTR.items():
+            assert hasattr(client, attr), (
+                f"_PLANE_ATTR maps {plane!r} → {attr!r}, but AsyncMusubiClient "
+                f"has no such attribute. The SDK uses singular `episodic`/`curated` "
+                f"and plural `concepts`/`artifacts`."
+            )
+    finally:
+        # AsyncMusubiClient holds an httpx.AsyncClient — close it so the
+        # test doesn't trigger an "unclosed resource" warning under
+        # asyncio strict mode.
+        import asyncio
+
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(client.close())
+        finally:
+            loop.close()

--- a/tests/adapters/test_mcp_canonical_tools.py
+++ b/tests/adapters/test_mcp_canonical_tools.py
@@ -19,10 +19,9 @@ import logging
 from typing import Any
 
 import pytest
-
-from musubi.adapters.mcp.tools import attach_tools
 from mcp.server.fastmcp import FastMCP
 
+from musubi.adapters.mcp.tools import attach_tools
 
 # --------------------------------------------------------------------------
 # Fakes
@@ -59,9 +58,13 @@ class _PlaneStub:
 
     async def get(self, *, namespace: str, object_id: str) -> dict[str, Any]:
         if object_id not in self.store:
-            from musubi.sdk.exceptions import MusubiError
+            from musubi.sdk.exceptions import NotFound
 
-            raise MusubiError(f"not found: {object_id} in {namespace}")
+            raise NotFound(
+                code="NOT_FOUND",
+                detail=f"not found: {object_id} in {namespace}",
+                status_code=404,
+            )
         return self.store[object_id]
 
 
@@ -142,8 +145,8 @@ def _invoke(mcp: FastMCP, name: str, **kwargs: Any) -> Any:
     keyed by name (private impl detail). We dig in rather than going
     through the JSON-RPC transport for these unit tests.
     """
-    tool_manager = mcp._tool_manager  # noqa: SLF001 — test access
-    tool = tool_manager._tools[name]  # noqa: SLF001
+    tool_manager = mcp._tool_manager
+    tool = tool_manager._tools[name]
     return tool.fn(**kwargs)
 
 
@@ -426,7 +429,7 @@ async def test_memory_recall_alias_forwards_to_search_and_logs_deprecation(
 
 def test_attach_tools_registers_all_canonical_plus_aliases() -> None:
     mcp, _ = _make_server()
-    tools = mcp._tool_manager._tools  # noqa: SLF001
+    tools = mcp._tool_manager._tools
     # Five canonical tools per [[07-interfaces/agent-tools]]
     for name in (
         "musubi_recent",


### PR DESCRIPTION
Closes #286.

## Summary

Implements the **canonical agent-tools surface** ([[07-interfaces/agent-tools]]) in `src/musubi/adapters/mcp/`. The MCP adapter now exposes the same five tools every other Musubi adapter exposes — same names, same parameter shapes — replacing the v1.0 `memory_capture` / `memory_recall` two-tool surface.

This PR replaces #290 (closed when its base branch was deleted after #289's squash merge). Same content, rebased onto current main.

Once this slice merges and the operator runs `claude mcp add -s user musubi -- python -m musubi.adapters.mcp serve`, **Claude Code itself gets the same tool kit Aoi has on phone, voice, and Discord.**

## Tools shipped

| Tool | Backing SDK call | Status |
|---|---|---|
| \`musubi_search\` | \`client.retrieve(mode=\"deep\")\` | working |
| \`musubi_get\` | \`client.<plane>.get()\` per the hard-coded plane→accessor map | working |
| \`musubi_remember\` | \`client.episodic.capture()\` with \`src:mcp-agent-remember\` auto-tag | working |
| \`musubi_think\` | \`client.thoughts.send()\` | working |
| \`musubi_recent\` | _(deferred)_ — clearly-deferred stub returning a user-readable message naming slice-retrieve-recent (#288). Logs at WARNING per the rule that ADR-punted deps must fail loud. |
| \`memory_capture\` / \`memory_recall\` | one-release deprecation aliases — forward to canonical impl + WARNING log |

## Bug caught and fixed

Copilot's review on #289 flagged that the Python SDK uses singular \`episodic\`/\`curated\` and **plural** \`concepts\`/\`artifacts\`. My initial \`_PLANE_ATTR\` map had singular for both — every test passed against my matching stub but production would have AttributeError'd. Fixed in this PR + a regression test (\`test_plane_attr_map_targets_match_real_sdk_accessors\`) that introspects the real \`AsyncMusubiClient\` so a future singular-vs-plural drift fails at unit-test time.

## Sidecar fix

\`docs/Musubi/_tools/tc_coverage.py\` had a stale path (\`docs/architecture\` instead of \`docs/Musubi\`) that broke \`make tc-coverage\` for **every** slice in the repo. Single-line fix included.

## Test plan

- [x] \`make check\` — 1290 tests pass, 0 errors
- [x] \`make agent-check\` — 0 errors (10 pre-existing warnings)
- [x] \`make tc-coverage SLICE=slice-mcp-canonical-tools\` — ✓ Closure Rule satisfied
- [x] 15 tests in \`tests/adapters/test_mcp_canonical_tools.py\`

## Definition of Done

- [x] First commit is the test contract
- [x] Slice frontmatter \`status: done\`, lock removed (in this PR's \`chore(slice)\` commit)
- [x] PR body opens with \`Closes #286.\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)