### PR TITLE
feat(observability): scrape qdrant metrics via Bearer-authed Prometheus job

### DIFF
--- a/deploy/ansible/deploy.yml
+++ b/deploy/ansible/deploy.yml
@@ -13,9 +13,9 @@
 
     - name: Render Prometheus scrape config
       # Prometheus mounts this file read-only at
-      # /etc/prometheus/prometheus.yml. The container has
-      # `--web.enable-lifecycle`, so a POST to /-/reload is the
-      # zero-downtime reload path; handled by the notify handler below.
+      # /etc/prometheus/prometheus.yml. The reload-prometheus handler
+      # below sends SIGHUP to the running container on change so the
+      # new config is picked up without recreating it.
       ansible.builtin.template:
         src: templates/prometheus.yml.j2
         dest: "{{ musubi_config_dir }}/prometheus.yml"
@@ -25,16 +25,19 @@
       notify: reload prometheus
 
     - name: Render Qdrant bearer-token file for Prometheus
-      # Mounted into the prometheus container at
+      # Mounted read-only into the prometheus container at
       # /etc/prometheus/qdrant.token; referenced by the qdrant scrape
-      # job's `authorization.credentials_file`. Mode 0640 keeps it
-      # readable by the musubi service group only.
+      # job's `authorization.credentials_file`. Chown to UID 65534
+      # (`nobody`) because the official prom/prometheus image runs as
+      # that user — bind mounts preserve host UID/GID, so the file
+      # must be readable by 65534 specifically. Mode 0400 grants
+      # owner-only read.
       ansible.builtin.template:
         src: templates/qdrant.token.j2
         dest: "{{ musubi_config_dir }}/qdrant.token"
-        owner: root
-        group: "{{ musubi_service_group }}"
-        mode: "0640"
+        owner: "65534"
+        group: "65534"
+        mode: "0400"
       notify: reload prometheus
 
     - name: Pull missing pinned images

--- a/deploy/ansible/deploy.yml
+++ b/deploy/ansible/deploy.yml
@@ -11,16 +11,31 @@
         group: "{{ musubi_service_group }}"
         mode: "0640"
 
-    - name: Copy Prometheus scrape config
+    - name: Render Prometheus scrape config
       # Prometheus mounts this file read-only at
-      # /etc/prometheus/prometheus.yml. A `SIGHUP` to the container
-      # reloads it without downtime.
-      ansible.builtin.copy:
-        src: "{{ playbook_dir }}/../prometheus/prometheus.yml"
+      # /etc/prometheus/prometheus.yml. The container has
+      # `--web.enable-lifecycle`, so a POST to /-/reload is the
+      # zero-downtime reload path; handled by the notify handler below.
+      ansible.builtin.template:
+        src: templates/prometheus.yml.j2
         dest: "{{ musubi_config_dir }}/prometheus.yml"
         owner: root
         group: "{{ musubi_service_group }}"
         mode: "0644"
+      notify: reload prometheus
+
+    - name: Render Qdrant bearer-token file for Prometheus
+      # Mounted into the prometheus container at
+      # /etc/prometheus/qdrant.token; referenced by the qdrant scrape
+      # job's `authorization.credentials_file`. Mode 0640 keeps it
+      # readable by the musubi service group only.
+      ansible.builtin.template:
+        src: templates/qdrant.token.j2
+        dest: "{{ musubi_config_dir }}/qdrant.token"
+        owner: root
+        group: "{{ musubi_service_group }}"
+        mode: "0640"
+      notify: reload prometheus
 
     - name: Pull missing pinned images
       community.docker.docker_compose_v2_pull:
@@ -73,3 +88,20 @@
       register: core_health
       until: core_health.status == 200
       changed_when: false
+
+  handlers:
+    - name: reload prometheus
+      # `kill -s HUP` is the zero-downtime reload signal — the container
+      # stays up, Prometheus re-reads `prometheus.yml` in place. Cheaper
+      # than the HTTP `/-/reload` path because it has no in-container
+      # tooling dependency. The prometheus container may not be running
+      # yet on a first-deploy run (it starts after this handler is
+      # registered but before flush), so swallow a "not running" exit.
+      ansible.builtin.command:
+        cmd: docker compose -f {{ musubi_config_dir }}/docker-compose.yml kill -s HUP prometheus
+      register: prometheus_reload
+      failed_when:
+        - prometheus_reload.rc != 0
+        - "'no such service' not in (prometheus_reload.stderr | default(''))"
+        - "'not running' not in (prometheus_reload.stderr | default(''))"
+      changed_when: prometheus_reload.rc == 0

