### PR TITLE
fix(observability): complete server-side OTel tracing (debt from slice-ops-observability)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,15 +16,20 @@ ENV UV_COMPILE_BYTECODE=1 \
 WORKDIR /app
 
 # Install production deps first so the layer caches when only source changes.
+# `--extra otel` includes the OpenTelemetry SDK + OTLP exporter + FastAPI/
+# logging instrumentation so the server can emit spans to Tempo when
+# Settings.otel_exporter_otlp_endpoint is set. Per
+# [[09-operations/observability]] § Tracing. When the endpoint is unset
+# the deps are imported lazily and produce no overhead.
 COPY pyproject.toml uv.lock ./
 RUN --mount=type=cache,target=/uv-cache \
-    uv sync --frozen --no-install-project --no-dev
+    uv sync --frozen --no-install-project --no-dev --extra otel
 
 # Now install the project itself.
 COPY src/ ./src/
 COPY README.md ./
 RUN --mount=type=cache,target=/uv-cache \
-    uv sync --frozen --no-dev
+    uv sync --frozen --no-dev --extra otel
 
 
 FROM python:3.12-slim-bookworm AS runtime

--- a/docs/Musubi/_inbox/cross-slice/slice-sdk-py-otel-spans.md
+++ b/docs/Musubi/_inbox/cross-slice/slice-sdk-py-otel-spans.md
@@ -86,6 +86,19 @@ to track in the install matrix.
 
 Resolved by PR #131.
 
-## Resolution
+## 2026-05-13 follow-up
 
