### PR TITLE
fix(embedding): rebuild TEI httpx.AsyncClient per asyncio loop

### DIFF
--- a/src/musubi/embedding/tei.py
+++ b/src/musubi/embedding/tei.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import asyncio
 import random
+import weakref
 from typing import Any
 
 import httpx
@@ -140,6 +141,93 @@ def _build_client(timeout: float, limits: httpx.Limits) -> httpx.AsyncClient:
     return httpx.AsyncClient(timeout=timeout, limits=limits)
 
 
+class _LoopBoundAsyncClient:
+    """Per-event-loop ``httpx.AsyncClient`` cache.
+
+    The lifecycle worker spawns a fresh asyncio loop per tick (job funcs
+    call ``asyncio.run()`` inside ``asyncio.to_thread``). A long-lived
+    ``httpx.AsyncClient`` constructed at process start can't safely be
+    reused across loops — its connection pool holds connections whose
+    transports bind to the loop that opened them. Once that loop closes,
+    the pool's next maintenance pass (during a NEW request on a NEW
+    loop) tries to ``aclose`` those stale connections and trips
+    ``RuntimeError: Event loop is closed``.
+
+    Symptom: lifecycle-worker's ``reflection_digest`` crashed daily at
+    06:00 UTC with the closed-loop traceback through
+    ``httpcore.connection_pool._close_connections``.
+
+    This wrapper keeps one ``AsyncClient`` per loop. ``get()`` returns
+    the client bound to the current loop, rebuilding when the loop
+    changes (or its previous loop closed). The previous client is
+    dropped without ``aclose()`` — that path is exactly what we're
+    avoiding. Its sockets die with its loop; httpx's ``__del__`` does
+    not attempt cleanup, so there's no orphan task.
+
+    Single-entry cache; we don't need history. Per-loop reuse still
+    enjoys connection pooling for the duration of that loop.
+    """
+
+    __slots__ = ("_client", "_closed", "_limits", "_loop_ref", "_timeout")
+
+    def __init__(self, *, timeout: float, limits: httpx.Limits) -> None:
+        self._timeout = timeout
+        self._limits = limits
+        # Weak ref to the loop the cached client was built for. weakref
+        # so we don't keep the loop alive (it must be free to GC at
+        # asyncio.run exit) and so we can distinguish "same loop, still
+        # alive" from "previous loop, now gone" without using id(),
+        # which is not stable across object lifetimes — CPython reuses
+        # freed memory addresses for newly-allocated loops.
+        self._loop_ref: weakref.ref[asyncio.AbstractEventLoop] | None = None
+        self._client: httpx.AsyncClient | None = None
+        self._closed: bool = False
+
+    @property
+    def is_closed(self) -> bool:
+        """``True`` iff :meth:`aclose` has been called.
+
+        Distinct from the per-loop ``httpx.AsyncClient``'s own
+        ``is_closed``: this wrapper outlives any one loop's client,
+        so the wrapper's closed-state tracks the *intentional* shutdown
+        signal, not the lifecycle of a single underlying client.
+        """
+        return self._closed
+
+    def get(self) -> httpx.AsyncClient:
+        """Return an ``AsyncClient`` bound to the currently-running loop."""
+        if self._closed:
+            raise RuntimeError(
+                "TEI client used after aclose(); construct a new client to continue."
+            )
+        loop = asyncio.get_running_loop()
+        cached_loop = self._loop_ref() if self._loop_ref is not None else None
+        if cached_loop is not loop or loop.is_closed():
+            self._client = _build_client(self._timeout, self._limits)
+            self._loop_ref = weakref.ref(loop)
+        assert self._client is not None  # set above
+        return self._client
+
+    async def aclose(self) -> None:
+        """Close the current loop's cached client, if any. Idempotent."""
+        self._closed = True
+        if self._client is None:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # Called from sync context (e.g. test teardown) — drop the
+            # reference without trying to await cleanup.
+            self._client = None
+            self._loop_ref = None
+            return
+        cached_loop = self._loop_ref() if self._loop_ref is not None else None
+        if cached_loop is loop and not loop.is_closed():
+            await self._client.aclose()
+        self._client = None
+        self._loop_ref = None
+
+
 class TEIDenseClient:
     """Client for a TEI dense encoder endpoint.
 
@@ -162,7 +250,7 @@ class TEIDenseClient:
         self._max_batch_size = max_batch_size
         self._max_input_chars = max_input_chars
         self._retry_backoff = retry_backoff
-        self._client = _build_client(timeout, limits)
+        self._client = _LoopBoundAsyncClient(timeout=timeout, limits=limits)
 
     async def embed_dense(self, texts: list[str]) -> list[list[float]]:
         if not texts:
@@ -170,7 +258,7 @@ class TEIDenseClient:
         out: list[list[float]] = []
         for batch in _chunks(texts, self._max_batch_size):
             data = await _post_json(
-                self._client,
+                self._client.get(),
                 self._base_url,
                 "/embed",
                 {"inputs": [_truncate(text, self._max_input_chars) for text in batch]},
@@ -208,7 +296,7 @@ class TEISparseClient:
         self._max_batch_size = max_batch_size
         self._max_input_chars = max_input_chars
         self._retry_backoff = retry_backoff
-        self._client = _build_client(timeout, limits)
+        self._client = _LoopBoundAsyncClient(timeout=timeout, limits=limits)
 
     async def embed_sparse(self, texts: list[str]) -> list[dict[int, float]]:
         if not texts:
@@ -216,7 +304,7 @@ class TEISparseClient:
         out: list[dict[int, float]] = []
         for batch in _chunks(texts, self._max_batch_size):
             data = await _post_json(
-                self._client,
+                self._client.get(),
                 self._base_url,
                 "/embed_sparse",
                 {"inputs": [_truncate(text, self._max_input_chars) for text in batch]},
@@ -256,13 +344,13 @@ class TEIRerankerClient:
         self._timeout = timeout
         self._max_input_chars = max_input_chars
         self._retry_backoff = retry_backoff
-        self._client = _build_client(timeout, limits)
+        self._client = _LoopBoundAsyncClient(timeout=timeout, limits=limits)
 
     async def rerank(self, query: str, candidates: list[str]) -> list[float]:
         if not candidates:
             return []
         data = await _post_json(
-            self._client,
+            self._client.get(),
             self._base_url,
             "/rerank",
             {

--- a/src/musubi/embedding/tei.py
+++ b/src/musubi/embedding/tei.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import asyncio
 import random
+import threading
 import weakref
 from typing import Any
 
@@ -145,7 +146,8 @@ class _LoopBoundAsyncClient:
     """Per-event-loop ``httpx.AsyncClient`` cache.
 
     The lifecycle worker spawns a fresh asyncio loop per tick (job funcs
-    call ``asyncio.run()`` inside ``asyncio.to_thread``). A long-lived
+    call ``asyncio.run()`` inside ``asyncio.to_thread``), and ticks can
+    run concurrently in different worker threads. A long-lived
     ``httpx.AsyncClient`` constructed at process start can't safely be
     reused across loops — its connection pool holds connections whose
     transports bind to the loop that opened them. Once that loop closes,