--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -53,7 +53,7 @@ musubi_tei_image: "ghcr.io/huggingface/text-embeddings-inference:86-1.2.0"
 musubi_ollama_image: "ollama/ollama:latest"
 musubi_ollama_model: "qwen3:4b"
 # Prometheus: pinned to an LTS-ish minor so the scrape-config syntax
-# (see deploy/prometheus/prometheus.yml) doesn't drift under us.
+# (see deploy/ansible/templates/prometheus.yml.j2) doesn't drift under us.
 musubi_prometheus_image: "prom/prometheus:v2.54.1"
 # node-exporter: host-level metrics. Pinned to the latest stable as of
 # 2026-04-07 (per ADR 0033). The collector flag set in

--- a/deploy/ansible/templates/docker-compose.yml.j2
+++ b/deploy/ansible/templates/docker-compose.yml.j2
@@ -154,6 +154,7 @@ services:
     image: {{ musubi_prometheus_image }}
     volumes:
       - /etc/musubi/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - /etc/musubi/qdrant.token:/etc/prometheus/qdrant.token:ro
       - /var/lib/musubi/prometheus-data:/prometheus
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"

--- a/deploy/ansible/templates/prometheus.yml.j2
+++ b/deploy/ansible/templates/prometheus.yml.j2
@@ -17,9 +17,13 @@
 # AND remote_write to shiori's Mimir for central aggregation, multi-host
 # correlation, and longer-horizon visualization.
 #
-# Not yet scraped (reason in parens):
-#   - qdrant (its /metrics requires the api-key header; secret-file wiring
-#     belongs to a follow-up slice).
+# Qdrant scrape uses `authorization.credentials_file` to send
+# `Authorization: Bearer <api-key>`. Qdrant 1.17 accepts either an
+# `api-key:` header or the Bearer form; Prometheus only natively
+# supports the Bearer form, so that's what we use. The token file is
+# rendered separately by `deploy/ansible/deploy.yml` from the
+# `vault_qdrant_api_key` variable and mounted into the container at
+# `/etc/prometheus/qdrant.token` (mode 0640, root:musubi).
 #
 # Visualization, alerting, and trace collection live on shiori per ADR 0033.
 # Local Grafana/Loki/Tempo/Alertmanager were planned by slice-ops-observability
@@ -89,6 +93,17 @@ scrape_configs:
   - job_name: prometheus
     static_configs:
       - targets: ["localhost:9090"]
+
+  # Qdrant — vector storage. Native Prometheus endpoint at /metrics; auth
+  # required. Bearer credentials come from a file rendered by ansible from
+  # `vault_qdrant_api_key`.
+  - job_name: qdrant
+    metrics_path: /metrics
+    authorization:
+      type: Bearer
+      credentials_file: /etc/prometheus/qdrant.token
+    static_configs:
+      - targets: ["qdrant:6333"]
 
   # node-exporter — host-level CPU / memory / disk / network / filesystem.
   # Runs as a sibling container on the musubi compose bridge, mounting

--- a/deploy/ansible/templates/qdrant.token.j2
+++ b/deploy/ansible/templates/qdrant.token.j2
@@ -1,0 +1,1 @@
+{{ vault_qdrant_api_key }}

--- a/deploy/ansible/update.yml
+++ b/deploy/ansible/update.yml
@@ -38,12 +38,20 @@
         mode: "0640"
 
     - name: Refresh Prometheus scrape config (may have new targets)
-      ansible.builtin.copy:
-        src: "{{ playbook_dir }}/../prometheus/prometheus.yml"
+      ansible.builtin.template:
+        src: templates/prometheus.yml.j2
         dest: "{{ musubi_config_dir }}/prometheus.yml"
         owner: root
         group: "{{ musubi_service_group }}"
         mode: "0644"
+
+    - name: Refresh Qdrant bearer-token file for Prometheus
+      ansible.builtin.template:
+        src: templates/qdrant.token.j2
+        dest: "{{ musubi_config_dir }}/qdrant.token"
+        owner: root
+        group: "{{ musubi_service_group }}"
+        mode: "0640"
 
     - name: Force-pull any image references (policy=always)
       # Distinct from deploy.yml, which uses policy=missing. Without

--- a/deploy/ansible/update.yml
+++ b/deploy/ansible/update.yml
@@ -44,14 +44,18 @@
         owner: root
         group: "{{ musubi_service_group }}"
         mode: "0644"
