### PR TITLE
chore(runbooks): fix upgrade.md ansible command + base-branch refs

### DIFF
--- a/deploy/runbooks/upgrade.md
+++ b/deploy/runbooks/upgrade.md
@@ -22,7 +22,10 @@ cd ~/musubi
 git pull --ff-only
 
 # Confirm the compose render will succeed with the current vars:
-ansible-playbook -i ~/.musubi-secrets/inventory-vars.yml \
+ansible-playbook \
+ -i deploy/ansible/inventory.yml \
+ -e @~/.musubi-secrets/inventory-vars.yml \
+ -e @~/.musubi-secrets/vault.yml \
  deploy/ansible/update.yml --check --ask-vault-pass
 ```
 
@@ -55,7 +58,7 @@ sed -i '' \
  -E 's|^musubi_core_image: .*|musubi_core_image: "ghcr.io/ericmey/musubi-core@sha256:<paste>"|' \
  deploy/ansible/group_vars/all.yml
 git commit -am "ops: bump musubi_core_image to @sha256:<first 12 chars>"
-gh pr create --base v2 --title "ops: bump musubi_core_image"
+gh pr create --base main --title "ops: bump musubi_core_image"
 ```
 
 **Expected output:**
@@ -73,7 +76,10 @@ Single-line diff in `group_vars/all.yml`. PR greens on CI.
 **Command:**
 
 ```bash
-ansible-playbook -i ~/.musubi-secrets/inventory-vars.yml \
+ansible-playbook \
+ -i deploy/ansible/inventory.yml \
+ -e @~/.musubi-secrets/inventory-vars.yml \
+ -e @~/.musubi-secrets/vault.yml \
  deploy/ansible/update.yml \
  --check --diff --ask-vault-pass
 ```
@@ -97,10 +103,16 @@ ansible-playbook -i ~/.musubi-secrets/inventory-vars.yml \
 **Command:**
 
 ```bash
-ansible-playbook -i ~/.musubi-secrets/inventory-vars.yml \
+ansible-playbook \
+ -i deploy/ansible/inventory.yml \
+ -e @~/.musubi-secrets/inventory-vars.yml \
+ -e @~/.musubi-secrets/vault.yml \
  deploy/ansible/update.yml --ask-vault-pass
 # Or for a multi-service bump:
-ansible-playbook -i ~/.musubi-secrets/inventory-vars.yml \
+ansible-playbook \
+ -i deploy/ansible/inventory.yml \
+ -e @~/.musubi-secrets/inventory-vars.yml \
+ -e @~/.musubi-secrets/vault.yml \
  deploy/ansible/update.yml \
  -e changed_services='["core","tei-dense"]' --ask-vault-pass
 ```
@@ -161,10 +173,13 @@ git -C ~/musubi log -p -- deploy/ansible/group_vars/all.yml | head -40
 
 # Revert:
 git -C ~/musubi revert --no-edit <bump-sha>
-git -C ~/musubi push origin v2
+git -C ~/musubi push origin main
 
 # Re-run update.yml:
-ansible-playbook -i ~/.musubi-secrets/inventory-vars.yml \
+ansible-playbook \
+ -i deploy/ansible/inventory.yml \
+ -e @~/.musubi-secrets/inventory-vars.yml \
+ -e @~/.musubi-secrets/vault.yml \
  deploy/ansible/update.yml --ask-vault-pass
 ```
 


### PR DESCRIPTION
## Summary

Two doc bugs in `deploy/runbooks/upgrade.md` surfaced during the ADR 0033 deploy. No code or playbook changes — runbook hygiene only.

## Bugs fixed

**1. The ansible-playbook invocation is wrong (4 occurrences).**

Runbook says:

```bash
ansible-playbook -i ~/.musubi-secrets/inventory-vars.yml \
 deploy/ansible/update.yml --ask-vault-pass
```

This fails immediately with `provided hosts list is empty`. `~/.musubi-secrets/inventory-vars.yml` is a *vars file* (loose top-level variables: `operator_ssh_user`, `musubi_host`, etc.), not an *inventory* (host-group definitions). Ansible parses it as inventory, emits warnings about the top-level vars not being valid groups, then can't match the `hosts: musubi` pattern in `deploy/ansible/update.yml`.

Additionally `vault.yml` was never loaded, so the compose template render fails on `vault_qdrant_api_key is undefined`.

**Corrected form:**

```bash
ansible-playbook \
 -i deploy/ansible/inventory.yml \
 -e @~/.musubi-secrets/inventory-vars.yml \
 -e @~/.musubi-secrets/vault.yml \
 deploy/ansible/update.yml --ask-vault-pass
```

`-i` points at the actual inventory; `-e @<file>` loads the vars (the `@` is critical — without it ansible treats the path string as a literal `key=value`).

**2. Two `v2`-branch references are stale (sections 2 + 6).**

- `gh pr create --base v2` → `gh pr create --base main`
- `git -C ~/musubi push origin v2` → `git -C ~/musubi push origin main`

`v2` was the dev branch before main went live. `origin/HEAD` is `main` per `git remote show origin`; recent releases (v1.2.4, v1.3.0, v1.3.1) all merged to main. Updated both references.

## Gates

- `make wikilink-check` ✓
- `uv run pytest tests/ops/` ✓ (163 passed, 1 skipped — unrelated)

## Test plan

- [ ] Merge to main
- [ ] Next musubi-side ansible deploy uses the corrected command from the runbook without modification