-Resolved by PR #131.
+This ticket fixed the SDK consumer-side path (one span per HTTP call,
+opt-in via `[otel]` extras). It did **not** also fix the server side —
+musubi-core itself never initialized a `TracerProvider`, never installed
+`FastAPIInstrumentor`, never emitted spans.
+
+The server-side gap was scoped under `slice-ops-observability`
+(see `09-operations/observability.md` § Tracing) but discovered
+unshipped on 2026-05-13. It is being completed under issue
+[#302](https://github.com/ericmey/musubi/issues/302) — debt repayment,
+not new scope.
+
+Once the server side ships, the SDK spans this ticket resolved will
+finally have something to link to: SDK span → server span → Tempo
+trace, as the original spec diagrammed.

--- a/docs/Musubi/_inbox/cross-slice/slice-sdk-py-otel-spans.md
+++ b/docs/Musubi/_inbox/cross-slice/slice-sdk-py-otel-spans.md
@@ -8,7 +8,7 @@ status: resolved
 opened_by: vscode-cc-sonnet47
 opened_at: 2026-04-19
 tags: [section/inbox-cross-slice, type/cross-slice, status/resolved]
-updated: 2026-04-19
+updated: 2026-05-13
 ---
 
 # Add OpenTelemetry span emission to the Python SDK

--- a/docs/Musubi/_slices/slice-ops-observability.md
+++ b/docs/Musubi/_slices/slice-ops-observability.md
@@ -7,7 +7,7 @@ status: done
 owner: vscode-cc-sonnet47
 phase: "8 Ops"
 tags: [section/slices, status/done, type/slice]
-updated: 2026-04-19
+updated: 2026-05-13
 reviewed: true
 depends-on: ["[[_slices/slice-ops-compose]]"]
 blocks: ["[[_slices/slice-ops-first-deploy]]", "[[_slices/slice-ops-hardening-suite]]"]
@@ -99,9 +99,11 @@ the **Tracing portion** of this slice's spec
 (`09-operations/observability.md` § Tracing — "OpenTelemetry SDK in Core +
 adapter libraries. Spans go to a local OTel Collector → Tempo") was
 **never implemented**. The slice closed marking observability complete,
-but only metrics + the `StructuredJsonFormatter` shipped. There are no
-OTel imports anywhere outside `src/musubi/sdk/tracing.py` (the SDK
-consumer-side, which is itself dormant).
+but only metrics + the `StructuredJsonFormatter` shipped. In
+production code (`src/musubi/`), there are no OTel imports outside
+`src/musubi/sdk/tracing.py` (the SDK consumer-side, which is itself
+dormant). Test modules import the OTel SDK to exercise SDK behaviour,
+but no shipping code path emits spans.
 
 Verified by querying the live Tempo datasource on shiori via the Grafana
 MCP: zero tags, zero `service.name` values, zero traces. The whole fleet

--- a/docs/Musubi/_slices/slice-ops-observability.md
+++ b/docs/Musubi/_slices/slice-ops-observability.md
@@ -92,10 +92,42 @@ Agents append one entry per work session. Format:
 - This work-log entry retains the slice's history; the slice is not reopened (status stays `done`). The superseded `## Owned paths` entries are struck through with a wikilink to ADR 0033 for traceability.
 - Future central-side artifacts (musubi-specific dashboards on shiori, alert routing, log shipping) are out of this slice's scope per ADR 0033 — they belong to follow-up slices/PRs scoped to the shiori-side codebase.
 
+### 2026-05-13 — aoi/command-chair — Tracing section was never implemented
+
+While building the harem-ops fleet telemetry coverage map, discovered that
+the **Tracing portion** of this slice's spec
+(`09-operations/observability.md` § Tracing — "OpenTelemetry SDK in Core +
+adapter libraries. Spans go to a local OTel Collector → Tempo") was
+**never implemented**. The slice closed marking observability complete,
+but only metrics + the `StructuredJsonFormatter` shipped. There are no
+OTel imports anywhere outside `src/musubi/sdk/tracing.py` (the SDK
+consumer-side, which is itself dormant).
+
+Verified by querying the live Tempo datasource on shiori via the Grafana
+MCP: zero tags, zero `service.name` values, zero traces. The whole fleet
+has zero trace coverage.
+
+The status of this slice **stays `done`** — its history is the artifact.
+The unshipped Tracing scope is being completed under issue
+[#302](https://github.com/ericmey/musubi/issues/302) without expanding
+beyond the original spec. Two small companion fixes are included to make
+the spec actually true:
+
+- Route uvicorn access + error logs through `StructuredJsonFormatter`
+  (currently they bypass it and emit plain `INFO: ... GET ...` lines —
+  the JSON-logs contract the spec mandated has not been honoured in
+  practice).
+- Inject `trace_id` / `span_id` into the formatter's payload when there
+  is an active span — connecting tissue between the two telemetry
+  signals the spec already requires.
+
+This is debt repayment, not a new slice.
+
 ## Cross-slice tickets opened by this slice
 
 - _(none yet)_
 
 ## PR links
 
-- _(none yet)_
+- _(none yet — issue [#302](https://github.com/ericmey/musubi/issues/302)
+  completes the unshipped Tracing scope)_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,17 @@ musubi = "musubi.cli.main:app"
 
 
 [project.optional-dependencies]
+# Server-side OTel: tracer provider + OTLP gRPC exporter + auto-instrumentation
+# for FastAPI and the stdlib `logging` module. The SDK consumer-side
+# (src/musubi/sdk/tracing.py) only needs the API; the server needs the full
+# pipeline to actually emit spans. Both share the [otel] extra so installs
+# remain coherent.
 otel = [
     "opentelemetry-api>=1.27",
+    "opentelemetry-sdk>=1.27",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.27",
+    "opentelemetry-instrumentation-fastapi>=0.48b0",
+    "opentelemetry-instrumentation-logging>=0.48b0",
 ]
 dev = [
     "pytest>=8",
@@ -53,8 +62,13 @@ dev = [
 
     "types-PyYAML",
     "jinja2>=3",
+    # OTel deps duplicated here so the dev env can import tracing helpers
+    # without pulling the [otel] extra explicitly. Mirrors the [otel] set above.
     "opentelemetry-api>=1.27",
     "opentelemetry-sdk>=1.27",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.27",
+    "opentelemetry-instrumentation-fastapi>=0.48b0",
+    "opentelemetry-instrumentation-logging>=0.48b0",
 ]
 
 

--- a/src/musubi/api/app.py
+++ b/src/musubi/api/app.py
@@ -56,7 +56,13 @@ from musubi.api.routers import (
     writes_retrieve_stream,
     writes_thoughts,
 )
-from musubi.observability import install_metrics_middleware, request_id_var
+from musubi.observability import (
+    configure_logging,
+    init_tracing,
+    install_metrics_middleware,
+    instrument_fastapi,
+    request_id_var,
+)
 from musubi.settings import Settings
 
 log = logging.getLogger(__name__)
@@ -146,6 +152,25 @@ def create_app(*, settings: Settings | None = None) -> FastAPI:
         from musubi.config import get_settings as _get_settings
 
         settings = _get_settings()
+
+    # Wire structured JSON logging on root + uvicorn so the JSON-logs
+    # contract from [[09-operations/observability]] § Logs is actually
+    # honoured in container output. Idempotent — tests calling
+    # ``create_app`` repeatedly reuse the same handler.
+    configure_logging()
+
+    # Initialize OTel tracing if Settings.otel_exporter_otlp_endpoint is
+    # set. No-op otherwise; production runs unchanged when traces
+    # aren't configured. Per [[09-operations/observability]] § Tracing.
+    init_tracing(
+        endpoint=settings.otel_exporter_otlp_endpoint or None,
+        service_name=settings.otel_service_name,
+        service_namespace=settings.otel_service_namespace,
+        host_name=settings.otel_host_name or None,
+        service_version=settings.musubi_service_version or None,
+        deployment_environment=settings.otel_deployment_environment,
+    )
+
     app = FastAPI(
         title="Musubi Core API",
         version="0.1.0",
@@ -156,6 +181,10 @@ def create_app(*, settings: Settings | None = None) -> FastAPI:
         docs_url="/v1/docs",
         redoc_url=None,
     )
+
+    # FastAPI auto-instrumentation: root span per HTTP request. Safe
+    # no-op when tracing isn't initialized.
+    instrument_fastapi(app)
 
     install_metrics_middleware(app)
 

--- a/src/musubi/observability/__init__.py
+++ b/src/musubi/observability/__init__.py
@@ -1,6 +1,6 @@
-"""Observability — metrics, structured logs, and component health probes.
+"""Observability — metrics, structured logs, tracing, and component health probes.
 
-Per [[09-operations/observability]]. Three independent surfaces share
+Per [[09-operations/observability]]. Four independent surfaces share
 one module so the API + workers can pull `from musubi.observability
 import …` without a longer dotted path:
 
@@ -13,19 +13,32 @@ import …` without a longer dotted path:
 - **Logs:** :class:`StructuredJsonFormatter` produces the spec's
   JSON-per-line shape; :data:`request_id_var` is a contextvar each
   log record reads to populate ``request_id``;
-  :func:`redact_token_filter` scrubs JWT-shaped strings before emit.
+  :func:`redact_token_filter` scrubs JWT-shaped strings before emit;
+  :func:`configure_logging` re-routes uvicorn through the JSON
+  formatter at app startup.
+- **Tracing:** :func:`init_tracing` builds an OTel ``TracerProvider``
+  exporting OTLP/gRPC to the endpoint named by
+  ``OTEL_EXPORTER_OTLP_ENDPOINT`` (e.g. ``http://shiori.mey.house:4317``);
+  :func:`instrument_fastapi` installs FastAPI auto-instrumentation;
+  :func:`get_tracer` returns a tracer for hand-instrumented named spans.
+  All three are no-ops when ``OTEL_EXPORTER_OTLP_ENDPOINT`` is unset.
 - **Health:** :func:`check_component_health` probes a downstream
   service's ``/health`` endpoint and returns a typed
   :class:`musubi.api.responses.ComponentStatus`.
 
-OpenTelemetry tracing is intentionally OUT OF SCOPE per
-``slice-sdk-py-otel-spans.md`` — the SDK spec scopes OTel as
-opt-in; same constraint applies here.
+Tracing was scoped under ``slice-ops-observability`` per
+[[09-operations/observability]] § Tracing but not shipped with the
+original slice. It is being completed here (see issue #302 and the
+2026-05-13 work-log entry on that slice). The earlier statement in this
+docstring that OTel tracing was "OUT OF SCOPE" reflected the unshipped
+state, not a design decision — it is now removed because it is no
+longer accurate.
 """
 
 from musubi.observability.health import check_component_health
 from musubi.observability.logging_setup import (
     StructuredJsonFormatter,
+    configure_logging,
     redact_token_filter,
     request_id_var,
 )
@@ -38,6 +51,14 @@ from musubi.observability.registry import (
     default_registry,
     render_text_format,
 )
+from musubi.observability.tracing import (
+    get_tracer,
+    init_tracing,
+    instrument_fastapi,
+)
+from musubi.observability.tracing import (
+    is_enabled as tracing_is_enabled,
+)
 
 __all__ = [
     "Counter",
@@ -46,9 +67,14 @@ __all__ = [
     "Registry",
     "StructuredJsonFormatter",
     "check_component_health",
+    "configure_logging",
     "default_registry",
+    "get_tracer",
+    "init_tracing",
     "install_metrics_middleware",
+    "instrument_fastapi",
     "redact_token_filter",
     "render_text_format",
     "request_id_var",
+    "tracing_is_enabled",
 ]

--- a/src/musubi/observability/logging_setup.py
+++ b/src/musubi/observability/logging_setup.py
@@ -14,6 +14,7 @@ import logging
 import re
 import time
 from contextvars import ContextVar
+from typing import Any
 
 request_id_var: ContextVar[str | None] = ContextVar("request_id", default=None)
 """Per-request correlation id. The API's correlation-id middleware
@@ -134,11 +135,21 @@ def redact_token_filter(record: logging.LogRecord) -> bool:
     return True
 
 
+# Module-level handler reused across `configure_logging()` calls so
+# repeat invocations don't churn StreamHandler / Formatter instances.
+# Lazily constructed on first call. The TextIO type parameter is left
+# at its default (sys.stderr) — narrowing it here would constrain
+# future test fixtures that want a different stream.
+_handler: logging.StreamHandler[Any] | None = None
+
+
 def configure_logging(*, level: int = logging.INFO) -> None:
     """Install :class:`StructuredJsonFormatter` on the root + uvicorn loggers.
 
     Called once at app startup. Idempotent — multiple calls reuse the
-    same handler.
+    same module-level handler instance (constructed lazily on first
+    call) so callers that invoke this repeatedly (e.g., test suites)
+    don't churn handler/formatter objects on each call.
 
     Why: uvicorn ships with its own log config that bypasses any
     formatter installed via ``logging.basicConfig``. Without this
@@ -153,11 +164,12 @@ def configure_logging(*, level: int = logging.INFO) -> None:
     The redact filter is attached too so JWT-shaped substrings are
     scrubbed before emit.
     """
-    formatter = StructuredJsonFormatter()
-
-    handler = logging.StreamHandler()
-    handler.setFormatter(formatter)
-    handler.addFilter(redact_token_filter)
+    global _handler
+    if _handler is None:
+        _handler = logging.StreamHandler()
+        _handler.setFormatter(StructuredJsonFormatter())
+        _handler.addFilter(redact_token_filter)
+    handler = _handler
 
     # Root logger: replace whatever's there with our single JSON handler.
     root = logging.getLogger()

--- a/src/musubi/observability/logging_setup.py
+++ b/src/musubi/observability/logging_setup.py
@@ -67,6 +67,18 @@ class StructuredJsonFormatter(logging.Formatter):
         rid = request_id_var.get()
         if rid is not None:
             payload["request_id"] = rid
+        # OTel correlation: LoggingInstrumentor (when installed by
+        # `musubi.observability.tracing.init_tracing`) sets
+        # ``otelTraceID``/``otelSpanID`` on every record from the current
+        # span context. Promote them to top-level ``trace_id``/``span_id``
+        # so the JSON log shape matches the spec language and lines up
+        # with Grafana's logs-to-traces correlation defaults.
+        otel_trace_id = getattr(record, "otelTraceID", None)
+        if otel_trace_id and otel_trace_id != "0" * 32:
+            payload["trace_id"] = otel_trace_id
+        otel_span_id = getattr(record, "otelSpanID", None)
+        if otel_span_id and otel_span_id != "0" * 16:
+            payload["span_id"] = otel_span_id
         # Pull any extra fields the caller attached (record.namespace,
         # record.object_id, etc.) into the top-level payload.
         for k, v in record.__dict__.items():
@@ -74,8 +86,20 @@ class StructuredJsonFormatter(logging.Formatter):
                 continue
             if k == "message":
                 continue
+            # The OTel injected fields are already represented above as
+            # trace_id/span_id; don't duplicate them with their raw names.
+            if k in {"otelTraceID", "otelSpanID", "otelServiceName", "otelTraceSampled"}:
+                continue
             payload.setdefault(k, v)
-        if record.exc_info is not None:
+        # ``record.exc_info`` per stdlib conventions is either None or a
+        # 3-tuple ``(type, value, tb)``. The OTel LoggingInstrumentor's
+        # patched ``Logger.makeRecord`` can set it to ``True`` instead
+        # (an asymmetric stdlib quirk: ``Logger._log`` accepts ``True``
+        # and resolves it via ``sys.exc_info()`` BEFORE record creation,
+        # but third-party logger wrappers don't always normalize it).
+        # Only format when we actually have a tuple — silently skip
+        # ``True`` / other truthy non-tuples to avoid crashing emit.
+        if isinstance(record.exc_info, tuple) and len(record.exc_info) == 3:
             payload["exc_info"] = self.formatException(record.exc_info)
         return json.dumps(payload, default=str)
 
@@ -110,8 +134,56 @@ def redact_token_filter(record: logging.LogRecord) -> bool:
     return True
 
 
+def configure_logging(*, level: int = logging.INFO) -> None:
+    """Install :class:`StructuredJsonFormatter` on the root + uvicorn loggers.
+
+    Called once at app startup. Idempotent — multiple calls reuse the
+    same handler.
+
+    Why: uvicorn ships with its own log config that bypasses any
+    formatter installed via ``logging.basicConfig``. Without this
+    function, uvicorn's access log emits ``INFO: 1.2.3.4 - "GET /foo
+    HTTP/1.1" 200 OK`` plain-text lines to stdout regardless of what
+    we attached at the root. This function rebuilds uvicorn's
+    handlers so the JSON contract from
+    [[09-operations/observability]] § Logs is actually honoured in
+    container output (verified missing 2026-05-13 against the live
+    Loki datasource).
+
+    The redact filter is attached too so JWT-shaped substrings are
+    scrubbed before emit.
+    """
+    formatter = StructuredJsonFormatter()
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    handler.addFilter(redact_token_filter)
+
+    # Root logger: replace whatever's there with our single JSON handler.
+    root = logging.getLogger()
+    root.setLevel(level)
+    # Avoid duplicate handlers on repeat calls (idempotency).
+    for existing in list(root.handlers):
+        root.removeHandler(existing)
+    root.addHandler(handler)
+
+    # Uvicorn ships its own logger config that bypasses the root. Each
+    # of these loggers has `propagate=False` by default in uvicorn's
+    # logging dictConfig, so we must explicitly point them at handlers
+    # OR enable propagation. Enabling propagation is simpler and means
+    # one handler does all the work.
+    for name in ("uvicorn", "uvicorn.access", "uvicorn.error"):
+        lg = logging.getLogger(name)
+        # Drop uvicorn's own handlers; let records propagate to root.
+        for existing in list(lg.handlers):
+            lg.removeHandler(existing)
+        lg.propagate = True
+        lg.setLevel(level)
+
+
 __all__ = [
     "StructuredJsonFormatter",
+    "configure_logging",
     "redact_token_filter",
     "request_id_var",
 ]

--- a/src/musubi/observability/tracing.py
+++ b/src/musubi/observability/tracing.py
@@ -1,0 +1,190 @@
+"""OpenTelemetry tracing setup for Musubi Core.
+
+Per [[09-operations/observability]] § Tracing — completes the Tracing
+portion of `slice-ops-observability` that was scoped but never shipped
+(see issue #302 and the 2026-05-13 work-log entry on that slice).
+
+Behaviour:
+
+- Endpoint-gated. If ``endpoint`` is empty / ``None``, every helper here
+  is a no-op (returns ``None`` / does nothing). The server runs
+  unchanged when traces are not wanted.
+- When ``endpoint`` is provided, :func:`init_tracing` builds a
+  :class:`TracerProvider` with a :class:`Resource` carrying the
+  ``service.name``, ``service.namespace``, ``host.name``,
+  ``service.version``, and ``deployment.environment`` attributes that
+  the rest of the fleet emits (so musubi-core lines up with openclaw,
+  livekit, etc. on Tempo + Mimir labels).
+- Span export goes over OTLP/gRPC to the supplied endpoint
+  (e.g. ``http://shiori.mey.house:4317``).
+- 100% sampling per the spec ("100% in v1 (low traffic; dedicated host
+  has spare headroom)"). No sampler argument is passed; OTel's default
+  is ``ParentBased(AlwaysOn)`` which is exactly 100% root-sampling.
+- :class:`LoggingInstrumentor` is installed alongside the tracer so that
+  ``trace_id`` / ``span_id`` are exposed on log records, picked up by
+  :class:`musubi.observability.logging_setup.StructuredJsonFormatter`.
+
+This module does not read environment variables directly. Per the
+codebase rule enforced by
+``tests/test_config.py::test_no_module_imports_os_environ_for_config``,
+environment access lives in :mod:`musubi.config` /
+:mod:`musubi.settings` only. Callers — typically
+:func:`musubi.api.app.create_app` — pass values pulled from
+:class:`Settings`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.trace import Tracer
+
+log = logging.getLogger(__name__)
+
+# Module-level singleton so init_tracing() is idempotent. Tests can reset
+# this via _reset_for_tests().
+_provider: TracerProvider | None = None
+_provider_initialized: bool = False
+
+
+def is_enabled(endpoint: str | None) -> bool:
+    """Return True when an OTLP endpoint is configured.
+
+    Callers should pass ``settings.otel_exporter_otlp_endpoint``. An
+    empty string or ``None`` disables tracing.
+    """
+    return bool(endpoint and endpoint.strip())
+
+
+def init_tracing(
+    *,
+    endpoint: str | None,
+    service_name: str = "musubi-core",
+    service_namespace: str = "musubi",
+    host_name: str | None = None,
+    service_version: str | None = None,
+    deployment_environment: str = "harem-world",
+) -> TracerProvider | None:
+    """Build and install the global TracerProvider.
+
+    Returns the provider on success, ``None`` when tracing is disabled
+    (no endpoint supplied) or when called more than once.
+
+    Idempotent: a second call returns ``None`` and does not reinstall.
+
+    All values are passed by the caller — typically pulled from
+    :class:`musubi.settings.Settings`. Defaults match what the rest of
+    the fleet emits so musubi-core's spans align on the same labels as
+    openclaw/livekit in Tempo + Mimir.
+    """
+    global _provider, _provider_initialized
+
+    if _provider_initialized:
+        return None
+    _provider_initialized = True
+
+    if not is_enabled(endpoint):
+        log.debug("tracing.init: no endpoint provided; tracing disabled")
+        return None
+
+    # Defer all OTel SDK imports until we know we need them. Keeps the
+    # module importable even when the [otel] extra is not installed.
+    try:
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+            OTLPSpanExporter,
+        )
+        from opentelemetry.instrumentation.logging import LoggingInstrumentor
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    except ImportError as exc:
+        log.warning(
+            "tracing.init: OTel SDK not installed; tracing disabled "
+            "(install with `pip install musubi[otel]`). Detail: %s",
+            exc,
+        )
+        return None
+
+    resource_attrs: dict[str, str] = {
+        "service.name": service_name,
+        "service.namespace": service_namespace,
+        "deployment.environment": deployment_environment,
+    }
+    if host_name is None:
+        host_name = _read_hostname()
+    if host_name:
+        resource_attrs["host.name"] = host_name
+    if service_version:
+        resource_attrs["service.version"] = service_version
+
+    resource = Resource.create(resource_attrs)
+    provider = TracerProvider(resource=resource)
+    # The supplied endpoint is the OTLP/gRPC target; the exporter does
+    # not also need to read OTEL_EXPORTER_OTLP_ENDPOINT.
+    assert endpoint is not None  # narrowed by is_enabled() above
+    exporter = OTLPSpanExporter(endpoint=endpoint)
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+
+    # Inject trace_id / span_id into log records so the formatter can
+    # serialize them. This is what gives us logs ↔ traces correlation.
+    LoggingInstrumentor().instrument(set_logging_format=False)
+
+    _provider = provider
+    log.info(
+        "tracing.init: ok (service=%s namespace=%s endpoint=%s)",
+        service_name,
+        service_namespace,
+        endpoint,
+    )
+    return provider
+
+
+def instrument_fastapi(app: FastAPI) -> None:
+    """Install FastAPI auto-instrumentation if tracing is enabled.
+
+    Safe to call when tracing is disabled — no-op then.
+    """
+    if _provider is None:
+        return
+    try:
+        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+    except ImportError:
+        log.warning("tracing.instrument_fastapi: OTel FastAPI instrumentation not installed")
+        return
+    FastAPIInstrumentor.instrument_app(app)
+    log.debug("tracing.instrument_fastapi: instrumented FastAPI app")
+
+
+def get_tracer(name: str = "musubi") -> Tracer:
+    """Return an OTel tracer for hand-instrumented spans.
+
+    When tracing is disabled, returns OTel's default no-op tracer; callers
+    can use ``tracer.start_as_current_span(...)`` unconditionally without
+    runtime guards.
+    """
+    from opentelemetry import trace as _trace  # local import to keep cold start cheap
+
+    return _trace.get_tracer(name)
+
+
+def _read_hostname() -> str | None:
+    """Read the host's name from socket.gethostname()."""
+    try:
+        import socket
+
+        return socket.gethostname() or None
+    except OSError:
+        return None
+
+
+def _reset_for_tests() -> None:
+    """Reset module state. Test-only — production code never calls this."""
+    global _provider, _provider_initialized
+    _provider = None
+    _provider_initialized = False

--- a/src/musubi/observability/tracing.py
+++ b/src/musubi/observability/tracing.py
@@ -83,9 +83,13 @@ def init_tracing(
     """
     global _provider, _provider_initialized
 
+    # Idempotency: only short-circuit when a provider was actually
+    # installed previously. No-op paths (endpoint unset, ImportError)
+    # leave the flag unset so a later call with a real endpoint /
+    # available OTel install can still initialize. Copilot review on
+    # PR #303 flagged the original eager-flag-set as a real bug.
     if _provider_initialized:
         return None
-    _provider_initialized = True
 
     if not is_enabled(endpoint):
         log.debug("tracing.init: no endpoint provided; tracing disabled")
@@ -136,6 +140,7 @@ def init_tracing(
     LoggingInstrumentor().instrument(set_logging_format=False)
 
     _provider = provider
+    _provider_initialized = True  # only after the install actually succeeded
     log.info(
         "tracing.init: ok (service=%s namespace=%s endpoint=%s)",
         service_name,
@@ -161,14 +166,60 @@ def instrument_fastapi(app: FastAPI) -> None:
     log.debug("tracing.instrument_fastapi: instrumented FastAPI app")
 
 
+class _NoOpSpan:
+    """Local no-op span used when ``opentelemetry-api`` is not installed.
+
+    Implements just the subset of the Span API hand-instrumented spans
+    in this codebase actually call:
+
+    - context-manager (``__enter__``/``__exit__``) so
+      ``with tracer.start_as_current_span(...) as span:`` works.
+    - ``set_attribute`` so attribute-tagging calls are silently dropped.
+    - ``is_recording`` returns ``False`` for tests that want to check
+      whether the span is real.
+    """
+
+    def __enter__(self) -> _NoOpSpan:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def set_attribute(self, key: str, value: object) -> None:
+        return None
+
+    def is_recording(self) -> bool:
+        return False
+
+
+class _NoOpTracer:
+    """Local no-op tracer for the ``opentelemetry-api``-not-installed path.
+
+    Only ``start_as_current_span`` is exposed because that's the surface
+    every caller in this codebase uses. If more API is needed later,
+    extend here — we'd rather extend a small local class than make
+    ``opentelemetry-api`` a hard dependency.
+    """
+
+    def start_as_current_span(self, _name: str, **_kwargs: object) -> _NoOpSpan:
+        return _NoOpSpan()
+
+
 def get_tracer(name: str = "musubi") -> Tracer:
     """Return an OTel tracer for hand-instrumented spans.
 
-    When tracing is disabled, returns OTel's default no-op tracer; callers
-    can use ``tracer.start_as_current_span(...)`` unconditionally without
-    runtime guards.
+    When tracing is disabled or ``opentelemetry-api`` is not installed,
+    returns a local no-op tracer; callers can use
+    ``tracer.start_as_current_span(...)`` unconditionally without
+    runtime guards. The local fallback matters because callers like
+    :mod:`musubi.retrieve.orchestration` invoke ``get_tracer()`` at
+    module-import time — a hard ``ImportError`` here would crash the
+    process on a default ``pip install musubi`` (no ``[otel]`` extra).
     """
-    from opentelemetry import trace as _trace  # local import to keep cold start cheap
+    try:
+        from opentelemetry import trace as _trace  # local import keeps cold start cheap
+    except ImportError:
+        return _NoOpTracer()  # type: ignore[return-value]
 
     return _trace.get_tracer(name)
 

--- a/src/musubi/retrieve/orchestration.py
+++ b/src/musubi/retrieve/orchestration.py
@@ -12,6 +12,7 @@ from qdrant_client import QdrantClient
 
 from musubi.embedding.base import Embedder
 from musubi.embedding.tei import TEIRerankerClient
+from musubi.observability import get_tracer
 from musubi.retrieve.blended import (
     BlendedRetrievalQuery,
     run_blended_retrieve,
@@ -27,6 +28,11 @@ from musubi.retrieve.fast import run_fast_retrieve
 from musubi.types.common import Err, LifecycleState, Ok, Result
 
 logger = logging.getLogger(__name__)
+# Tracer for hand-instrumented spans matching the named hierarchy in
+# [[09-operations/observability]] § Tracing. When tracing is disabled
+# this is a no-op tracer; ``start_as_current_span`` is safe to call
+# unconditionally.
+_tracer = get_tracer("musubi.retrieve")
 
 
 class NamespaceTarget(BaseModel):
@@ -86,116 +92,133 @@ async def retrieve(
 ) -> Result[list[RetrievalResult], RetrievalError]:
     """Execute the configured retrieval pipeline based on the query."""
 
-    # 1. validate query
-    if isinstance(query, dict):
-        try:
-            parsed_query = RetrievalQuery.model_validate(query)
-        except ValidationError as e:
-            return Err(error=RetrievalError(kind="bad_query", detail=str(e)))
-    else:
-        try:
-            parsed_query = RetrievalQuery.model_validate(query.model_dump())
-        except ValidationError as e:
-            return Err(error=RetrievalError(kind="bad_query", detail=str(e)))
+    # Hand-instrumented span per [[09-operations/observability]] §
+    # Tracing. The span is a no-op when tracing is disabled (env var
+    # OTEL_EXPORTER_OTLP_ENDPOINT unset). Attributes are set as soon as
+    # the query is validated so a trace failing on bad_query still
+    # carries enough context to debug.
+    with _tracer.start_as_current_span("retrieve.orchestration") as _span:
+        # 1. validate query
+        if isinstance(query, dict):
+            try:
+                parsed_query = RetrievalQuery.model_validate(query)
+            except ValidationError as e:
+                _span.set_attribute("musubi.query.invalid", True)
+                return Err(error=RetrievalError(kind="bad_query", detail=str(e)))
+        else:
+            try:
+                parsed_query = RetrievalQuery.model_validate(query.model_dump())
+            except ValidationError as e:
+                _span.set_attribute("musubi.query.invalid", True)
+                return Err(error=RetrievalError(kind="bad_query", detail=str(e)))
 
-    # Basic auth check handled upstream, here we just dispatch.
-    # Expand the query into per-plane pipeline runs when the router
-    # supplied explicit `namespace_targets`; otherwise derive a single
-    # target from the top-level namespace (legacy path — orchestrator
-    # callers that don't go through the HTTP router).
-    if parsed_query.namespace_targets:
-        targets = [(t.namespace, t.plane) for t in parsed_query.namespace_targets]
-    else:
-        derived_plane = (
-            parsed_query.namespace.rsplit("/", 1)[-1]
-            if parsed_query.namespace.count("/") == 2
-            else (parsed_query.planes[0] if parsed_query.planes else "episodic")
-        )
-        targets = [(parsed_query.namespace, derived_plane)]
+        _span.set_attribute("musubi.namespace", parsed_query.namespace)
+        _span.set_attribute("musubi.mode", parsed_query.mode)
+        _span.set_attribute("musubi.limit", parsed_query.limit)
 
-    # Single-target fast path preserves the current behaviour bit-for-
-    # bit (one pipeline run, one Qdrant query per collection, no merge).
-    # Multi-target path runs the same pipeline per target concurrently
-    # and merges ranked results by score at the end.
-    if len(targets) == 1:
-        return await _run_single(
-            client=client,
-            embedder=embedder,
-            reranker=reranker,
-            llm=llm,
-            parsed_query=parsed_query,
-            namespace=targets[0][0],
-            plane=targets[0][1],
-            now=now,
-        )
+        # Basic auth check handled upstream, here we just dispatch.
+        # Expand the query into per-plane pipeline runs when the router
+        # supplied explicit `namespace_targets`; otherwise derive a
+        # single target from the top-level namespace (legacy path —
+        # orchestrator callers that don't go through the HTTP router).
+        if parsed_query.namespace_targets:
+            targets = [(t.namespace, t.plane) for t in parsed_query.namespace_targets]
+        else:
+            derived_plane = (
+                parsed_query.namespace.rsplit("/", 1)[-1]
+                if parsed_query.namespace.count("/") == 2
+                else (parsed_query.planes[0] if parsed_query.planes else "episodic")
+            )
+            targets = [(parsed_query.namespace, derived_plane)]
+        _span.set_attribute("musubi.target_count", len(targets))
 
-    # Fan out — one pipeline run per (namespace, plane) target. Call
-    # `_run_single` directly rather than recursing through `retrieve()`:
-    # the query is already parsed + validated, and re-entering the
-    # top-level would redo target expansion, pydantic validation, and
-    # the single-vs-multi branch logic for each leg. `gather(return_
-    # exceptions=True)` so a single plane failing doesn't blank the
-    # whole cross-plane response (ADR 0028).
-    results_per_target = await asyncio.gather(
-        *(
-            _run_single(
+        # Single-target fast path preserves the current behaviour bit-
+        # for-bit (one pipeline run, one Qdrant query per collection,
+        # no merge). Multi-target path runs the same pipeline per
+        # target concurrently and merges ranked results by score at
+        # the end.
+        if len(targets) == 1:
+            return await _run_single(
                 client=client,
                 embedder=embedder,
                 reranker=reranker,
                 llm=llm,
                 parsed_query=parsed_query,
-                namespace=ns,
-                plane=plane,
+                namespace=targets[0][0],
+                plane=targets[0][1],
                 now=now,
             )
-            for ns, plane in targets
-        ),
-        return_exceptions=True,
-    )
 
-    # Merge dedup keeps the **highest-scoring** hit per object_id.
-    # First-seen dedup would drop a stronger match purely because it
-    # arrived from a later target in the gather order. Build a
-    # {object_id → best hit} map, then materialise once at the end.
-    best_by_id: dict[str, RetrievalResult] = {}
-    transient_any = False
-    internal_err: RetrievalError | None = None
-    for outcome in results_per_target:
-        # Client disconnect / server shutdown produces CancelledError.
-        # Re-raise so the cancellation propagates up through the
-        # request lifecycle — swallowing it to return a partial
-        # response would be worse than surfacing the abort cleanly.
-        if isinstance(outcome, asyncio.CancelledError):
-            raise outcome
-        if isinstance(outcome, Err):
-            # Per-plane failures: transient/timeout degrades per-plane;
-            # an internal error from *any* plane surfaces as a 5xx
-            # because the merged response would silently under-report.
-            if outcome.error.kind == "timeout":
-                transient_any = True
+        # Fan out — one pipeline run per (namespace, plane) target.
+        # Call `_run_single` directly rather than recursing through
+        # `retrieve()`: the query is already parsed + validated, and
+        # re-entering the top-level would redo target expansion,
+        # pydantic validation, and the single-vs-multi branch logic
+        # for each leg. `gather(return_exceptions=True)` so a single
+        # plane failing doesn't blank the whole cross-plane response
+        # (ADR 0028).
+        results_per_target = await asyncio.gather(
+            *(
+                _run_single(
+                    client=client,
+                    embedder=embedder,
+                    reranker=reranker,
+                    llm=llm,
+                    parsed_query=parsed_query,
+                    namespace=ns,
+                    plane=plane,
+                    now=now,
+                )
+                for ns, plane in targets
+            ),
+            return_exceptions=True,
+        )
+
+        # Merge dedup keeps the **highest-scoring** hit per object_id.
+        # First-seen dedup would drop a stronger match purely because
+        # it arrived from a later target in the gather order. Build a
+        # {object_id → best hit} map, then materialise once at the end.
+        best_by_id: dict[str, RetrievalResult] = {}
+        transient_any = False
+        internal_err: RetrievalError | None = None
+        for outcome in results_per_target:
+            # Client disconnect / server shutdown produces
+            # CancelledError. Re-raise so the cancellation propagates
+            # up through the request lifecycle — swallowing it to
+            # return a partial response would be worse than surfacing
+            # the abort cleanly.
+            if isinstance(outcome, asyncio.CancelledError):
+                raise outcome
+            if isinstance(outcome, Err):
+                # Per-plane failures: transient/timeout degrades per-
+                # plane; an internal error from *any* plane surfaces
+                # as a 5xx because the merged response would silently
+                # under-report.
+                if outcome.error.kind == "timeout":
+                    transient_any = True
+                    continue
+                if outcome.error.kind in ("internal", "bad_query"):
+                    internal_err = outcome.error
+                    break
                 continue
-            if outcome.error.kind in ("internal", "bad_query"):
-                internal_err = outcome.error
+            if isinstance(outcome, Ok):
+                for hit in outcome.value:
+                    current = best_by_id.get(hit.object_id)
+                    if current is None or hit.score > current.score:
+                        best_by_id[hit.object_id] = hit
+                continue
+            if isinstance(outcome, Exception):
+                logger.warning("cross-plane retrieve per-plane exception: %r", outcome)
+                internal_err = RetrievalError(kind="internal", detail=str(outcome))
                 break
-            continue
-        if isinstance(outcome, Ok):
-            for hit in outcome.value:
-                current = best_by_id.get(hit.object_id)
-                if current is None or hit.score > current.score:
-                    best_by_id[hit.object_id] = hit
-            continue
-        if isinstance(outcome, Exception):
-            logger.warning("cross-plane retrieve per-plane exception: %r", outcome)
-            internal_err = RetrievalError(kind="internal", detail=str(outcome))
-            break
 
-    if internal_err is not None:
-        return Err(error=internal_err)
-    if not best_by_id and transient_any:
-        return Err(error=RetrievalError(kind="timeout", detail="all planes timed out"))
+        if internal_err is not None:
+            return Err(error=internal_err)
+        if not best_by_id and transient_any:
+            return Err(error=RetrievalError(kind="timeout", detail="all planes timed out"))
 
-    merged = sorted(best_by_id.values(), key=lambda r: r.score, reverse=True)
-    return Ok(value=merged[: parsed_query.limit])
+        merged = sorted(best_by_id.values(), key=lambda r: r.score, reverse=True)
+        return Ok(value=merged[: parsed_query.limit])
 
 
 async def _run_single(

--- a/src/musubi/settings.py
+++ b/src/musubi/settings.py
@@ -141,6 +141,43 @@ class Settings(BaseSettings):
     )
 
     # ------------------------------------------------------------------
+    # OpenTelemetry tracing (server-side). Per
+    # [[09-operations/observability]] § Tracing. All fields are optional
+    # and default to "off" / unset — the server runs unchanged when
+    # traces aren't wanted. Field names match the canonical OTel env
+    # vars so existing OTel docs/tools apply directly.
+    # ------------------------------------------------------------------
+    otel_exporter_otlp_endpoint: str = Field(
+        default="",
+        description="OTLP/gRPC endpoint for span export "
+        "(e.g. `http://shiori.mey.house:4317`). Empty disables tracing.",
+    )
+    otel_service_name: str = Field(
+        default="musubi-core",
+        description="Resource `service.name` attribute on emitted spans. "
+        "Aligned with the rest of the fleet so Tempo + Mimir labels match.",
+    )
+    otel_service_namespace: str = Field(
+        default="musubi",
+        description="Resource `service.namespace` attribute on emitted spans.",
+    )
+    otel_deployment_environment: str = Field(
+        default="harem-world",
+        description="Resource `deployment.environment` attribute.",
+    )
+    otel_host_name: str = Field(
+        default="",
+        description="Override the host.name resource attribute. "
+        "Empty (default) means `init_tracing` derives it from the "
+        "container/host hostname.",
+    )
+    musubi_service_version: str = Field(
+        default="",
+        description="Resource `service.version` attribute. Typically set "
+        "by the deploy pipeline to the git sha or tag of the running image.",
+    )
+
+    # ------------------------------------------------------------------
     # repr: pydantic-settings already masks SecretStr as ``**********``;
     # override to prune internal pydantic noise for a cleaner log line.
     # ------------------------------------------------------------------

--- a/tests/observability/test_observability.py
+++ b/tests/observability/test_observability.py
@@ -20,11 +20,12 @@ Closure plan:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from importlib import import_module
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import pytest
@@ -40,6 +41,7 @@ from musubi.observability import (
     render_text_format,
     request_id_var,
 )
+from musubi.types.common import Err
 
 # ---------------------------------------------------------------------------
 # Registry primitives — unit tests for the in-process metrics layer
@@ -208,11 +210,62 @@ def test_log_line_never_contains_raw_token() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skip(
-    reason="deferred to slice-sdk-py-otel-spans: opentelemetry-api opt-in per spec; cross-slice ticket _inbox/cross-slice/slice-sdk-py-otel-spans.md"
-)
-def test_otel_span_covers_retrieve_orchestration() -> None:
-    """Bullet 6 — placeholder."""
+def test_otel_span_covers_retrieve_orchestration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bullet 6 — verify the `retrieve.orchestration` named span fires.
+
+    Previously skipped while OTel was deferred. Now exercised by
+    initializing the tracer with an in-memory span exporter, invoking
+    the orchestrator with a bad query (so it returns early without
+    needing Qdrant), and asserting that a span with the spec's name
+    was captured.
+    """
+    from opentelemetry import trace as _trace
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    from musubi.observability import tracing as _tracing_mod
+    from musubi.retrieve import orchestration as _orch
+
+    # Stand up a real TracerProvider with an in-memory exporter, then
+    # re-bind the orchestration module's tracer to it so spans we open
+    # actually land in the exporter.
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider(resource=Resource.create({"service.name": "test"}))
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(_trace, "_TRACER_PROVIDER", provider, raising=False)
+    monkeypatch.setattr(_orch, "_tracer", provider.get_tracer("musubi.retrieve"))
+
+    # Bad-query path returns early — doesn't need Qdrant / embedder /
+    # any real backend — but still passes through the orchestration
+    # span. That's enough to prove the span fires.
+    result = asyncio.run(
+        _orch.retrieve(
+            client=cast(Any, None),
+            embedder=cast(Any, None),
+            query={"namespace": "", "query_text": ""},  # invalid: namespace min_length=1
+        )
+    )
+    # Expect a bad_query Err (not a span assertion — establishing the
+    # path exercised the orchestration span).
+    assert isinstance(result, Err)
+    assert result.error.kind == "bad_query"
+
+    spans = exporter.get_finished_spans()
+    span_names = [s.name for s in spans]
+    assert "retrieve.orchestration" in span_names
+    # The invalid-query span should carry the marker attribute.
+    orch_span = next(s for s in spans if s.name == "retrieve.orchestration")
+    assert orch_span.attributes is not None
+    assert orch_span.attributes.get("musubi.query.invalid") is True
+
+    # Reset the global tracing state so subsequent tests aren't affected.
+    _tracing_mod._reset_for_tests()
 
 
 def test_lifecycle_job_start_end_emitted_to_events_table() -> None:
@@ -350,6 +403,92 @@ def test_structured_json_formatter_includes_logger_name() -> None:
     payload = json.loads(formatter.format(record))
     assert payload["service"] == "musubi.api.routers.episodic"
     assert payload["level"] == "warning"
+
+
+def test_structured_json_formatter_promotes_otel_ids_to_trace_span() -> None:
+    """When LoggingInstrumentor has set otelTraceID/otelSpanID on the
+    record, the formatter exposes them as ``trace_id``/``span_id`` and
+    suppresses the raw OTel-prefixed keys."""
+    formatter = StructuredJsonFormatter()
+    record = logging.LogRecord(
+        name="musubi.test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=0,
+        msg="inside span",
+        args=(),
+        exc_info=None,
+    )
+    record.otelTraceID = "deadbeefcafef00dbaadf00ddecafbad"  # 32 hex
+    record.otelSpanID = "f00dbabe5f1c5b1e"  # 16 hex
+    record.otelTraceSampled = True
+    record.otelServiceName = "musubi-core"
+
+    payload = json.loads(formatter.format(record))
+    assert payload["trace_id"] == "deadbeefcafef00dbaadf00ddecafbad"
+    assert payload["span_id"] == "f00dbabe5f1c5b1e"
+    # Raw OTel-prefixed keys must not leak into the JSON.
+    assert "otelTraceID" not in payload
+    assert "otelSpanID" not in payload
+    assert "otelServiceName" not in payload
+    assert "otelTraceSampled" not in payload
+
+
+def test_structured_json_formatter_skips_zero_trace_ids() -> None:
+    """All-zero trace/span IDs (record had no active span at emit) are
+    not surfaced — they're noise."""
+    formatter = StructuredJsonFormatter()
+    record = logging.LogRecord(
+        name="musubi.test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=0,
+        msg="no span active",
+        args=(),
+        exc_info=None,
+    )
+    record.otelTraceID = "0" * 32
+    record.otelSpanID = "0" * 16
+
+    payload = json.loads(formatter.format(record))
+    assert "trace_id" not in payload
+    assert "span_id" not in payload
+
+
+def test_configure_logging_routes_uvicorn_through_json_formatter() -> None:
+    """configure_logging must rewire uvicorn loggers so their records
+    propagate to a single root handler using StructuredJsonFormatter.
+
+    Otherwise uvicorn emits plain `INFO: 1.2.3.4 - "GET /foo HTTP/1.1"`
+    lines that bypass the spec's JSON contract — confirmed missing
+    against the live Loki datasource 2026-05-13.
+    """
+    from musubi.observability import configure_logging
+
+    configure_logging()
+
+    root = logging.getLogger()
+    assert len(root.handlers) == 1
+    handler = root.handlers[0]
+    assert isinstance(handler.formatter, StructuredJsonFormatter)
+
+    # Uvicorn loggers must propagate to root (so the JSON handler fires).
+    for name in ("uvicorn", "uvicorn.access", "uvicorn.error"):
+        lg = logging.getLogger(name)
+        assert lg.propagate is True, f"{name} should propagate to root"
+        assert lg.handlers == [], f"{name} should not carry its own handlers"
+
+
+def test_configure_logging_is_idempotent() -> None:
+    """Repeated calls don't stack duplicate handlers on the root."""
+    from musubi.observability import configure_logging
+
+    configure_logging()
+    first_count = len(logging.getLogger().handlers)
+    configure_logging()
+    configure_logging()
+    final_count = len(logging.getLogger().handlers)
+    assert first_count == final_count == 1
 
 
 def test_redact_token_filter_idempotent() -> None:

--- a/tests/observability/test_tracing.py
+++ b/tests/observability/test_tracing.py
@@ -1,0 +1,209 @@
+"""Tests for :mod:`musubi.observability.tracing`.
+
+Covers:
+
+- Endpoint-gating: when ``endpoint`` is empty/None, every helper is a
+  no-op.
+- :func:`init_tracing` returning a :class:`TracerProvider` with the
+  expected resource attributes when an endpoint is supplied.
+- Idempotency — a second :func:`init_tracing` call does nothing.
+- :func:`instrument_fastapi` no-op when tracing is disabled, instruments
+  when enabled.
+- :func:`get_tracer` always returns a tracer — production code can use
+  ``tracer.start_as_current_span(...)`` unconditionally.
+
+The OTLP exporter never actually talks to a network endpoint in these
+tests: we stub it with an in-memory equivalent. End-to-end exporter
+behaviour is covered by the OTel SDK's own test suite.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from musubi.observability import tracing
+
+
+def _reset_otel_globals() -> None:
+    """Reset OTel's process-wide TracerProvider + LoggingInstrumentor.
+
+    OTel refuses to override its global TracerProvider once set; tests
+    need a clean slate per case, so we reach into ``_TRACER_PROVIDER``
+    and ``_TRACER_PROVIDER_SET_ONCE`` directly. These attributes are
+    internal to OTel and not in its public type stubs; we use
+    ``getattr``/``setattr`` to avoid mypy errors on the access.
+    """
+    import opentelemetry.trace as _otel_trace
+    from opentelemetry.instrumentation.logging import LoggingInstrumentor
+
+    tracing._reset_for_tests()
+    setattr(_otel_trace, "_TRACER_PROVIDER", None)
+    once_cls: Any = getattr(_otel_trace, "Once")
+    setattr(_otel_trace, "_TRACER_PROVIDER_SET_ONCE", once_cls())
+    if LoggingInstrumentor().is_instrumented_by_opentelemetry:
+        LoggingInstrumentor().uninstrument()
+
+
+@pytest.fixture(autouse=True)
+def _reset_tracing_state() -> Iterator[None]:
+    """Reset both Musubi's module-level singleton AND OTel's global
+    TracerProvider between tests."""
+    _reset_otel_globals()
+    yield
+    _reset_otel_globals()
+
+
+@pytest.fixture(autouse=True)
+def _stub_otlp_exporter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace the OTLP gRPC exporter with an in-memory one for tests.
+
+    The real :class:`OTLPSpanExporter` spawns a background worker thread
+    that tries to connect to the configured endpoint on first export.
+    Tests don't need a live collector and the failed-connect retry
+    noise floods test output. We wrap :class:`InMemorySpanExporter` so
+    it accepts (and ignores) the ``endpoint=`` kwarg the real exporter
+    requires.
+    """
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    class _StubOTLPExporter(InMemorySpanExporter):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__()
+
+    # The real import happens lazily inside init_tracing, so we have to
+    # patch where the function reads it from.
+    import opentelemetry.exporter.otlp.proto.grpc.trace_exporter as _otlp_mod
+
+    monkeypatch.setattr(_otlp_mod, "OTLPSpanExporter", _StubOTLPExporter)
+
+
+_ENDPOINT = "http://localhost:4317"
+
+
+class TestIsEnabled:
+    def test_disabled_when_endpoint_none(self) -> None:
+        assert tracing.is_enabled(None) is False
+
+    def test_disabled_when_endpoint_empty(self) -> None:
+        assert tracing.is_enabled("") is False
+
+    def test_disabled_when_endpoint_whitespace(self) -> None:
+        assert tracing.is_enabled("   ") is False
+
+    def test_enabled_when_endpoint_set(self) -> None:
+        assert tracing.is_enabled("http://shiori.mey.house:4317") is True
+
+
+class TestInitTracing:
+    def test_returns_none_when_endpoint_unset(self) -> None:
+        assert tracing.init_tracing(endpoint=None) is None
+
+    def test_returns_provider_when_enabled(self) -> None:
+        from opentelemetry.sdk.trace import TracerProvider
+
+        provider = tracing.init_tracing(
+            endpoint=_ENDPOINT,
+            host_name="testhost",
+            service_version="0.0.0-test",
+        )
+        assert provider is not None
+        assert isinstance(provider, TracerProvider)
+
+    def test_resource_attributes_set_correctly(self) -> None:
+        provider = tracing.init_tracing(
+            endpoint=_ENDPOINT,
+            service_name="musubi-core-test",
+            service_namespace="musubi",
+            host_name="testhost",
+            service_version="v1.2.3",
+            deployment_environment="test-env",
+        )
+        assert provider is not None
+        attrs = provider.resource.attributes
+        assert attrs["service.name"] == "musubi-core-test"
+        assert attrs["service.namespace"] == "musubi"
+        assert attrs["host.name"] == "testhost"
+        assert attrs["service.version"] == "v1.2.3"
+        assert attrs["deployment.environment"] == "test-env"
+
+    def test_idempotent_second_call_returns_none(self) -> None:
+        first = tracing.init_tracing(endpoint=_ENDPOINT, host_name="t")
+        second = tracing.init_tracing(endpoint=_ENDPOINT, host_name="t")
+        assert first is not None
+        assert second is None
+
+    def test_host_name_defaults_from_socket_when_unset(self) -> None:
+        provider = tracing.init_tracing(endpoint=_ENDPOINT)
+        assert provider is not None
+        # Some hostname should be discovered — value depends on the
+        # test host but should not be empty/None.
+        assert provider.resource.attributes.get("host.name", "") != ""
+
+    def test_service_version_omitted_when_blank(self) -> None:
+        provider = tracing.init_tracing(endpoint=_ENDPOINT, host_name="t", service_version="")
+        assert provider is not None
+        # Empty string for version is treated as "not set" — the
+        # resource attribute should be absent.
+        assert "service.version" not in provider.resource.attributes
+
+
+class TestInstrumentFastapi:
+    def test_noop_when_tracing_disabled(self) -> None:
+        from fastapi import FastAPI
+
+        app = FastAPI()
+        # Should not raise even though no provider is configured.
+        tracing.instrument_fastapi(app)
+
+    def test_instruments_app_when_enabled(self) -> None:
+        from fastapi import FastAPI
+
+        tracing.init_tracing(endpoint=_ENDPOINT, host_name="t")
+        app = FastAPI()
+        tracing.instrument_fastapi(app)
+        # The FastAPIInstrumentor adds middleware as a side effect; no
+        # public API to introspect that, but the call should be silent.
+        # Confirming "no exception raised" is the contract here.
+
+
+class TestGetTracer:
+    def test_returns_tracer_when_disabled(self) -> None:
+        t = tracing.get_tracer()
+        # Even in no-op mode, start_as_current_span must work.
+        with t.start_as_current_span("test.span"):
+            pass
+
+    def test_returns_tracer_when_enabled(self) -> None:
+        tracing.init_tracing(endpoint=_ENDPOINT, host_name="t")
+        t = tracing.get_tracer("musubi.test")
+        with t.start_as_current_span("retrieve.dense_encode") as span:
+            assert span.is_recording()
+
+
+class TestLoggingInstrumentor:
+    def test_init_tracing_installs_logging_instrumentor(self) -> None:
+        """``init_tracing`` must install :class:`LoggingInstrumentor` so
+        log records pick up the active span's ids.
+
+        We assert the instrumentor was activated (the contract we own)
+        rather than the trace-id payload on records (which is OTel's
+        internal behaviour and fragile across test isolation).
+        """
+        from opentelemetry.instrumentation.logging import LoggingInstrumentor
+
+        assert LoggingInstrumentor().is_instrumented_by_opentelemetry is False
+        tracing.init_tracing(endpoint=_ENDPOINT, host_name="t")
+        assert LoggingInstrumentor().is_instrumented_by_opentelemetry is True
+
+    def test_disabled_does_not_install_logging_instrumentor(self) -> None:
+        """When endpoint unset, LoggingInstrumentor stays uninstalled —
+        no side effects on log records when tracing is off."""
+        from opentelemetry.instrumentation.logging import LoggingInstrumentor
+
+        tracing.init_tracing(endpoint=None)
+        assert LoggingInstrumentor().is_instrumented_by_opentelemetry is False

--- a/tests/observability/test_tracing.py
+++ b/tests/observability/test_tracing.py
@@ -137,6 +137,19 @@ class TestInitTracing:
         assert first is not None
         assert second is None
 
+    def test_noop_first_call_does_not_block_later_real_init(self) -> None:
+        """First call with no endpoint must NOT consume the idempotency
+        slot. Caller may legitimately pass ``None`` first (e.g., env
+        unset at startup, later turned on) and try again with a real
+        endpoint — the second call should still build the provider.
+
+        Regression guard for Copilot review feedback on PR #303.
+        """
+        first = tracing.init_tracing(endpoint=None)
+        assert first is None
+        second = tracing.init_tracing(endpoint=_ENDPOINT, host_name="t")
+        assert second is not None
+
     def test_host_name_defaults_from_socket_when_unset(self) -> None:
         provider = tracing.init_tracing(endpoint=_ENDPOINT)
         assert provider is not None
@@ -183,6 +196,39 @@ class TestGetTracer:
         t = tracing.get_tracer("musubi.test")
         with t.start_as_current_span("retrieve.dense_encode") as span:
             assert span.is_recording()
+
+    def test_returns_noop_when_opentelemetry_api_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``get_tracer()`` must NOT raise when ``opentelemetry-api`` is
+        not installed — the default ``pip install musubi`` doesn't pull
+        the ``[otel]`` extra, and modules like
+        :mod:`musubi.retrieve.orchestration` call ``get_tracer()`` at
+        module-import time. A hard ImportError there would crash any
+        consumer of musubi without OTel installed.
+
+        Simulate the missing dep by making ``opentelemetry`` import-error
+        at the path ``get_tracer`` reads from, then verify the returned
+        tracer still supports the span context-manager surface this
+        codebase uses.
+        """
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "opentelemetry" or name.startswith("opentelemetry."):
+                raise ImportError(f"simulated: {name} not installed")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        t = tracing.get_tracer("musubi.test")
+        # Surface contract: start_as_current_span returns a context
+        # manager yielding something with set_attribute + is_recording.
+        with t.start_as_current_span("retrieve.orchestration") as span:
+            span.set_attribute("musubi.namespace", "eric/x")  # must not raise
+            assert span.is_recording() is False
 
 
 class TestLoggingInstrumentor:

--- a/uv.lock
+++ b/uv.lock
@@ -39,6 +39,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asgiref"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -303,6 +312,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e1/cf/b50ddf667c15276a9ab15a70ef5f257564de271957933ffea49d2cdbcdfb/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41", size = 313547, upload-time = "2026-03-27T19:11:14.892Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4", size = 202595, upload-time = "2026-03-27T19:11:13.595Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
 ]
 
 [[package]]
@@ -732,7 +753,7 @@ wheels = [
 
 [[package]]
 name = "musubi"
-version = "1.3.0"
+version = "1.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
@@ -756,6 +777,9 @@ dev = [
     { name = "jinja2" },
     { name = "mypy" },
     { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-instrumentation-logging" },
     { name = "opentelemetry-sdk" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -767,6 +791,10 @@ dev = [
 ]
 otel = [
     { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-instrumentation-logging" },
+    { name = "opentelemetry-sdk" },
 ]
 
 [package.dev-dependencies]
@@ -784,7 +812,14 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
     { name = "opentelemetry-api", marker = "extra == 'dev'", specifier = ">=1.27" },
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.27" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'dev'", specifier = ">=1.27" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'otel'", specifier = ">=1.27" },
+    { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'dev'", specifier = ">=0.48b0" },
+    { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'otel'", specifier = ">=0.48b0" },
+    { name = "opentelemetry-instrumentation-logging", marker = "extra == 'dev'", specifier = ">=0.48b0" },
+    { name = "opentelemetry-instrumentation-logging", marker = "extra == 'otel'", specifier = ">=0.48b0" },
     { name = "opentelemetry-sdk", marker = "extra == 'dev'", specifier = ">=1.27" },
+    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.27" },
     { name = "pydantic", specifier = ">=2.9" },
     { name = "pydantic-settings", specifier = ">=2.4" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10" },
@@ -936,6 +971,108 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/28/e8eca94966fe9a1465f6094dc5ddc5398473682180279c94020bc23b4906/opentelemetry_exporter_otlp_proto_common-1.41.0.tar.gz", hash = "sha256:966bbce537e9edb166154779a7c4f8ab6b8654a03a28024aeaf1a3eacb07d6ee", size = 20411, upload-time = "2026-04-09T14:38:36.572Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/c4/78b9bf2d9c1d5e494f44932988d9d91c51a66b9a7b48adf99b62f7c65318/opentelemetry_exporter_otlp_proto_common-1.41.0-py3-none-any.whl", hash = "sha256:7a99177bf61f85f4f9ed2072f54d676364719c066f6d11f515acc6c745c7acf0", size = 18366, upload-time = "2026-04-09T14:38:15.135Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/46/d75a3f8c91915f2e58f61d0a2e4ada63891e7c7a37a20ff7949ba184a6b2/opentelemetry_exporter_otlp_proto_grpc-1.41.0.tar.gz", hash = "sha256:f704201251c6f65772b11bddea1c948000554459101bdbb0116e0a01b70592f6", size = 25754, upload-time = "2026-04-09T14:38:37.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/f6/b09e2e0c9f0b5750cebc6eaf31527b910821453cef40a5a0fe93550422b2/opentelemetry_exporter_otlp_proto_grpc-1.41.0-py3-none-any.whl", hash = "sha256:3a1a86bd24806ccf136ec9737dbfa4c09b069f9130ff66b0acb014f9c5255fd1", size = 20299, upload-time = "2026-04-09T14:38:17.01Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/fd/b8e90bb340957f059084376f94cff336b0e871a42feba7d3f7342365e987/opentelemetry_instrumentation-0.62b0.tar.gz", hash = "sha256:aa1b0b9ab2e1722c2a8a5384fb016fc28d30bba51826676c8036074790d2861e", size = 34042, upload-time = "2026-04-09T14:40:22.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b6/3356d2e335e3c449c5183e9b023f30f04f1b7073a6583c68745ea2e704b1/opentelemetry_instrumentation-0.62b0-py3-none-any.whl", hash = "sha256:30d4e76486eae64fb095264a70c2c809c4bed17b73373e53091470661f7d477c", size = 34158, upload-time = "2026-04-09T14:39:21.428Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/38/999bf777774878971c2716de4b7a03cd57a7decb4af25090e703b79fa0e5/opentelemetry_instrumentation_asgi-0.62b0.tar.gz", hash = "sha256:93cde8c62e5918a3c1ff9ba020518127300e5e0816b7e8b14baf46a26ba619fc", size = 26779, upload-time = "2026-04-09T14:40:26.566Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/cf/29df82f5870178143bdb5c9a7be044b9f78c71e1c5dcf995242e86d80158/opentelemetry_instrumentation_asgi-0.62b0-py3-none-any.whl", hash = "sha256:89b62a6f996b260b162f515c25e6d78e39286e4cbe2f935899e51b32f31027e2", size = 17011, upload-time = "2026-04-09T14:39:27.305Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-fastapi"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/09/92740c6d114d1bef392557a03ae6de64065c83c1b331dae9b57fe718497c/opentelemetry_instrumentation_fastapi-0.62b0.tar.gz", hash = "sha256:e4748e4e575077e08beaf2c5d2f369da63dd90882d89d73c4192a97356637dec", size = 25056, upload-time = "2026-04-09T14:40:36.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/bb/186ffe0fde0ad33ceb50e1d3596cc849b732d3b825592a6a507a40c8c49b/opentelemetry_instrumentation_fastapi-0.62b0-py3-none-any.whl", hash = "sha256:06d3272ad15f9daea5a0a27c32831aff376110a4b0394197120256ef6d610e6e", size = 13482, upload-time = "2026-04-09T14:39:43.446Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-logging"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/47/8b81b7f007addf4dfd2b2f0753326e62822e1fec674605d0ec7c39d479b0/opentelemetry_instrumentation_logging-0.62b0.tar.gz", hash = "sha256:61f23be960e047054b3aa38998e7d1eb1fd9bef6f52097e28bc113af8b6f3bd8", size = 18968, upload-time = "2026-04-09T14:40:40.733Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/36/135fd0f4a154ea225de0a418d36f8cf9cf273ad31d41a3a2aaa91862b817/opentelemetry_instrumentation_logging-0.62b0-py3-none-any.whl", hash = "sha256:9a27b6c3d419170d96dedcea7d38cc0418f0dd1054365f52499a0a1eb70b8faf", size = 17489, upload-time = "2026-04-09T14:39:49.384Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/d9/08e3dc6156878713e8c811682bc76151f5fe1a3cb7f3abda3966fd56e71e/opentelemetry_proto-1.41.0.tar.gz", hash = "sha256:95d2e576f9fb1800473a3e4cfcca054295d06bdb869fda4dc9f4f779dc68f7b6", size = 45669, upload-time = "2026-04-09T14:38:45.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/8c/65ef7a9383a363864772022e822b5d5c6988e6f9dabeebb9278f5b86ebc3/opentelemetry_proto-1.41.0-py3-none-any.whl", hash = "sha256:b970ab537309f9eed296be482c3e7cca05d8aca8165346e929f658dbe153b247", size = 72074, upload-time = "2026-04-09T14:38:29.38Z" },
+]
+
+[[package]]
 name = "opentelemetry-sdk"
 version = "1.41.0"
 source = { registry = "https://pypi.org/simple" }
@@ -960,6 +1097,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a3/b0/c14f723e86c049b7bf8ff431160d982519b97a7be2857ed2247377397a24/opentelemetry_semantic_conventions-0.62b0.tar.gz", hash = "sha256:cbfb3c8fc259575cf68a6e1b94083cc35adc4a6b06e8cf431efa0d62606c0097", size = 145753, upload-time = "2026-04-09T14:38:48.274Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/6c/5e86fa1759a525ef91c2d8b79d668574760ff3f900d114297765eb8786cb/opentelemetry_semantic_conventions-0.62b0-py3-none-any.whl", hash = "sha256:0ddac1ce59eaf1a827d9987ab60d9315fb27aea23304144242d1fcad9e16b489", size = 231619, upload-time = "2026-04-09T14:38:32.394Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/e7/830f7c57135158eb8a8efd3f94ab191a89e3b8a49bed314a35ee501da3f2/opentelemetry_util_http-0.62b0.tar.gz", hash = "sha256:a62e4b19b8a432c0de657f167dee3455516136bb9c6ed463ca8063019970d835", size = 11393, upload-time = "2026-04-09T14:40:59.442Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/7f/5c1b7d4385852b9e5eacd4e7f9d8b565d3d351d17463b24916ad098adf1a/opentelemetry_util_http-0.62b0-py3-none-any.whl", hash = "sha256:c20462808d8cc95b69b0dc4a3e02a9d36beb663347e96c931f51ffd78bd318ad", size = 9294, upload-time = "2026-04-09T14:40:19.014Z" },
 ]
 
 [[package]]
@@ -1003,17 +1149,17 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "7.34.1"
+version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
-    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
-    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
-    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
-    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]
@@ -1649,6 +1795,70 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255, upload-time = "2026-03-06T02:52:45.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848, upload-time = "2026-03-06T02:53:48.728Z" },
+    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433, upload-time = "2026-03-06T02:54:40.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013, upload-time = "2026-03-06T02:53:26.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326, upload-time = "2026-03-06T02:53:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444, upload-time = "2026-03-06T02:54:09.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237, upload-time = "2026-03-06T02:54:03.884Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563, upload-time = "2026-03-06T02:53:20.412Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198, upload-time = "2026-03-06T02:53:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441, upload-time = "2026-03-06T02:52:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836, upload-time = "2026-03-06T02:53:22.053Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259, upload-time = "2026-03-06T02:53:41.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851, upload-time = "2026-03-06T02:52:48.672Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446, upload-time = "2026-03-06T02:54:14.013Z" },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056, upload-time = "2026-03-06T02:54:10.829Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359, upload-time = "2026-03-06T02:53:03.623Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479, upload-time = "2026-03-06T02:53:45.844Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271, upload-time = "2026-03-06T02:54:46.356Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573, upload-time = "2026-03-06T02:52:50.163Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205, upload-time = "2026-03-06T02:53:47.494Z" },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452, upload-time = "2026-03-06T02:53:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842, upload-time = "2026-03-06T02:52:52.114Z" },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075, upload-time = "2026-03-06T02:53:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719, upload-time = "2026-03-06T02:54:33.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643, upload-time = "2026-03-06T02:52:42.721Z" },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805, upload-time = "2026-03-06T02:54:25.441Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990, upload-time = "2026-03-06T02:53:57.456Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670, upload-time = "2026-03-06T02:54:55.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357, upload-time = "2026-03-06T02:54:24.092Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269, upload-time = "2026-03-06T02:53:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894, upload-time = "2026-03-06T02:54:15.391Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #302.

## Why

`slice-ops-observability` (closed 2026-04-19, status `done`) scoped
server-side OTel tracing per `09-operations/observability.md` § Tracing
but never shipped it. Verified 2026-05-13 against the live Tempo
datasource: zero tags, zero `service.name` values, zero traces fleet-wide.

This PR closes the gap. **No scope expansion** beyond the original spec.
See issue #302 for the full background.

## Plan (commits land in order)

- [x] **Docs addenda** — `slice-ops-observability.md` work-log entry +
  `slice-sdk-py-otel-spans.md` follow-up note. Already on this branch
  (commit fd09bec). Per repo prime directive: no debt left in our wake.
- [ ] **`[otel]` extras update** — add `opentelemetry-sdk`,
  `opentelemetry-exporter-otlp-proto-grpc`,
  `opentelemetry-instrumentation-fastapi`,
  `opentelemetry-instrumentation-logging` to the existing extra.
- [ ] **OTel SDK init** — `src/musubi/observability/tracing.py` (new
  module). Env-gated by `OTEL_EXPORTER_OTLP_ENDPOINT`. Resource with
  `service.name=musubi-core`, `service.namespace=musubi`,
  `host.name=musubi`. 100% sampling per spec.
- [ ] **FastAPI auto-instrumentation** — `FastAPIInstrumentor.instrument_app(app)`
  in `create_app()` (gated by env var).
- [ ] **Logging wiring fix** — uvicorn access + error loggers routed
  through `StructuredJsonFormatter`. Currently bypassed; this is making
  the JSON-logs spec actually true.
- [ ] **`trace_id`/`span_id` injection** — extend `StructuredJsonFormatter`
  to read the active span context and add the IDs to the JSON payload
  when present. Connects logs ↔ traces.
- [ ] **Hand-instrumented spans** matching the spec's diagrammed
  hierarchy: `auth.validate`, `retrieve.orchestration`,
  `retrieve.dense_encode`, `retrieve.sparse_encode`,
  `retrieve.qdrant.query_points`, `retrieve.rerank`,
  `retrieve.score.blend`, `response.serialize`.
- [ ] **Tests** — `tests/observability/test_tracing.py` (new). Plus
  extending `test_observability.py` for the trace_id/span_id injection
  path and the uvicorn-logger-routing fix. Coverage gate is 85%.
- [ ] **Dockerfile** — install the `[otel]` extras into the production
  image so the SDK is available when `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
- [ ] `make check` + full pytest pass locally.

## Verification (manual, post-deploy)

1. Bring up musubi with `OTEL_EXPORTER_OTLP_ENDPOINT=http://shiori.mey.house:4317`.
2. Hit any endpoint.
3. Query Tempo via Grafana MCP: `service.name=musubi-core` shows the
   named-span hierarchy.
4. Query Loki: log lines for `service_name=core,service_namespace=musubi`
   are now JSON with `trace_id` and `span_id` fields.

## Discovery context

Found while building the harem-ops fleet telemetry coverage map
(harem-ops `wiki/services/observability/coverage-map.md` 2026-05-13).
The coverage audit revealed three signals across the fleet:
metrics ✅, logs ⚠ (musubi shipping via Alloy as of today),
traces ❌ (zero across the entire fleet). This PR is the first
service to close its trace gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)