+      notify: reload prometheus
 
     - name: Refresh Qdrant bearer-token file for Prometheus
+      # See deploy.yml for the UID 65534 rationale (prometheus container
+      # runs as `nobody`; bind mounts preserve host ownership).
       ansible.builtin.template:
         src: templates/qdrant.token.j2
         dest: "{{ musubi_config_dir }}/qdrant.token"
-        owner: root
-        group: "{{ musubi_service_group }}"
-        mode: "0640"
+        owner: "65534"
+        group: "65534"
+        mode: "0400"
+      notify: reload prometheus
 
     - name: Force-pull any image references (policy=always)
       # Distinct from deploy.yml, which uses policy=missing. Without
@@ -85,6 +89,21 @@
       register: core_health
       until: core_health.status == 200
       changed_when: false
+
+  handlers:
+    - name: reload prometheus
+      # SIGHUP triggers an in-place reload of prometheus.yml. The
+      # prometheus service may not be in `changed_services` for this
+      # update run, so swallow "no such service" / "not running"
+      # without failing the play.
+      ansible.builtin.command:
+        cmd: docker compose -f {{ musubi_config_dir }}/docker-compose.yml kill -s HUP prometheus
+      register: prometheus_reload
+      failed_when:
+        - prometheus_reload.rc != 0
+        - "'no such service' not in (prometheus_reload.stderr | default(''))"
+        - "'not running' not in (prometheus_reload.stderr | default(''))"
+      changed_when: prometheus_reload.rc == 0
 
     - name: Ensure upgrade-history log directory exists
       ansible.builtin.file:

--- a/docs/Musubi/09-operations/CLAUDE.md
+++ b/docs/Musubi/09-operations/CLAUDE.md
@@ -33,7 +33,7 @@ Per [[13-decisions/0033-centralize-observability-on-shiori]], visualization /
 log aggregation / trace storage / alerting all live on a dedicated
 observability host (shiori) external to this repo. Local on the musubi host:
 
-- **Metrics (local scrape):** Prometheus on the musubi compose bridge — scrapes `core:8100/v1/ops/metrics`, the three TEI services, node-exporter, and itself. Config at `deploy/prometheus/prometheus.yml`. Local TSDB retains 30 days for direct PromQL access at `127.0.0.1:9090` if shiori is unreachable.
+- **Metrics (local scrape):** Prometheus on the musubi compose bridge — scrapes `core:8100/v1/ops/metrics`, qdrant (Bearer-authed `/metrics`), the three TEI services, node-exporter, and itself. Config rendered from `deploy/ansible/templates/prometheus.yml.j2`. Local TSDB retains 30 days for direct PromQL access at `127.0.0.1:9090` if shiori is unreachable.
 - **Metrics (central forward):** prometheus `remote_write` → `shiori.mey.house:9009/api/v1/push` (Mimir). Source of truth for visualization, alerting, and multi-host correlation.
 - **Host metrics:** node-exporter sidecar container; standard prom/node-exporter image, mounts /proc, /sys, / read-only.
 - **Logs:** structured JSON to stdout (still required) — central Loki ingest from musubi is a follow-up PR scoped to the shiori-side codebase.

--- a/tests/observability/test_observability.py
+++ b/tests/observability/test_observability.py
@@ -605,20 +605,22 @@ _DEPLOY = _REPO_ROOT / "deploy"
 
 
 def test_prometheus_config_loads() -> None:
-    """deploy/prometheus/prometheus.yml parses as YAML + has scrape_configs.
-
-    Qdrant is intentionally NOT scraped yet — its /metrics requires
-    the `api-key` header and the secret-file wiring is a follow-up
-    (see work-log 2026-04-21 entry). The active targets are
-    musubi-core + the three TEI services + prometheus self-scrape.
+    """deploy/ansible/templates/prometheus.yml.j2 parses as YAML (after Jinja
+    placeholder substitution) and has the expected scrape targets:
+    musubi-core, qdrant, the three TEI services, prometheus self,
+    and node-exporter.
     """
     import yaml
 
-    cfg = yaml.safe_load((_DEPLOY / "prometheus" / "prometheus.yml").read_text())
+    raw = (_DEPLOY / "ansible" / "templates" / "prometheus.yml.j2").read_text()
+    # Substitute the lone Jinja placeholder so yaml.safe_load can parse.
+    raw = raw.replace("{{ vault_qdrant_api_key }}", "x")
+    cfg = yaml.safe_load(raw)
     assert "scrape_configs" in cfg
     job_names = {j["job_name"] for j in cfg["scrape_configs"]}
     assert "musubi-core" in job_names
     assert "tei-dense" in job_names
+    assert "qdrant" in job_names, "qdrant scrape must be present (added 2026-05-14)"
 
 
 # Loki / Tempo / Grafana load-tests removed per

--- a/tests/ops/test_prometheus.py
+++ b/tests/ops/test_prometheus.py
@@ -16,7 +16,7 @@ Scope:
   scrape config read-only, persists TSDB under `/var/lib/musubi/prometheus-data`,
   binds host-local-only (no external exposure without Kong — see
   ADR 0024), and carries the retention flag.
-- `deploy.yml` copies the scrape config to the host alongside the
+- `deploy.yml` renders the scrape config to the host alongside the
   compose render step.
 """
 
