### PR TITLE
OTel label alignment for musubi (F3.1/F3.2) + deploy wrapper

### DIFF
--- a/deploy/prometheus/prometheus.yml
+++ b/deploy/prometheus/prometheus.yml
@@ -30,8 +30,9 @@ global:
   scrape_interval: 15s
   scrape_timeout: 10s
   external_labels:
-    cluster: musubi
-    host: musubi
+    deployment_environment: harem-world
+    host_name: musubi
+    service_namespace: musubi
 
 # Mirror every sample to shiori's Mimir. Local TSDB still serves direct
 # PromQL queries on 127.0.0.1:9090 if shiori is unreachable.
@@ -43,6 +44,11 @@ remote_write:
       - source_labels: [job]
         regex: prometheus
         action: drop
+      # Promote `job` → `service_name` so musubi-emitted series match the
+      # OTel convention used by openclaw/livekit/shiori. See [[wiki/services/observability/integration-baseline#F3.1]].
+      - source_labels: [job]
+        target_label: service_name
+        action: replace
 
 scrape_configs:
   # Musubi Core — HTTP API metrics (request counts, latency histograms,
@@ -52,8 +58,6 @@ scrape_configs:
     metrics_path: /v1/ops/metrics
     static_configs:
       - targets: ["core:8100"]
-        labels:
-          service: core
 
   # TEI — each embedder/reranker exposes its own /metrics on port 80
   # (batch latency, queue depth, GPU utilisation).
@@ -62,7 +66,6 @@ scrape_configs:
     static_configs:
       - targets: ["tei-dense:80"]
         labels:
-          service: tei-dense
           model: bge-m3
 
   - job_name: tei-sparse
@@ -70,7 +73,6 @@ scrape_configs:
     static_configs:
       - targets: ["tei-sparse:80"]
         labels:
-          service: tei-sparse
           model: splade-v3
 
   - job_name: tei-reranker
@@ -78,7 +80,6 @@ scrape_configs:
     static_configs:
       - targets: ["tei-reranker:80"]
         labels:
-          service: tei-reranker
           model: bge-reranker-v2-m3
 
   # Prometheus scrapes itself — cheap, handy for debugging "are scrapes
@@ -97,5 +98,3 @@ scrape_configs:
   - job_name: node-exporter
     static_configs:
       - targets: ["node-exporter:9100"]
-        labels:
-          service: node-exporter

--- a/deploy/runbooks/upgrade.md
+++ b/deploy/runbooks/upgrade.md
@@ -22,7 +22,10 @@ cd ~/musubi
 git pull --ff-only
 
 # Confirm the compose render will succeed with the current vars:
-ansible-playbook -i ~/.musubi-secrets/inventory-vars.yml \
+ansible-playbook \
+ -i deploy/ansible/inventory.yml \
+ -e @~/.musubi-secrets/inventory-vars.yml \
+ -e @~/.musubi-secrets/vault.yml \
  deploy/ansible/update.yml --check --ask-vault-pass
 ```
 
@@ -55,7 +58,7 @@ sed -i '' \
  -E 's|^musubi_core_image: .*|musubi_core_image: "ghcr.io/ericmey/musubi-core@sha256:<paste>"|' \
  deploy/ansible/group_vars/all.yml
 git commit -am "ops: bump musubi_core_image to @sha256:<first 12 chars>"
-gh pr create --base v2 --title "ops: bump musubi_core_image"
+gh pr create --base main --title "ops: bump musubi_core_image"
 ```
 
 **Expected output:**
@@ -73,7 +76,10 @@ Single-line diff in `group_vars/all.yml`. PR greens on CI.
 **Command:**
 
 ```bash
-ansible-playbook -i ~/.musubi-secrets/inventory-vars.yml \
+ansible-playbook \
+ -i deploy/ansible/inventory.yml \
+ -e @~/.musubi-secrets/inventory-vars.yml \
+ -e @~/.musubi-secrets/vault.yml \
  deploy/ansible/update.yml \
  --check --diff --ask-vault-pass
 ```
@@ -97,10 +103,16 @@ ansible-playbook -i ~/.musubi-secrets/inventory-vars.yml \
 **Command:**
 
 ```bash
-ansible-playbook -i ~/.musubi-secrets/inventory-vars.yml \
+ansible-playbook \
+ -i deploy/ansible/inventory.yml \
+ -e @~/.musubi-secrets/inventory-vars.yml \
+ -e @~/.musubi-secrets/vault.yml \
  deploy/ansible/update.yml --ask-vault-pass
 # Or for a multi-service bump:
-ansible-playbook -i ~/.musubi-secrets/inventory-vars.yml \
+ansible-playbook \
+ -i deploy/ansible/inventory.yml \
+ -e @~/.musubi-secrets/inventory-vars.yml \
+ -e @~/.musubi-secrets/vault.yml \
  deploy/ansible/update.yml \
  -e changed_services='["core","tei-dense"]' --ask-vault-pass
 ```
