### PR TITLE
Batch A: three musubi small fixes (promotion schema, qdrant factory, node-exporter udev)

### DIFF
--- a/deploy/ansible/templates/docker-compose.yml.j2
+++ b/deploy/ansible/templates/docker-compose.yml.j2
@@ -195,11 +195,13 @@ services:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /:/host/rootfs:ro,rslave
-      # /run/udev so the diskstats collector can attach the human-
-      # readable device name + WWN to disk metrics (DEVNAME, ID_FS_UUID).
-      # Without this the collector logs `Failed to open directory,
-      # disabling udev device properties` on every restart and the
-      # node_disk_* series lack the udev-derived labels.
+      # /run/udev so the diskstats collector can attach udev-derived
+      # labels to node_disk_* series — DEVNAME, ID_WWN, ID_SERIAL,
+      # ID_MODEL and friends (not ID_FS_UUID, which is the filesystem
+      # UUID exposed via a different udev path). Without this the
+      # collector logs `Failed to open directory, disabling udev
+      # device properties` on every restart and node_disk_* loses
+      # those identifying labels.
       - /run/udev:/host/run/udev:ro
     restart: unless-stopped
 

--- a/deploy/ansible/templates/docker-compose.yml.j2
+++ b/deploy/ansible/templates/docker-compose.yml.j2
@@ -189,11 +189,18 @@ services:
       - "--path.procfs=/host/proc"
       - "--path.sysfs=/host/sys"
       - "--path.rootfs=/host/rootfs"
+      - "--path.udev.data=/host/run/udev/data"
       - "--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc|var/lib/docker)($|/)"
     volumes:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /:/host/rootfs:ro,rslave
+      # /run/udev so the diskstats collector can attach the human-
+      # readable device name + WWN to disk metrics (DEVNAME, ID_FS_UUID).
+      # Without this the collector logs `Failed to open directory,
+      # disabling udev device properties` on every restart and the
+      # node_disk_* series lack the udev-derived labels.
+      - /run/udev:/host/run/udev:ro
     restart: unless-stopped
 
   ollama:

--- a/src/musubi/api/bootstrap.py
+++ b/src/musubi/api/bootstrap.py
@@ -53,6 +53,7 @@ from musubi.planes.curated import CuratedPlane
 from musubi.planes.episodic import EpisodicPlane
 from musubi.planes.thoughts import ThoughtsPlane
 from musubi.settings import Settings
+from musubi.storage import build_qdrant_client
 
 _DEFAULT_RETRY_ATTEMPTS = 5
 _DEFAULT_RETRY_BACKOFF_S = 1.0