@@ -28,10 +28,18 @@ from typing import Any
 import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
-PROM_CONFIG = ROOT / "deploy" / "prometheus" / "prometheus.yml"
+PROM_CONFIG = ROOT / "deploy" / "ansible" / "templates" / "prometheus.yml.j2"
 COMPOSE_TEMPLATE = ROOT / "deploy" / "ansible" / "templates" / "docker-compose.yml.j2"
 GROUP_VARS = ROOT / "deploy" / "ansible" / "group_vars" / "all.yml"
 DEPLOY_PLAYBOOK = ROOT / "deploy" / "ansible" / "deploy.yml"
+
+
+def _load_prom_config() -> Any:
+    # `prometheus.yml.j2` has no Jinja placeholders inside scrape blocks
+    # today, but tolerate them in case a future change adds one.
+    rendered = PROM_CONFIG.read_text()
+    rendered = rendered.replace("{{ vault_qdrant_api_key }}", "x")
+    return yaml.safe_load(rendered)
 
 
 def _load(path: Path) -> Any:
@@ -45,14 +53,14 @@ def _load(path: Path) -> Any:
 
 def test_prometheus_config_parses() -> None:
     assert PROM_CONFIG.exists(), f"missing {PROM_CONFIG}"
-    cfg = _load(PROM_CONFIG)
+    cfg = _load_prom_config()
     assert isinstance(cfg, dict)
     assert "global" in cfg
     assert "scrape_configs" in cfg
 
 
 def test_scrape_interval_is_fast_enough_for_p95_math() -> None:
-    cfg = _load(PROM_CONFIG)
+    cfg = _load_prom_config()
     interval = cfg["global"]["scrape_interval"]
     # Parse "15s" / "60s" / "1m"
     if interval.endswith("s"):
@@ -65,7 +73,7 @@ def test_scrape_interval_is_fast_enough_for_p95_math() -> None:
 
 
 def test_scrape_targets_musubi_core_metrics_endpoint() -> None:
-    cfg = _load(PROM_CONFIG)
+    cfg = _load_prom_config()
     jobs = {j["job_name"]: j for j in cfg["scrape_configs"]}
     assert "musubi-core" in jobs, "no scrape job for musubi-core"
     core = jobs["musubi-core"]
@@ -82,7 +90,7 @@ def test_external_labels_identify_host() -> None:
     rest of the fleet (openclaw, livekit, shiori) so cross-emitter queries
     work without a label-rename layer at query time. See
     wiki/services/observability/integration-baseline.md (F3.1)."""
-    cfg = _load(PROM_CONFIG)
+    cfg = _load_prom_config()
     labels = cfg["global"].get("external_labels") or {}
     assert "host_name" in labels, "external_labels.host_name missing (OTel convention)"
     assert "deployment_environment" in labels, "external_labels.deployment_environment missing"
@@ -94,7 +102,7 @@ def test_remote_write_to_shiori_central() -> None:
     Mimir instance on shiori. Without this block, musubi metrics never reach
     central observability — the centralization is a runtime no-op.
     """
-    cfg = _load(PROM_CONFIG)
+    cfg = _load_prom_config()
     rw = cfg.get("remote_write") or []
     assert rw, "remote_write block missing — central observability won't receive musubi metrics"
     urls = [entry.get("url", "") for entry in rw]
@@ -107,7 +115,7 @@ def test_scrape_targets_node_exporter() -> None:
     """Per ADR 0033, host-level metrics are collected by node-exporter
     sibling container, scraped on the compose bridge as `node-exporter:9100`.
     """
-    cfg = _load(PROM_CONFIG)
+    cfg = _load_prom_config()
     jobs = {j["job_name"]: j for j in cfg["scrape_configs"]}
     assert "node-exporter" in jobs, "no scrape job for node-exporter — host metrics gap"
     targets = [t for sc in jobs["node-exporter"]["static_configs"] for t in sc["targets"]]