@@ -161,10 +173,13 @@ git -C ~/musubi log -p -- deploy/ansible/group_vars/all.yml | head -40
 
 # Revert:
 git -C ~/musubi revert --no-edit <bump-sha>
-git -C ~/musubi push origin v2
+git -C ~/musubi push origin main
 
 # Re-run update.yml:
-ansible-playbook -i ~/.musubi-secrets/inventory-vars.yml \
+ansible-playbook \
+ -i deploy/ansible/inventory.yml \
+ -e @~/.musubi-secrets/inventory-vars.yml \
+ -e @~/.musubi-secrets/vault.yml \
  deploy/ansible/update.yml --ask-vault-pass
 ```
 

--- a/scripts/musubi-deploy
+++ b/scripts/musubi-deploy
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# musubi-deploy — friendlier wrapper around the musubi ansible playbook.
+#
+# Default: dry-run (--check --diff).  Pass --apply to do the real thing.
+#
+# Usage:
+#   musubi-deploy <service[,service...]>           # dry-run
+#   musubi-deploy --apply <service[,service...]>   # real
+#   musubi-deploy --apply core,tei-dense           # multiple services
+#   musubi-deploy --help
+#
+# Env / paths assumed:
+#   This script must be run from the musubi repo root, OR set
+#   $MUSUBI_REPO to point at the checkout. Defaults to $PWD.
+#
+#   $MUSUBI_SECRETS_DIR overrides the secrets dir.
+#   Defaults to ~/.musubi-secrets/.
+#
+#   $ANSIBLE_VAULT_PASSWORD_FILE — if set and readable, the wrapper
+#   uses --vault-password-file instead of prompting via --ask-vault-pass.
+#   Useful for headless / CI invocations.
+#
+# Exit codes:
+#   0  success
+#   1  bad usage
+#   2  missing inputs (repo, secrets, etc.)
+#   anything else — ansible-playbook's exit code
+
+set -euo pipefail
+
+MUSUBI_REPO="${MUSUBI_REPO:-$PWD}"
+MUSUBI_SECRETS_DIR="${MUSUBI_SECRETS_DIR:-$HOME/.musubi-secrets}"
+
+usage() {
+  sed -n '/^# musubi-deploy/,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+die() {
+  echo "musubi-deploy: $*" >&2
+  exit "${2:-1}"
+}
+
+apply=false
+services=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply)
+      apply=true
+      shift
+      ;;
+    --help | -h)
+      usage 0
+      ;;
+    --*)
+      die "unknown flag: $1" 1
+      ;;
+    *)
+      if [[ -n "$services" ]]; then
+        die "only one service list allowed (use comma-separated: a,b,c)" 1
+      fi
+      services="$1"
+      shift
+      ;;
+  esac
+done
+
+[[ -n "$services" ]] || { usage 1 ; }
+
+# Build the JSON list ansible expects: ["a", "b", ...]
+services_json="[$(echo "$services" | awk -F, '{
+  for (i = 1; i <= NF; i++) {
+    printf "%s\"%s\"", (i > 1 ? ", " : ""), $i
+  }
+}')]"
+
+# Sanity-check inputs.
+playbook="$MUSUBI_REPO/deploy/ansible/update.yml"
+inventory="$MUSUBI_REPO/deploy/ansible/inventory.yml"
+inv_vars="$MUSUBI_SECRETS_DIR/inventory-vars.yml"
+vault="$MUSUBI_SECRETS_DIR/vault.yml"
+
+[[ -f "$playbook" ]]  || die "playbook not found at $playbook (set MUSUBI_REPO?)" 2
+[[ -f "$inventory" ]] || die "inventory not found at $inventory" 2
+[[ -f "$inv_vars" ]]  || die "inventory-vars not found at $inv_vars (set MUSUBI_SECRETS_DIR?)" 2
+[[ -f "$vault" ]]     || die "vault file not found at $vault" 2
+
+# Compose the command.
+cmd=(
+  ansible-playbook
+  -i "$inventory"
+  -e "@$inv_vars"
+  -e "@$vault"
+  "$playbook"
+  -e "changed_services=$services_json"
+)
+
+# Vault password: prefer file over interactive prompt when available.
+if [[ -n "${ANSIBLE_VAULT_PASSWORD_FILE:-}" && -r "$ANSIBLE_VAULT_PASSWORD_FILE" ]]; then
+  cmd+=( --vault-password-file "$ANSIBLE_VAULT_PASSWORD_FILE" )
+else
+  cmd+=( --ask-vault-pass )
+fi
+
+if ! $apply; then
+  cmd+=(--check --diff)
+  echo "musubi-deploy: DRY RUN (--check --diff). Pass --apply to execute."
+else
+  echo "musubi-deploy: APPLY mode. Services: $services"
+  read -r -p "Confirm apply to musubi (y/N)? " response
+  case "$response" in
+    [yY] | [yY][eE][sS])
+      ;;
+    *)
+      echo "Aborted."
+      exit 0
+      ;;
+  esac
+fi
+
+echo "+ ${cmd[*]}"
+exec "${cmd[@]}"

--- a/tests/ops/test_prometheus.py
+++ b/tests/ops/test_prometheus.py
@@ -78,11 +78,15 @@ def test_scrape_targets_musubi_core_metrics_endpoint() -> None:
 
 
 def test_external_labels_identify_host() -> None:
-    """Every metric must carry enough metadata to be attributed to this
-    box once we have more than one musubi host."""
+    """Every metric must carry the OTel resource attributes used by the
+    rest of the fleet (openclaw, livekit, shiori) so cross-emitter queries
+    work without a label-rename layer at query time. See
+    wiki/services/observability/integration-baseline.md (F3.1)."""
     cfg = _load(PROM_CONFIG)
     labels = cfg["global"].get("external_labels") or {}
-    assert "host" in labels, "external_labels.host missing"
+    assert "host_name" in labels, "external_labels.host_name missing (OTel convention)"
+    assert "deployment_environment" in labels, "external_labels.deployment_environment missing"
+    assert "service_namespace" in labels, "external_labels.service_namespace missing"
 
 
 def test_remote_write_to_shiori_central() -> None:


### PR DESCRIPTION
## Summary

- Rewrites musubi prometheus.yml labels to match OTel conventions used elsewhere in the fleet (openclaw, livekit, shiori).
- Adds a friendlier wrapper script (`scripts/musubi-deploy`) for ansible playbook invocations — used to deploy this very change to musubi (eats own dogfood).

## Background

Per the cross-emitter audit in `wiki/services/observability/integration-baseline.md` (F3.1, F3.2): musubi data carried Prometheus-style labels (`cluster=musubi`, `host=musubi`, `service=core`) while openclaw + livekit shipped OTel-style (`host_name=`, `service_name=`, `service_namespace=`, `deployment_environment=`). A query like `up{host_name="musubi"}` returned nothing; `up{host="shiori"}` also returned nothing. Two emitters, one question, two queries.

This PR aligns musubi to the fleet convention.

## Changes

**`deploy/prometheus/prometheus.yml`:**
- `external_labels`: replace `cluster: musubi` + `host: musubi` with `deployment_environment: harem-world`, `host_name: musubi`, `service_namespace: musubi`.
- `remote_write.write_relabel_configs`: add `job` → `service_name` promotion.
- Drop redundant per-target `service:` static labels (job_name now feeds `service_name`).
- Preserve domain labels (`model: bge-m3` etc.) on TEI scrapes.

**`scripts/musubi-deploy`** (new):
- Default: dry-run (`--check --diff`); `--apply` runs for real behind y/N confirm.
- Reads vault password from `ANSIBLE_VAULT_PASSWORD_FILE` when set; otherwise falls back to `--ask-vault-pass`.

## Verification (post-deploy on musubi)

```
$ curl -sS shiori:9009/prometheus/api/v1/label/host_name/values
musubi, nyla, shiori          ← was: nyla, shiori

$ curl -sS shiori:9009/prometheus/api/v1/label/service_name/values
musubi-core, node-exporter, tei-dense, tei-reranker, tei-sparse,
grafana, openclaw-nyla, openclaw-livekit-{aoi,nyla,party}, otelcol-contrib

$ curl -sS shiori:9009/prometheus/api/v1/query?query=up{host_name="musubi"}
all 5 targets up=1
```

Old `cluster=musubi`/`host=musubi` series stopped receiving samples 5s before the prometheus restart and will age out per default 5min instant lookback.

## Follow-on (separate)

- Bake `service_version: {git_sha_at_deploy}` per scrape via ansible templating (F3.2 deferred).

## Test plan

- [x] Dry-run shows expected diff against live `/etc/musubi/prometheus.yml`
- [x] Apply succeeds (ok=8 changed=3 failed=0)
- [x] Prometheus restarts cleanly, WAL replay completes, remote_write reconnects to shiori
- [x] Mimir index shows musubi under `host_name`, `service_name`, `service_namespace` labels
- [x] `up{host_name="musubi"}` returns all targets