### PR TITLE
chore(deploy): wire OTEL endpoint + version-stamping generator

### DIFF
--- a/.github/workflows/auto-digest-bump.yml
+++ b/.github/workflows/auto-digest-bump.yml
@@ -133,35 +133,56 @@ jobs:
 
       - name: Patch group_vars
         id: patch
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
+          DIGEST: ${{ steps.resolve.outputs.digest }}
         run: |
           set -euo pipefail
           FILE="deploy/ansible/group_vars/all.yml"
-          NEW="ghcr.io/ericmey/musubi-core@${{ steps.resolve.outputs.digest }}"
+          NEW_IMAGE="ghcr.io/ericmey/musubi-core@${DIGEST}"
 
-          # Replace the line regardless of what was there before. The file
-          # uses double-quoted strings for this field.
-          python3 - <<PY
-          import re, pathlib
-          p = pathlib.Path("$FILE")
+          # Patch both `musubi_core_image:` (digest pin) and
+          # `musubi_core_version:` (human-readable tag) so spans + dashboards
+          # carry the release tag alongside the immutable digest. Both lines
+          # use double-quoted strings. Each substitution is required — a
+          # mismatch means the file shape drifted and the patch should fail
+          # loudly rather than silently no-op one of the two fields.
+          python3 - <<'PY'
+          import os, pathlib, re
+
+          p = pathlib.Path(os.environ["FILE"])
+          tag = os.environ["TAG"]
+          new_image = os.environ["NEW_IMAGE"]
           text = p.read_text()
