### PR TITLE
fix(llm): constrain Ollama decoding with Pydantic JSON Schema

### DIFF
--- a/src/musubi/llm/ollama.py
+++ b/src/musubi/llm/ollama.py
@@ -9,8 +9,11 @@ real production implementation.
 
 Design contract:
 
-- Every call posts to ``{base_url}/api/chat`` with
-  ``format: "json"`` and ``temperature: 0`` for determinism.
+- Every call posts to ``{base_url}/api/chat`` with a Pydantic-derived
+  JSON Schema as ``format`` and ``temperature: 0`` for determinism.
+  Ollama's structured-output decoder (≥0.5.0) constrains generation to
+  the schema, preventing missing-field validation failures that
+  free-form ``format: "json"`` permits.
 - A fresh :class:`httpx.AsyncClient` per call — matches the rest of the
   codebase (see :mod:`musubi.embedding.tei`) and keeps the client
   loop-agnostic so the lifecycle worker can re-enter
@@ -90,6 +93,15 @@ class _ContradictionResponse(BaseModel):
     reason: str = ""
 
 
+# Cache JSON Schemas at import time — they're used on every Ollama call
+# as the ``format`` value, which switches Ollama into structured-output
+# mode and constrains decoding to required fields.
+_IMPORTANCE_SCHEMA: dict[str, Any] = _ImportanceResponse.model_json_schema()
+_TOPICS_SCHEMA: dict[str, Any] = _TopicResponse.model_json_schema()
+_SYNTHESIS_SCHEMA: dict[str, Any] = _SynthesisResponse.model_json_schema()
+_CONTRADICTION_SCHEMA: dict[str, Any] = _ContradictionResponse.model_json_schema()
+
+
 def _load_prompt(name: str, version: str) -> str:
     """Load a frozen prompt file from ``musubi.llm.prompts.<name>``."""
     resource = files("musubi.llm.prompts").joinpath(name).joinpath(f"{version}.txt")
@@ -151,7 +163,7 @@ class HttpxOllamaClient:
         )
         prompt = _load_prompt("importance", _IMPORTANCE_PROMPT_V).replace("{ITEMS}", rendered)
 
-        raw = await self._chat(prompt, kind="importance")
+        raw = await self._chat(prompt, kind="importance", schema=_IMPORTANCE_SCHEMA)
         if raw is None:
             return None
         try:
@@ -184,7 +196,7 @@ class HttpxOllamaClient:
         )
         prompt = _load_prompt("topics", _TOPICS_PROMPT_V).replace("{ITEMS}", rendered)
 
-        raw = await self._chat(prompt, kind="topics")
+        raw = await self._chat(prompt, kind="topics", schema=_TOPICS_SCHEMA)
         if raw is None:
             return None
         try:
@@ -224,7 +236,7 @@ class HttpxOllamaClient:
             for m in cluster.memories
         )
         prompt = _load_prompt("synthesis", _SYNTHESIS_PROMPT_V).replace("{ITEMS}", rendered)
-        raw = await self._chat(prompt, kind="synthesis")
+        raw = await self._chat(prompt, kind="synthesis", schema=_SYNTHESIS_SCHEMA)
         if raw is None:
             return None
         try:
@@ -251,7 +263,7 @@ class HttpxOllamaClient:
             .replace("{B_TITLE}", pair.concept_b.title)
             .replace("{B_CONTENT}", _one_line(pair.concept_b.content))
         )
-        raw = await self._chat(prompt, kind="contradiction")
+        raw = await self._chat(prompt, kind="contradiction", schema=_CONTRADICTION_SCHEMA)
         if raw is None:
             return None
         try:
@@ -266,14 +278,26 @@ class HttpxOllamaClient:
     # Internals
     # ------------------------------------------------------------------
 
-    async def _chat(self, prompt: str, *, kind: str) -> str | None:
-        """POST to /api/chat; return the assistant message content or None."""
+    async def _chat(
+        self,
+        prompt: str,
+        *,
+        kind: str,
+        schema: dict[str, Any] | None = None,
+    ) -> str | None:
+        """POST to /api/chat; return the assistant message content or None.
+
+        When ``schema`` is provided, it is passed as the ``format`` value
+        to engage Ollama's structured-output mode (≥0.5.0); the model
+        is then constrained to emit JSON conforming to the schema. When
+        ``schema`` is ``None``, falls back to free-form JSON mode.
+        """
         url = f"{self._base_url}/api/chat"
         payload: dict[str, Any] = {
             "model": self._model,
             "messages": [{"role": "user", "content": prompt}],
             "stream": False,
-            "format": "json",
+            "format": schema if schema is not None else "json",
             "options": {"temperature": 0},
         }
         try:

--- a/tests/llm/test_ollama.py
+++ b/tests/llm/test_ollama.py
@@ -103,7 +103,10 @@ async def test_score_importance_posts_chat_payload(httpx_mock: HTTPXMock) -> Non
     body = json.loads(req.content)
     assert body["model"] == _MODEL
     assert body["stream"] is False
-    assert body["format"] == "json"
+    assert isinstance(body["format"], dict)
+    assert body["format"].get("type") == "object"
+    assert "items" in body["format"].get("properties", {})
+    assert "items" in body["format"].get("required", [])
     assert body["options"]["temperature"] == 0
     assert body["messages"][0]["role"] == "user"
     assert items[0].object_id in body["messages"][0]["content"]


### PR DESCRIPTION
## Summary
- Switch `_chat()` from `format: "json"` to a Pydantic-derived JSON Schema per call kind. Ollama's structured-output decoder (≥0.5.0) then refuses to emit responses missing required fields.
- Closes the class of soft failures where qwen3:4b occasionally omits `importance` from synthesis responses and the lifecycle worker skips the cluster (observed 2026-05-14 03:01 UTC in Loki — `ollama-synthesis-validate-failed err=1 validation error for _SynthesisResponse importance Field required`).
- Cache the four schemas (`_ImportanceResponse`, `_TopicResponse`, `_SynthesisResponse`, `_ContradictionResponse`) at import time; all four call sites pass their corresponding schema.

## Why now
Memory consolidation is the core of Musubi's value. Soft skips compound — a cluster that fails on a missing field today is one that doesn't become a concept, and the same cluster can fail again next sweep. Closing the root cause (free-form JSON) is cheaper than retry-tolerance forever.

## Compatibility
- Live cluster runs Ollama **0.23.4** — well past the **0.5.0** cutoff where schema-format landed.
- Behavior unchanged on the success path: same Pydantic models still validate the response.
- `_chat()` accepts an optional `schema` arg with `None` fallback to `"json"`, so future callers without a schema still work.
- `promotion_client.py:134` uses `format: "json"` on a different code path (concept promotion). Out of scope here — tracked as follow-up.

## Test plan
- [x] `pytest tests/llm/test_ollama.py tests/lifecycle/test_synthesis.py` — 49 passed, 6 pre-existing skips
- [x] Full suite: 1304 passed, 195 skipped, 17 deselected
- [x] `ruff check` clean on changed files
- [x] `mypy src/musubi/llm/ollama.py` clean
- [ ] Post-deploy: watch Loki for `ollama-synthesis-validate-failed` over 24h — expect zero