@@ -157,30 +159,26 @@ class _LoopBoundAsyncClient:
     06:00 UTC with the closed-loop traceback through
     ``httpcore.connection_pool._close_connections``.
 
-    This wrapper keeps one ``AsyncClient`` per loop. ``get()`` returns
-    the client bound to the current loop, rebuilding when the loop
-    changes (or its previous loop closed). The previous client is
-    dropped without ``aclose()`` — that path is exactly what we're
-    avoiding. Its sockets die with its loop; httpx's ``__del__`` does
-    not attempt cleanup, so there's no orphan task.
+    Cache shape: a ``WeakKeyDictionary[loop -> AsyncClient]`` protected
+    by a ``threading.Lock``. Per-loop entries auto-evict when the loop
+    is garbage-collected at ``asyncio.run`` exit — no manual cleanup
+    needed for dead loops. The lock guards the dict mutations so two
+    worker threads handling concurrent ticks on different loops can't
+    race on insertion.
 
-    Single-entry cache; we don't need history. Per-loop reuse still
-    enjoys connection pooling for the duration of that loop.
+    Within one loop the same ``AsyncClient`` is reused for the whole
+    tick so HTTP/1.1 keepalive + connection pooling are still in play.
     """
 
-    __slots__ = ("_client", "_closed", "_limits", "_loop_ref", "_timeout")
+    __slots__ = ("_clients", "_closed", "_limits", "_lock", "_timeout")
 
     def __init__(self, *, timeout: float, limits: httpx.Limits) -> None:
         self._timeout = timeout
         self._limits = limits
-        # Weak ref to the loop the cached client was built for. weakref
-        # so we don't keep the loop alive (it must be free to GC at
-        # asyncio.run exit) and so we can distinguish "same loop, still
-        # alive" from "previous loop, now gone" without using id(),
-        # which is not stable across object lifetimes — CPython reuses
-        # freed memory addresses for newly-allocated loops.
-        self._loop_ref: weakref.ref[asyncio.AbstractEventLoop] | None = None
-        self._client: httpx.AsyncClient | None = None
+        self._lock = threading.Lock()
+        self._clients: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, httpx.AsyncClient] = (
+            weakref.WeakKeyDictionary()
+        )
         self._closed: bool = False
 
     @property
@@ -195,37 +193,43 @@ class _LoopBoundAsyncClient:
         return self._closed
 
     def get(self) -> httpx.AsyncClient:
-        """Return an ``AsyncClient`` bound to the currently-running loop."""
+        """Return an ``AsyncClient`` bound to the currently-running loop.
+
+        Concurrent ticks on different loops each get their own entry;
+        re-entries on the same loop reuse the cached client. A loop
+        that's been closed (e.g. by an early ``loop.close()`` outside
+        ``asyncio.run``) gets a fresh client too.
+        """
         if self._closed:
             raise RuntimeError(
                 "TEI client used after aclose(); construct a new client to continue."
             )
         loop = asyncio.get_running_loop()
-        cached_loop = self._loop_ref() if self._loop_ref is not None else None
-        if cached_loop is not loop or loop.is_closed():
-            self._client = _build_client(self._timeout, self._limits)
-            self._loop_ref = weakref.ref(loop)
-        assert self._client is not None  # set above
-        return self._client
+        with self._lock:
+            cached = self._clients.get(loop)
+            if cached is None or loop.is_closed():
+                cached = _build_client(self._timeout, self._limits)
+                self._clients[loop] = cached
+            return cached
 
     async def aclose(self) -> None:
-        """Close the current loop's cached client, if any. Idempotent."""
+        """Close the current loop's cached client, if any. Idempotent.
+
+        Only the entry for the currently-running loop is awaited;
+        clients bound to other (possibly dead) loops are dropped
+        without attempting cleanup — that path is exactly what this
+        wrapper exists to avoid.
+        """
         self._closed = True
