### PR TITLE
chore(slice): close slice-openclaw-canonical-tools post-merge

### DIFF
--- a/docs/Musubi/_slices/slice-openclaw-canonical-tools.md
+++ b/docs/Musubi/_slices/slice-openclaw-canonical-tools.md
@@ -3,10 +3,11 @@ title: "Slice: OpenClaw plugin — canonical agent tools"
 slice_id: slice-openclaw-canonical-tools
 section: _slices
 type: slice
-status: blocked
+status: done
+owner: aoi-claude-opus
 phase: "8 Post-1.0"
-tags: [section/slices, status/blocked, type/slice, adapter, openclaw, agent-tools]
-updated: 2026-04-29
+tags: [section/slices, status/done, type/slice, adapter, openclaw, agent-tools]
+updated: 2026-04-30
 reviewed: false
 depends-on: ["[[_slices/slice-retrieve-recent]]"]
 blocks: []
@@ -16,7 +17,7 @@ blocks: []
 
 > Bring the openclaw-musubi plugin onto the canonical agent-tools surface. Add `musubi_recent`, alias `musubi_recall` → `musubi_search` for one release, drop the alias afterward. `musubi_get` already lands in `openclaw-musubi#24`.
 
-**Phase:** 8 Post-1.0 · **Status:** `blocked` (on [[_slices/slice-retrieve-recent]] for full canonical surface; MAY pick up early with the documented fallback path for `musubi_recent`)
+**Phase:** 8 Post-1.0 · **Status:** `done` (shipped via openclaw-musubi PRs #24 + #26 on 2026-04-30; `musubi_recent` ships with the GET /v1/episodic fallback path until [[_slices/slice-retrieve-recent]] lands the cross-channel `mode=recent`) · **Owner:** `aoi-claude-opus`
 
 ## Implementation lives in a sibling repo
 


### PR DESCRIPTION
No tracking Issue: post-merge cleanup of vault state. The slice's tracking issue (#287) auto-closed on the openclaw-musubi#26 merge via \`Closes ericmey/musubi#287\`; this PR flips the vault-side slice frontmatter to match.

## Summary

\`slice-openclaw-canonical-tools\` shipped via two openclaw-musubi PRs:

- [openclaw-musubi#24](https://github.com/ericmey/openclaw-musubi/pull/24) — \`musubi_get\` (merged 2026-04-30)
- [openclaw-musubi#26](https://github.com/ericmey/openclaw-musubi/pull/26) — \`musubi_search\` rename + \`musubi_recent\` + \`musubi_recall\` deprecation alias (merged 2026-04-30)

Both PRs landed earlier today. This commit flips the slice frontmatter from \`status: blocked\` to \`status: done\` so the vault state matches reality, and sets owner = \`aoi-claude-opus\`.

\`musubi_recent\` ships with the documented GET /v1/episodic fallback path until [[_slices/slice-retrieve-recent]] (#288) lands the cross-channel \`mode=recent\`. Documented in the openclaw-musubi PR and in the slice's "Anticipated paths at pickup" section.

## Test plan

- [x] \`make agent-check\` — 0 errors. 9 warnings (all pre-existing).
- [x] Vault state matches the actual implementation status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)