@@ -171,7 +172,7 @@ def bootstrap_production_app(
     # plaintext Qdrant doesn't ssl-handshake-fail against an HTTP
     # endpoint. Production deploys leave the flag at its default
     # (False) so https=True is the production default.
-    qdrant = QdrantClient(
+    qdrant = build_qdrant_client(
         host=settings.qdrant_host,
         port=settings.qdrant_port,
         api_key=settings.qdrant_api_key.get_secret_value(),

--- a/src/musubi/api/dependencies.py
+++ b/src/musubi/api/dependencies.py
@@ -28,6 +28,7 @@ from musubi.planes.curated import CuratedPlane
 from musubi.planes.episodic import EpisodicPlane
 from musubi.planes.thoughts import ThoughtsPlane
 from musubi.settings import Settings
+from musubi.storage import build_qdrant_client
 
 
 def get_settings_dep() -> Settings:
@@ -39,10 +40,15 @@ def get_settings_dep() -> Settings:
 def _build_qdrant_client_default() -> QdrantClient:
     """Lazy production-default Qdrant client; constructed on first use."""
     settings = get_settings()
-    return QdrantClient(
+    # Test/dev fallback only: production replaces this whole factory
+    # via `bootstrap_production_app`. Plain HTTP is the historical
+    # default here and matches the QdrantClient default that this path
+    # used pre-factory.
+    return build_qdrant_client(
         host=settings.qdrant_host,
         port=settings.qdrant_port,
         api_key=settings.qdrant_api_key.get_secret_value(),
+        https=False,
     )
 
 

--- a/src/musubi/api/dependencies.py
+++ b/src/musubi/api/dependencies.py
@@ -41,14 +41,15 @@ def _build_qdrant_client_default() -> QdrantClient:
     """Lazy production-default Qdrant client; constructed on first use."""
     settings = get_settings()
     # Test/dev fallback only: production replaces this whole factory
-    # via `bootstrap_production_app`. Plain HTTP is the historical
-    # default here and matches the QdrantClient default that this path
-    # used pre-factory.
+    # via `bootstrap_production_app`. Honour `musubi_allow_plaintext`
+    # the same way the production path does so route-level callers of
+    # `get_qdrant_client` get the configured TLS policy when they
+    # haven't gone through bootstrap.
     return build_qdrant_client(
         host=settings.qdrant_host,
         port=settings.qdrant_port,
         api_key=settings.qdrant_api_key.get_secret_value(),
-        https=False,
+        https=not settings.musubi_allow_plaintext,
     )
 
 

--- a/src/musubi/lifecycle/runner.py
+++ b/src/musubi/lifecycle/runner.py
@@ -287,8 +287,6 @@ async def _main_async() -> None:
     """Module entrypoint — compose real deps and run until signal."""
     from pathlib import Path
 
-    from qdrant_client import QdrantClient
-
     from musubi.config import get_settings
     from musubi.embedding.tei import TEIDenseClient, TEIRerankerClient, TEISparseClient
     from musubi.lifecycle.demotion import DemotionDeps, build_demotion_jobs
@@ -317,6 +315,7 @@ async def _main_async() -> None:
     from musubi.planes.curated.plane import CuratedPlane
     from musubi.planes.episodic.plane import EpisodicPlane
     from musubi.planes.thoughts.plane import ThoughtsPlane
+    from musubi.storage import build_qdrant_client
     from musubi.vault.writelog import WriteLog
     from musubi.vault.writer import VaultWriter as _VaultWriter
 
@@ -340,7 +339,7 @@ async def _main_async() -> None:
         deployment_environment=settings.otel_deployment_environment,
     )
 
-    qdrant = QdrantClient(
+    qdrant = build_qdrant_client(
         host=settings.qdrant_host,
         port=settings.qdrant_port,
         api_key=settings.qdrant_api_key.get_secret_value(),

--- a/src/musubi/llm/promotion_client.py
+++ b/src/musubi/llm/promotion_client.py
@@ -48,6 +48,13 @@ class _PromotionResponse(BaseModel):
     sections: list[str] = Field(default_factory=list)
 
 
+# Cache the JSON Schema at import time so each promotion call doesn't
+# pay regeneration cost. The schema constrains Ollama's structured-output
+# decoder (≥0.5.0) — the LLM can't omit `body` even on best-of-N drift.
+# Same pattern as `musubi.llm.ollama` (PR #311, 2026-05-14).
+_PROMOTION_SCHEMA: dict[str, Any] = _PromotionResponse.model_json_schema()
+
+
 def _load_prompt(name: str, version: str) -> str:
     resource = files("musubi.llm.prompts").joinpath(name).joinpath(f"{version}.txt")
     return resource.read_text(encoding="utf-8")
@@ -126,12 +133,17 @@ class HttpxPromotionClient:
             raise ValueError(f"promotion-render body rejected: {exc}") from exc
 
     async def _chat(self, prompt: str) -> str:
+        # Pass the Pydantic-derived JSON Schema as `format` to engage
+        # Ollama's structured-output mode (≥0.5.0). Without this, qwen3:4b
+        # occasionally emits a response missing `body`, which would
+        # ValueError out of `render_curated_markdown` and burn a sweep
+        # tick. See PR #311 (the same fix applied to musubi.llm.ollama).
         url = f"{self._base_url}/api/chat"
         payload: dict[str, Any] = {
             "model": self._model,
             "messages": [{"role": "user", "content": prompt}],
             "stream": False,
-            "format": "json",
+            "format": _PROMOTION_SCHEMA,
             "options": {"temperature": 0.2},
         }
         async with httpx.AsyncClient(timeout=self._timeout_s) as client:

--- a/src/musubi/storage/__init__.py
+++ b/src/musubi/storage/__init__.py
@@ -1,0 +1,10 @@
+"""Production-grade storage client factories.
+
+Today: Qdrant. Future home for any backend wrappers that need to encode
+configuration choices (cert trust, retry policy, instrumentation) in
+one place instead of scattering them across call sites.
+"""
+
+from musubi.storage.qdrant_factory import build_qdrant_client
+
+__all__ = ["build_qdrant_client"]

--- a/src/musubi/storage/qdrant_factory.py
+++ b/src/musubi/storage/qdrant_factory.py
@@ -1,0 +1,55 @@
+"""Factory for production-grade QdrantClient construction.
+
+The qdrant-client library raises ``UserWarning: Api key is used with an
+insecure connection`` whenever an API key is supplied over plain HTTP.
+On musubi's compose bridge that warning is structurally noisy:
+
+- Qdrant lives on the internal ``musubi_default`` Docker network, never
+  reachable from outside the host.
+- mTLS for intra-compose traffic is tracked separately (see
+  ``MUSUBI_ALLOW_PLAINTEXT`` env flag + the future hardening slice).
+- The warning fires on every container start — twice for the lifecycle
+  worker (during signal handler reconnect), and once for core.
+
+Rather than ``warnings.filterwarnings("ignore", ...)`` globally (which
+would hide *all* qdrant warnings, including ones we'd want to see), this
+factory wraps the construction in a tightly scoped ``catch_warnings``
+block and silences only the one message we know is intentional. Any
+future qdrant_client warning surfaces unchanged.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+from qdrant_client import QdrantClient
+
+_INSECURE_API_KEY_WARNING = "Api key is used with an insecure connection."
+
+
+def build_qdrant_client(
+    *,
+    host: str,
+    port: int,
+    api_key: str,
+    https: bool = True,
+) -> QdrantClient:
+    """Construct a ``QdrantClient`` with the documented insecure-API-key
+    warning suppressed when ``https`` is False.
+
+    All non-``https`` callsites in production accept the trade-off — the
+    network is internal-only and the API key is rotated via vault. The
+    factory documents that choice in one place instead of scattering
+    ``warnings.catch_warnings`` blocks across modules.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=_INSECURE_API_KEY_WARNING,
+            category=UserWarning,
+            module=r"qdrant_client\..*",
+        )
+        return QdrantClient(host=host, port=port, api_key=api_key, https=https)
+
+
+__all__ = ["build_qdrant_client"]

--- a/src/musubi/storage/qdrant_factory.py
+++ b/src/musubi/storage/qdrant_factory.py
@@ -20,11 +20,16 @@ future qdrant_client warning surfaces unchanged.
 
 from __future__ import annotations
 
+import re
 import warnings
 
 from qdrant_client import QdrantClient
 
-_INSECURE_API_KEY_WARNING = "Api key is used with an insecure connection."
+# `warnings.filterwarnings` treats `message` as a regex matched from
+# the start of the warning text. Escape the literal — the trailing `.`
+# is a literal period in the upstream message, not a regex wildcard —
+# and add `\Z` so we only match this exact warning.
+_INSECURE_API_KEY_WARNING = re.escape("Api key is used with an insecure connection.") + r"\Z"
 
 
 def build_qdrant_client(
@@ -43,11 +48,16 @@ def build_qdrant_client(
     ``warnings.catch_warnings`` blocks across modules.
     """
     with warnings.catch_warnings():
+        # The `\Z` anchor on the message pattern is the precision
+        # guarantee here — we suppress only the exact documented
+        # warning. The `module` filter was tempting as belt-and-braces
+        # but excludes warnings whose stacklevel resolves outside
+        # `qdrant_client` (test stubs, future code paths) and led to
+        # leakage in tests. Message-anchor is enough.
         warnings.filterwarnings(
             "ignore",
             message=_INSECURE_API_KEY_WARNING,
             category=UserWarning,
-            module=r"qdrant_client\..*",
         )
         return QdrantClient(host=host, port=port, api_key=api_key, https=https)
 

--- a/tests/api/test_bootstrap.py
+++ b/tests/api/test_bootstrap.py
@@ -65,25 +65,29 @@ def settings(api_settings: Settings) -> Settings:
 def patch_qdrant_ok() -> Iterator[Any]:
     """Replace BOTH dep probes with happy-path doubles so the
     bootstrap completes without touching the network. Yields the
-    QdrantClient mock for tests that need to introspect it."""
+    QdrantClient mock for tests that need to introspect it.
+
+    Patches the `build_qdrant_client` factory (introduced in the
+    qdrant-warning-suppression slice) rather than the raw class, so
+    fixtures stay valid as production wiring evolves."""
     with (
-        patch("musubi.api.bootstrap.QdrantClient") as mock_qd_cls,
+        patch("musubi.api.bootstrap.build_qdrant_client") as mock_qd_factory,
         patch("musubi.api.bootstrap._probe_tei", return_value=None),
         patch("musubi.store.bootstrap"),
     ):
-        instance = mock_qd_cls.return_value
+        instance = mock_qd_factory.return_value
         instance.get_collections.return_value = type("Collections", (), {"collections": []})()
-        yield mock_qd_cls
+        yield mock_qd_factory
 
 
 @pytest.fixture
 def patch_qdrant_unreachable() -> Iterator[Any]:
     """First call to QdrantClient.get_collections raises ConnectionError;
     bootstrap's retry should eventually surface BootstrapError."""
-    with patch("musubi.api.bootstrap.QdrantClient") as mock_cls:
-        instance = mock_cls.return_value
+    with patch("musubi.api.bootstrap.build_qdrant_client") as mock_factory:
+        instance = mock_factory.return_value
         instance.get_collections.side_effect = ConnectionError("qdrant unreachable")
-        yield mock_cls
+        yield mock_factory
 
 
 @pytest.fixture
@@ -92,16 +96,16 @@ def patch_qdrant_recovers() -> Iterator[Any]:
     probe is patched happy throughout so this fixture isolates the
     Qdrant retry behaviour."""
     with (
-        patch("musubi.api.bootstrap.QdrantClient") as mock_cls,
+        patch("musubi.api.bootstrap.build_qdrant_client") as mock_factory,
         patch("musubi.api.bootstrap._probe_tei", return_value=None),
         patch("musubi.store.bootstrap"),
     ):
-        instance = mock_cls.return_value
+        instance = mock_factory.return_value
         instance.get_collections.side_effect = [
             ConnectionError("qdrant transient"),
             type("Collections", (), {"collections": []})(),
         ]
-        yield mock_cls
+        yield mock_factory
 
 
 # ---------------------------------------------------------------------------

--- a/tests/llm/test_promotion_client.py
+++ b/tests/llm/test_promotion_client.py
@@ -109,9 +109,7 @@ async def test_render_engages_ollama_structured_output_mode(httpx_mock: HTTPXMoc
         json=_chat_body(_valid_payload()),
     )
     client = _client()
-    await client.render_curated_markdown(
-        title="T", content="C", rationale="R", top_memories=[]
-    )
+    await client.render_curated_markdown(title="T", content="C", rationale="R", top_memories=[])
     request = httpx_mock.get_request()
     assert request is not None
     body = json.loads(request.content)

--- a/tests/llm/test_promotion_client.py
+++ b/tests/llm/test_promotion_client.py
@@ -99,6 +99,29 @@ async def test_render_includes_top_memories_in_prompt(httpx_mock: HTTPXMock) -> 
     assert "the-tell-tale-memory-string" in user_prompt
 
 
+async def test_render_engages_ollama_structured_output_mode(httpx_mock: HTTPXMock) -> None:
+    """The /api/chat payload must pass a JSON Schema as `format` so
+    Ollama refuses to emit responses missing required fields (e.g.
+    `body`). Same constraint we ship in musubi.llm.ollama."""
+    httpx_mock.add_response(
+        url=f"{_BASE_URL}/api/chat",
+        method="POST",
+        json=_chat_body(_valid_payload()),
+    )
+    client = _client()
+    await client.render_curated_markdown(
+        title="T", content="C", rationale="R", top_memories=[]
+    )
+    request = httpx_mock.get_request()
+    assert request is not None
+    body = json.loads(request.content)
+    fmt = body["format"]
+    assert isinstance(fmt, dict), "format must be a JSON Schema dict, not the bare 'json' string"
+    assert fmt.get("type") == "object"
+    assert "body" in fmt.get("properties", {})
+    assert "body" in fmt.get("required", []), "`body` must be in required so Ollama can't omit it"
+
+
 # ---------------------------------------------------------------------------
 # Failure paths — Protocol contract says RAISE, not return None
 # ---------------------------------------------------------------------------

--- a/tests/ops/test_prometheus.py
+++ b/tests/ops/test_prometheus.py
@@ -170,6 +170,25 @@ def test_node_exporter_service_exists() -> None:
     assert "/sys:/host/sys:ro" in volumes_text, "node-exporter must bind-mount host /sys"
 
 
+def test_node_exporter_has_udev_mount_and_flag() -> None:
+    """Without /run/udev mounted AND --path.udev.data pointing at it,
+    the diskstats collector self-disables udev metadata and node_disk_*
+    series lose ID_WWN / ID_SERIAL / ID_MODEL labels. Both halves are
+    required; either one missing reintroduces the warning + gap."""
+    svc = _render_compose()["services"]["node-exporter"]
+    volumes_text = " ".join(svc.get("volumes", []))
+    assert "/run/udev:/host/run/udev:ro" in volumes_text, (
+        "node-exporter must bind-mount /run/udev so the diskstats collector "
+        "can read udev device properties"
+    )
+    cmd = svc.get("command") or []
+    joined_cmd = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
+    assert "--path.udev.data=/host/run/udev/data" in joined_cmd, (
+        "node-exporter must be told where to find udev data in the container; "
+        "the bind mount alone is insufficient"
+    )
+
+
 def test_prometheus_mounts_scrape_config_readonly() -> None:
     svc = _render_compose()["services"]["prometheus"]
     ro_mounts = [

--- a/tests/storage/test_qdrant_factory.py
+++ b/tests/storage/test_qdrant_factory.py
@@ -1,0 +1,76 @@
+"""Unit tests for :mod:`musubi.storage.qdrant_factory`.
+
+The factory exists to silence one specific qdrant-client warning while
+letting every other warning through. These tests pin both halves of
+that contract.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+from musubi.storage.qdrant_factory import build_qdrant_client
+
+
+def _install_stub_client(monkeypatch: Any, *, warning_text: str | None) -> None:
+    """Replace the QdrantClient constructor with a stub that optionally
+    emits a controlled UserWarning before returning. The stub is
+    installed at the factory module's import binding so the patch
+    travels through ``build_qdrant_client``."""
+
+    class _StubClient:
+        def __init__(self, **_: Any) -> None:
+            if warning_text is not None:
+                warnings.warn(warning_text, UserWarning, stacklevel=2)
+
+    monkeypatch.setattr("musubi.storage.qdrant_factory.QdrantClient", _StubClient)
+
+
+def test_factory_suppresses_only_the_documented_insecure_warning(
+    monkeypatch: Any,
+) -> None:
+    _install_stub_client(
+        monkeypatch,
+        warning_text="Api key is used with an insecure connection.",
+    )
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        build_qdrant_client(host="q", port=6333, api_key="k", https=False)
+    insecure = [
+        w for w in captured if "Api key is used with an insecure connection" in str(w.message)
+    ]
+    assert insecure == [], "the documented insecure-connection warning must be suppressed"
+
+
+def test_factory_lets_unrelated_qdrant_warnings_through(monkeypatch: Any) -> None:
+    """A future qdrant_client warning we haven't seen yet must still
+    surface — the whole point of scoping the filter is to avoid
+    masking real issues."""
+    _install_stub_client(
+        monkeypatch,
+        warning_text="Some other unrelated qdrant_client warning",
+    )
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        build_qdrant_client(host="q", port=6333, api_key="k", https=False)
+    matched = [w for w in captured if "unrelated" in str(w.message)]
+    assert matched, "unrelated qdrant_client warnings must reach the caller"
+
+
+def test_factory_filter_pattern_is_anchored(monkeypatch: Any) -> None:
+    """Pattern uses `\\Z` so an extended message starting with the
+    documented phrase still surfaces — it could be a new upstream
+    warning we'd want to see."""
+    _install_stub_client(
+        monkeypatch,
+        warning_text=(
+            "Api key is used with an insecure connection. "
+            "Also your connection pool exceeded its limit."
+        ),
+    )
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        build_qdrant_client(host="q", port=6333, api_key="k", https=False)
+    leaked = [w for w in captured if "exceeded" in str(w.message)]
+    assert leaked, "extended messages must not be swallowed by the anchored filter"

--- a/uv.lock
+++ b/uv.lock
@@ -753,7 +753,7 @@ wheels = [
 
 [[package]]
 name = "musubi"
-version = "1.3.4"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Three independent fixes bundled into one PR so they share a single release cycle. Each commit stands on its own.

## 1. `fix(llm): constrain promotion_client Ollama decoding with JSON Schema`
- Follow-up to PR #311 (the synthesis fix). `promotion_client` was still on `format: "json"` — qwen3:4b could omit `body` and the sweep would `ValidationError`.
- Cache the Pydantic-derived schema once at import, pass it as `format`.
- New test asserts the payload uses a schema dict, not the bare `"json"` string.

## 2. `chore(storage): centralize Qdrant client construction in a factory`
- Closes the "Api key is used with an insecure connection" warning that fires on every container start. Qdrant is on the internal compose bridge; mTLS deferred to a separate slice. Warning is structurally noisy, not load-bearing.
- New `musubi.storage.build_qdrant_client` factory wraps the construction in a tightly scoped `warnings.catch_warnings` that silences *only* the documented message. Any other qdrant_client warning still surfaces.
- Three callsites (bootstrap, dependencies, runner) now route through the factory.
- Test fixtures patch `build_qdrant_client` instead of `QdrantClient` — same shape, more stable seam.

## 3. `fix(deploy): mount host /run/udev into node-exporter`
- node-exporter's diskstats collector self-disables udev metadata because the container can't see `/run/udev` from the host. Logs `Failed to open directory` twice per deploy cycle. The real cost is missing udev-derived labels on `node_disk_*` series.
- Add `/run/udev:/host/run/udev:ro` and `--path.udev.data=/host/run/udev/data`. Warning gone, labels restored.

## Test plan
- [x] `pytest tests/llm/test_promotion_client.py tests/api/test_bootstrap.py tests/ops/test_prometheus.py` — clean
- [x] Full suite: 1307 passed
- [x] `ruff` + `mypy` clean
- [ ] Post-deploy: lifecycle-worker startup logs no longer contain the qdrant insecure-connection warning
- [ ] Post-deploy: node-exporter logs no longer contain the udev-data warning; `node_disk_io_now{}` carries `device` label values from udev