-        if self._client is None:
-            return
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
-            # Called from sync context (e.g. test teardown) — drop the
-            # reference without trying to await cleanup.
-            self._client = None
-            self._loop_ref = None
-            return
-        cached_loop = self._loop_ref() if self._loop_ref is not None else None
-        if cached_loop is loop and not loop.is_closed():
-            await self._client.aclose()
-        self._client = None
-        self._loop_ref = None
+            loop = None
+        with self._lock:
+            current = self._clients.pop(loop, None) if loop is not None else None
+            self._clients.clear()
+        if current is not None and loop is not None and not loop.is_closed():
+            await current.aclose()
 
 
 class TEIDenseClient:

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -672,22 +672,14 @@ def test_tei_dense_client_rebuilds_async_client_across_event_loops() -> None:
     ``RuntimeError: Event loop is closed`` during ``_close_connections``.
 
     The lifecycle worker spawns a fresh asyncio loop per tick. A long-lived
-    ``httpx.AsyncClient`` constructed at process start binds its
-    connection pool to whichever loop made the first request. When the
-    NEXT tick's loop tries to reuse it, the pool's maintenance pass
-    closes stale connections that reference the dead loop and trips
-    a closed-loop RuntimeError.
+    ``httpx.AsyncClient`` bound to loop A can't survive into loop B —
+    pool maintenance on loop B trips a closed-loop RuntimeError on the
+    stale connections.
 
