### PR TITLE
chore(deploy): pin musubi-core to v1.3.2 signed digest

### DIFF
--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -38,7 +38,7 @@ musubi_core_port: 8100
 # For what's in a given version, see CHANGELOG.md (authoritative)
 # rather than a comment here — version-specific notes rot; the
 # changelog is the source of truth.
-musubi_core_image: "ghcr.io/ericmey/musubi-core@sha256:542021174ceac924aeae6fdc658fd0262e88261ada02767a2291256805b1a553"
+musubi_core_image: "ghcr.io/ericmey/musubi-core@sha256:cb86af8fa311bd61de2e1f5cf25c7ebdcf7417991e7bd8a7a724f760dfbbe744"
 musubi_qdrant_image: "qdrant/qdrant:v1.17.1"
 # TEI image tag = <compute-capability>-<version>. RTX 3080 is Ampere,
 # compute 8.6 → `86-*`. Other GPUs: `turing-*` (RTX 20xx), `89-*` (RTX 40xx),


### PR DESCRIPTION
chore(deploy): pin musubi-core to v1.3.2 signed digest

Automated by `.github/workflows/auto-digest-bump.yml` in response to the [v1.3.2](https://github.com/ericmey/musubi/releases/tag/v1.3.2) release.

## Supply-chain attestations
- cosign keyless signature via GitHub OIDC
- CycloneDX SBOM attached as a cosign attestation
- Trivy vulnerability scan — 0 CRITICAL (gate in `publish-core-image.yml`)

## Verify before deploy

```bash
cosign verify \
  --certificate-identity-regexp 'https://github.com/ericmey/musubi/.*' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  ghcr.io/ericmey/musubi-core@sha256:cb86af8fa311bd61de2e1f5cf25c7ebdcf7417991e7bd8a7a724f760dfbbe744
```

## After merge

```bash
# From the ansible control host:
cd ~/musubi
git pull origin main
ANSIBLE_VAULT_PASSWORD_FILE=~/ansible/.vault_pass \
  ansible-playbook \
    -i deploy/ansible/inventory.yml \
    -e @~/.musubi-secrets/inventory-vars.yml \
    -e @~/.musubi-secrets/vault.yml \
    -e 'changed_services=["core","lifecycle-worker"]' \
    deploy/ansible/update.yml
```

No tracking Issue: auto-generated release digest pin.