@@ -220,7 +228,41 @@ def test_group_vars_declares_prometheus_data_dir() -> None:
     assert "/var/lib/musubi/prometheus-data" in gv["musubi_data_dirs"]
 
 
-def test_deploy_playbook_copies_scrape_config() -> None:
+def test_deploy_playbook_renders_scrape_config() -> None:
     text = DEPLOY_PLAYBOOK.read_text()
-    assert "prometheus.yml" in text
-    assert "/prometheus/prometheus.yml" in text or "prometheus/prometheus.yml" in text
+    assert "templates/prometheus.yml.j2" in text, (
+        "deploy.yml must render prometheus.yml.j2 (not copy a static file)"
+    )
+    assert "templates/qdrant.token.j2" in text, (
+        "deploy.yml must render qdrant.token.j2 so the prometheus container "
+        "can authenticate against qdrant /metrics"
+    )
+
+
+def test_scrape_targets_qdrant_with_bearer_auth() -> None:
+    """Qdrant 1.17 requires Authorization: Bearer <api-key> on /metrics.
+    Prometheus uses authorization.credentials_file pointing at a file
+    rendered from `vault_qdrant_api_key` so the scrape config itself
+    stays secret-free."""
+    cfg = _load_prom_config()
+    jobs = {j["job_name"]: j for j in cfg["scrape_configs"]}
+    assert "qdrant" in jobs, "no scrape job for qdrant"
+    qdrant = jobs["qdrant"]
+    assert qdrant["metrics_path"] == "/metrics"
+    auth = qdrant.get("authorization") or {}
+    assert auth.get("type") == "Bearer", "qdrant scrape must use Bearer auth"
+    assert auth.get("credentials_file") == "/etc/prometheus/qdrant.token", (
+        "qdrant scrape must read the api-key from the mounted token file"
+    )
+    targets = [t for sc in qdrant["static_configs"] for t in sc["targets"]]
+    assert "qdrant:6333" in targets, "qdrant target must be 'qdrant:6333'"
+
+
+def test_prometheus_mounts_qdrant_token_readonly() -> None:
+    svc = _render_compose()["services"]["prometheus"]
+    ro_mounts = [
+        v
+        for v in svc["volumes"]
+        if isinstance(v, str) and v.endswith(":ro") and "qdrant.token" in v
+    ]
+    assert ro_mounts, "qdrant.token must be mounted read-only into prometheus"

--- a/uv.lock
+++ b/uv.lock
@@ -753,7 +753,7 @@ wheels = [
 
 [[package]]
 name = "musubi"
-version = "1.3.3"
+version = "1.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- Closes the qdrant scrape gap. Qdrant 1.17 accepts `Authorization: Bearer <api-key>` on `/metrics`; Prometheus supports that via `authorization.credentials_file`. The token is rendered from `vault_qdrant_api_key` to `/etc/musubi/qdrant.token` (0640) and mounted into the prometheus container.
- Moves `deploy/prometheus/prometheus.yml` → `deploy/ansible/templates/prometheus.yml.j2`. The previous in-line `copy` is now a `template`; both `deploy.yml` and `update.yml` are updated.
- Adds a `reload prometheus` handler (`docker compose kill -s HUP prometheus`) wired to both `prometheus.yml` and `qdrant.token` template tasks. Zero-downtime, no in-container HTTP tool needed.
- Fixes stale path references in `group_vars/all.yml` and `docs/Musubi/09-operations/CLAUDE.md`.
- Bumps `uv.lock` to 1.3.4 (catching up the release-please sync that wasn't auto-run for this version yet).

## Why this approach
Two options for Bearer-style auth in Prometheus scrape configs:
- Inline `credentials:` — puts the api-key in `prometheus.yml`, which is mode 0644 (host-readable).
- `credentials_file:` (chosen) — token in a separate 0640 file, scrape config stays secret-free.

The query-param path (`?api-key=`) was tested and **rejected by qdrant 1.17.1** — it only accepts the header form.

## Test plan
- [x] `ansible-playbook --syntax-check deploy.yml update.yml` from the yua control host — clean.
- [ ] Post-merge deploy via `deploy.yml` — expect `up{job="qdrant"} == 1` in Mimir within one scrape interval.
- [ ] Verify the qdrant scrape lands `app_info{name="qdrant",version="1.17.1"}` in Mimir under `service_name="qdrant"`.