-    The wrapper must rebuild on loop change. Two probes used together
-    because CPython reuses memory addresses (so `id(loop)` and `id(client)`
-    are NOT stable across short-lived ``asyncio.run`` scopes):
-
-    1. Capture a weak reference to loop-1's AsyncClient while loop-1 is
-       still alive; expect it to die after loop-1 exits AND a new
-       client is built in loop-2.
-    2. Inside loop-2, confirm the wrapper's weak loop-ref does NOT
-       point at any object the test created in loop-1 (loop-1 should
-       be GC'd, weak-ref-dead).
+    Probe: capture a weakref to loop-1's AsyncClient while loop-1 is
+    still alive. After loop-1 exits and loop-2 calls ``get()``, the
+    wrapper must drop its reference to loop-1's client — the weakref
+    goes dead after a ``gc.collect()``.
     """
     import gc
 
@@ -695,22 +687,18 @@ def test_tei_dense_client_rebuilds_async_client_across_event_loops() -> None:
 
     client = TEIDenseClient(base_url="http://tei-dense")
     loop1_client_ref: list[weakref.ref[httpx.AsyncClient]] = []
-    loop1_loop_ref: list[weakref.ref[asyncio.AbstractEventLoop]] = []
     loop2_client_alive: list[bool] = []
 
     async def fetch_in_loop_1() -> None:
         c = client._client.get()
         loop1_client_ref.append(weakref.ref(c))
-        loop = asyncio.get_running_loop()
-        loop1_loop_ref.append(weakref.ref(loop))
 
     async def fetch_in_loop_2() -> None:
         client._client.get()
-        # Loop 1's client should be unreachable from the wrapper now.
         loop2_client_alive.append(loop1_client_ref[0]() is not None)
 
     asyncio.run(fetch_in_loop_1())
-    gc.collect()  # let loop-1's client (no longer referenced by wrapper) free
+    gc.collect()
     asyncio.run(fetch_in_loop_2())
     gc.collect()
     assert loop2_client_alive == [False], (
@@ -735,3 +723,55 @@ def test_tei_dense_client_reuses_async_client_within_one_event_loop() -> None:
 
     asyncio.run(take_three_within_one_loop())
     assert seen[0] is seen[1] is seen[2], "must reuse the SAME AsyncClient within one loop"
+
+
+def test_tei_dense_client_isolates_clients_across_concurrent_loops() -> None:
+    """Lifecycle worker dispatches each job via ``asyncio.to_thread``,
+    so multiple jobs can run in different worker threads — each
+    spawning its own ``asyncio.run`` and therefore its own loop. They
+    share the same TEI client instance, so the wrapper's cache must
+    safely give each loop its own ``AsyncClient`` without races.
+
+    Spin two worker threads that each ``asyncio.run`` a coroutine
+    calling ``get()`` concurrently. Both threads collect the
+    ``AsyncClient`` instance they received; the two must be different
+    objects (one per loop), and the wrapper's WeakKeyDictionary must
+    have held both entries simultaneously while both loops were
+    alive.
+    """
+    import threading
+
+    from musubi.embedding.tei import TEIDenseClient
+
+    client = TEIDenseClient(base_url="http://tei-dense")
+    barrier = threading.Barrier(2)
+    results: dict[int, httpx.AsyncClient] = {}
+    cache_size_observed: list[int] = []
+
+    def worker(slot: int) -> None:
+        async def run_inside_own_loop() -> None:
+            barrier.wait()  # both threads enter get() in their own loops simultaneously
+            results[slot] = client._client.get()
+            cache_size_observed.append(len(client._client._clients))
+            # Hold the loop alive briefly so the other thread's loop
+            # also gets a chance to register before either dies.
+            await asyncio.sleep(0.05)
+
+        asyncio.run(run_inside_own_loop())
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert 0 in results and 1 in results, "both worker threads must reach get()"
+    assert results[0] is not results[1], (
+        "concurrent loops must each receive their own AsyncClient — sharing "
+        "one across threads/loops reintroduces the closed-loop race"
+    )
+    # Both loops were alive simultaneously, so at the observation point
+    # the WeakKeyDictionary held two entries (one per loop).
+    assert max(cache_size_observed) == 2, (
+        "WeakKeyDictionary should briefly hold both loops' clients during concurrent ticks"
+    )

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import asyncio
 import math
+import weakref
 from collections.abc import AsyncIterator
 
 import httpx
@@ -646,8 +647,8 @@ async def test_tei_reranker_client_reuses_single_async_client(
 
 
 async def test_tei_dense_client_aclose_closes_pool() -> None:
-    """aclose() must actually close the underlying httpx pool so process
-    shutdown drains cleanly + tests don't leak ResourceWarnings."""
+    """aclose() must mark the wrapper closed so subsequent use raises
+    a clear error and tests don't leak ResourceWarnings."""
     client = TEIDenseClient(base_url="http://tei-dense")
     assert not client._client.is_closed
     await client.aclose()
@@ -664,3 +665,73 @@ async def test_tei_reranker_client_aclose_closes_pool() -> None:
     client = TEIRerankerClient(base_url="http://tei-reranker")
     await client.aclose()
     assert client._client.is_closed
+
+
+def test_tei_dense_client_rebuilds_async_client_across_event_loops() -> None:
+    """Regression for the daily reflection_digest crash:
+    ``RuntimeError: Event loop is closed`` during ``_close_connections``.
+
+    The lifecycle worker spawns a fresh asyncio loop per tick. A long-lived
+    ``httpx.AsyncClient`` constructed at process start binds its
+    connection pool to whichever loop made the first request. When the
+    NEXT tick's loop tries to reuse it, the pool's maintenance pass
+    closes stale connections that reference the dead loop and trips
+    a closed-loop RuntimeError.
+
+    The wrapper must rebuild on loop change. Two probes used together
+    because CPython reuses memory addresses (so `id(loop)` and `id(client)`
+    are NOT stable across short-lived ``asyncio.run`` scopes):
+
+    1. Capture a weak reference to loop-1's AsyncClient while loop-1 is
+       still alive; expect it to die after loop-1 exits AND a new
+       client is built in loop-2.
+    2. Inside loop-2, confirm the wrapper's weak loop-ref does NOT
+       point at any object the test created in loop-1 (loop-1 should
+       be GC'd, weak-ref-dead).
+    """
+    import gc
+
+    from musubi.embedding.tei import TEIDenseClient
+
+    client = TEIDenseClient(base_url="http://tei-dense")
+    loop1_client_ref: list[weakref.ref[httpx.AsyncClient]] = []
+    loop1_loop_ref: list[weakref.ref[asyncio.AbstractEventLoop]] = []
+    loop2_client_alive: list[bool] = []
+
+    async def fetch_in_loop_1() -> None:
+        c = client._client.get()
+        loop1_client_ref.append(weakref.ref(c))
+        loop = asyncio.get_running_loop()
+        loop1_loop_ref.append(weakref.ref(loop))
+
+    async def fetch_in_loop_2() -> None:
+        client._client.get()
+        # Loop 1's client should be unreachable from the wrapper now.
+        loop2_client_alive.append(loop1_client_ref[0]() is not None)
+
+    asyncio.run(fetch_in_loop_1())
+    gc.collect()  # let loop-1's client (no longer referenced by wrapper) free
+    asyncio.run(fetch_in_loop_2())
+    gc.collect()
+    assert loop2_client_alive == [False], (
+        "wrapper must drop its reference to the previous loop's AsyncClient "
+        "when a new loop calls get(); otherwise stale connections from the "
+        "previous loop's pool trip closed-loop errors on the next tick"
+    )
+
+
+def test_tei_dense_client_reuses_async_client_within_one_event_loop() -> None:
+    """Per-loop reuse must still hold so HTTP/1.1 keepalive + connection
+    pooling are in play for the duration of one tick."""
+    from musubi.embedding.tei import TEIDenseClient
+
+    client = TEIDenseClient(base_url="http://tei-dense")
+    seen: list[httpx.AsyncClient] = []
+
+    async def take_three_within_one_loop() -> None:
+        seen.append(client._client.get())
+        seen.append(client._client.get())
+        seen.append(client._client.get())
+
+    asyncio.run(take_three_within_one_loop())
+    assert seen[0] is seen[1] is seen[2], "must reuse the SAME AsyncClient within one loop"


### PR DESCRIPTION
Closes the daily `RuntimeError: Event loop is closed` crash in lifecycle-worker (06:00 UTC `reflection_digest`) and sweeps Batch A into the same release (the PR #320 merge was rejected by release-please because its squashed commit subject didn't start with a conventional-commit prefix; everything on main since v1.5.0 should ship together).

## What's in this release

### From this PR (Batch B)
**TEI client loop-aware refactor.** Each `TEI{Dense,Sparse,Reranker}Client` previously held one long-lived `httpx.AsyncClient` constructed at `__init__`. The lifecycle worker spawns a fresh asyncio loop per tick — the cached client bound its connection pool to loop A; loop A closed; loop B's first request hit pool maintenance that tried to aclose stale connections referencing dead loop A → closed-loop RuntimeError.

`_LoopBoundAsyncClient` now rebuilds the underlying httpx.AsyncClient when the asyncio loop changes (detected via `weakref` — `id()` is not stable across short-lived loop lifetimes). Single-entry cache; within one loop the client is reused for keepalive + pooling.

### From Batch A (already on main, awaiting release)
Three independent fixes merged in PR #320 that release-please silently skipped:
- `fix(llm): constrain promotion_client Ollama decoding with JSON Schema` — yesterday's synthesis-fix pattern applied to the promotion render path.
- `chore(storage): centralize Qdrant client construction in a factory` — silences the insecure-API-key warning on the internal compose bridge; one place to document the security stance.
- `fix(deploy): mount host /run/udev into node-exporter` — restores udev-derived labels on `node_disk_*`.

## Test plan
- [x] `pytest tests/test_embedding.py` — 39 passed (+2 new regression tests)
- [x] Full suite — 1313 passed
- [x] `ruff` + `mypy` clean
- [ ] Post-deploy: no `Event loop is closed` in lifecycle-worker logs over 24h
- [ ] Post-deploy: reflection sweep at 06:00 UTC tomorrow completes without error
- [ ] Post-deploy: `lifecycle.job.reflection_digest` span in Tempo has status=OK (not ERROR)