-          new = '"${NEW}"'
-          updated = re.sub(
+
+          updated, n_image = re.subn(
               r'(musubi_core_image:\s*)(["\x27])[^"\x27]+\2',
-              rf'\g<1>{new}',
+              rf'\g<1>"{new_image}"',
               text,
               count=1,
           )
-          if updated == text:
+          if n_image == 0:
               raise SystemExit("musubi_core_image line not found in " + str(p))
+
+          updated, n_version = re.subn(
+              r'(musubi_core_version:\s*)(["\x27])[^"\x27]+\2',
+              rf'\g<1>"{tag}"',
+              updated,
+              count=1,
+          )
+          if n_version == 0:
+              raise SystemExit("musubi_core_version line not found in " + str(p))
+
           p.write_text(updated)
           PY
+          export FILE NEW_IMAGE
 
           if git diff --quiet "$FILE"; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "Already pinned to ${NEW}; nothing to do."
+            echo "Already pinned to ${NEW_IMAGE} @ ${TAG}; nothing to do."
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "Patched ${FILE}."
+            echo "Patched ${FILE} (image=${NEW_IMAGE}, version=${TAG})."
           fi
 
       - name: Open or update PR

--- a/.github/workflows/auto-digest-bump.yml
+++ b/.github/workflows/auto-digest-bump.yml
@@ -136,10 +136,10 @@ jobs:
         env:
           TAG: ${{ steps.resolve.outputs.tag }}
           DIGEST: ${{ steps.resolve.outputs.digest }}
+          FILE: deploy/ansible/group_vars/all.yml
+          NEW_IMAGE: ghcr.io/ericmey/musubi-core@${{ steps.resolve.outputs.digest }}
         run: |
           set -euo pipefail
-          FILE="deploy/ansible/group_vars/all.yml"
-          NEW_IMAGE="ghcr.io/ericmey/musubi-core@${DIGEST}"
 
           # Patch both `musubi_core_image:` (digest pin) and
           # `musubi_core_version:` (human-readable tag) so spans + dashboards
@@ -147,6 +147,10 @@ jobs:
           # use double-quoted strings. Each substitution is required — a
           # mismatch means the file shape drifted and the patch should fail
           # loudly rather than silently no-op one of the two fields.
+          #
+          # FILE/NEW_IMAGE/TAG arrive via the step-level `env:` block above so
+          # the Python subprocess sees them in `os.environ` (shell-only
+          # assignments would not be exported into the heredoc's process).
           python3 - <<'PY'
           import os, pathlib, re
 
@@ -175,7 +179,6 @@ jobs:
 
           p.write_text(updated)
           PY
-          export FILE NEW_IMAGE
 
           if git diff --quiet "$FILE"; then
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -39,6 +39,11 @@ musubi_core_port: 8100
 # rather than a comment here — version-specific notes rot; the
 # changelog is the source of truth.
 musubi_core_image: "ghcr.io/ericmey/musubi-core@sha256:cb86af8fa311bd61de2e1f5cf25c7ebdcf7417991e7bd8a7a724f760dfbbe744"
+# Human-readable version paired with `musubi_core_image`. Rendered into
+# `.env.production` as `MUSUBI_SERVICE_VERSION` so spans + dashboards carry
+# the tag, not just the digest. Bumped in lockstep with the image pin by
+# `.github/workflows/auto-digest-bump.yml`.
+musubi_core_version: "v1.3.2"
 musubi_qdrant_image: "qdrant/qdrant:v1.17.1"
 # TEI image tag = <compute-capability>-<version>. RTX 3080 is Ampere,
 # compute 8.6 → `86-*`. Other GPUs: `turing-*` (RTX 20xx), `89-*` (RTX 40xx),
@@ -55,6 +60,12 @@ musubi_prometheus_image: "prom/prometheus:v2.54.1"
 # deploy/ansible/templates/docker-compose.yml.j2 matches this version's
 # CLI surface; revisit on bump.
 musubi_node_exporter_image: "prom/node-exporter:v1.11.1"
+
+# OTel Collector endpoint for server-side span export. Empty disables tracing
+# (see src/musubi/observability/tracing.py + settings.py::otel_exporter_otlp_endpoint).
+# Defaults to the fleet's shared LGTM stack on shiori; override per-environment
+# via ~/.musubi-secrets/inventory-vars.yml when a host needs to diverge.
+musubi_otel_otlp_endpoint: "http://shiori.mey.house:4317"
 
 musubi_required_packages:
   - ca-certificates

--- a/deploy/ansible/templates/env.production.j2
+++ b/deploy/ansible/templates/env.production.j2
@@ -48,3 +48,12 @@ MUSUBI_ALLOW_PLAINTEXT=true
 # `.invalid` TLD (RFC 6761) keeps parsing happy while guaranteeing the URL
 # never resolves.
 OAUTH_AUTHORITY=https://oauth.deferred.invalid/
+
+# --- OpenTelemetry (server-side spans → shiori OTel Collector) ---------------
+# Endpoint empty ⇒ tracing is a no-op (per src/musubi/observability/tracing.py).
+# When set, init_tracing() installs the OTLP/gRPC exporter +
+# LoggingInstrumentor so log records pick up the active span's trace_id/span_id.
+# Other resource attributes (service.name, namespace, deployment.environment)
+# inherit settings.py defaults; override here only if a host needs to diverge.
+OTEL_EXPORTER_OTLP_ENDPOINT={{ musubi_otel_otlp_endpoint }}
+MUSUBI_SERVICE_VERSION={{ musubi_core_version }}


### PR DESCRIPTION
## Summary
- `deploy/ansible/templates/env.production.j2` now renders `OTEL_EXPORTER_OTLP_ENDPOINT` and `MUSUBI_SERVICE_VERSION` from two new group_vars defaults (`musubi_otel_otlp_endpoint`, `musubi_core_version`).
- `.github/workflows/auto-digest-bump.yml` extends its patch step so `musubi_core_version` is rewritten in lockstep with `musubi_core_image` on every release-please pin PR — no manual maintenance.

## Why now
v1.3.2 just rolled to musubi-workload (PR #303 → #305 → ansible `update.yml`). Code-side OTel ships; runtime confirms `OTEL_EXPORTER_OTLP_ENDPOINT` is unset on the running container, so `init_tracing()` is a no-op and no spans flow. This change closes that gap and parallel-fixes the "next time we bump, version drifts" foot-gun.

## After merge
On the ansible control host:
```bash
cd ~/musubi && git pull --ff-only
ANSIBLE_VAULT_PASSWORD_FILE=~/ansible/.vault_pass \
  ansible-playbook \
  -i deploy/ansible/inventory.yml \
  -e @~/.musubi-secrets/inventory-vars.yml \
  -e @~/.musubi-secrets/vault.yml \
  --check --diff \
  deploy/ansible/config.yml
```
Then drop `--check --diff` once the diff looks right. `config.yml` re-renders `.env.production` and restarts the stack — spans should appear in Tempo within a minute.

## Test plan
- [x] `make check` clean locally (1304 passed, no new Python code).
- [x] Generator's regex self-tested against the real `group_vars/all.yml` — both substitutions found and applied.
- [ ] Reviewer verifies the env-template + group_vars defaults match the canonical OTel env-var names (`OTEL_EXPORTER_OTLP_ENDPOINT`, `MUSUBI_SERVICE_VERSION`) in `settings.py`.
- [ ] Reviewer verifies the workflow Python heredoc handles missing keys correctly (the `raise SystemExit` on `n_version == 0` is the loud-failure path).
- [ ] Post-merge: `config.yml` dry-run on yua shows the expected `.env.production` diff; real run lands; Grafana → Tempo confirms spans tagged `service.name=musubi-core, service.version=v1.3.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)