### PR TITLE
fix(embedding): chunk + max-pool sparse inputs over SPLADE's 512-token cap

### DIFF
--- a/src/musubi/api/bootstrap.py
+++ b/src/musubi/api/bootstrap.py
@@ -46,7 +46,13 @@ from musubi.api.dependencies import (
     get_reranker,
     get_thoughts_plane,
 )
-from musubi.embedding import Embedder, TEIDenseClient, TEIRerankerClient, TEISparseClient
+from musubi.embedding import (
+    ChunkedEmbedder,
+    Embedder,
+    TEIDenseClient,
+    TEIRerankerClient,
+    TEISparseClient,
+)
 from musubi.planes.artifact import ArtifactPlane
 from musubi.planes.concept import ConceptPlane
 from musubi.planes.curated import CuratedPlane
@@ -202,7 +208,14 @@ def bootstrap_production_app(
         backoff_s=retry_backoff_s,
     )
 
-    embedder: Embedder = _TEICompositeEmbedder(dense=dense, sparse=sparse, reranker=reranker)
+    # ChunkedEmbedder enforces SPLADE-v3's 512-token input contract by
+    # chunking long inputs + max-pooling the sparse vectors. Without this
+    # wrap, writes that exceed the cap (information-dense milestone memories)
+    # bounce with HTTP 413 from tei-sparse and the whole episodic write
+    # fails — see musubi.embedding.chunked for the rationale.
+    embedder: Embedder = ChunkedEmbedder(
+        _TEICompositeEmbedder(dense=dense, sparse=sparse, reranker=reranker)
+    )
 
     # Every override below is a fresh closure-captured factory; calling
     # bootstrap a second time replaces the dict entries cleanly (idempotent).

--- a/src/musubi/embedding/__init__.py
+++ b/src/musubi/embedding/__init__.py
@@ -24,11 +24,13 @@ Specs realised:
 
 from musubi.embedding.base import Embedder, EmbeddingError
 from musubi.embedding.cache import CachedEmbedder
+from musubi.embedding.chunked import ChunkedEmbedder
 from musubi.embedding.fake import FakeEmbedder
 from musubi.embedding.tei import TEIDenseClient, TEIRerankerClient, TEISparseClient
 
 __all__ = [
     "CachedEmbedder",
+    "ChunkedEmbedder",
     "Embedder",
     "EmbeddingError",
     "FakeEmbedder",

--- a/src/musubi/embedding/chunked.py
+++ b/src/musubi/embedding/chunked.py
@@ -98,9 +98,12 @@ class ChunkedEmbedder(Embedder):
         per_input_chunks: list[list[str]] = []
         for text in texts:
             chunks = self._chunker.chunk(text)
-            if not chunks:
-                # Whitespace-only or empty input; let the downstream embedder
-                # decide. Preserves existing fake/TEI behavior for edge text.
+            # Whitespace-only inputs survive chunking as a single RawChunk
+            # whose content is "" (TokenSlidingChunker trims via _trim_span).
+            # Forward the original text in that case so cache keys and
+            # downstream embedder behavior stay consistent with the pre-wrap
+            # contract.
+            if not chunks or not any(c.content for c in chunks):
                 per_input_chunks.append([text])
             else:
                 per_input_chunks.append([c.content for c in chunks])

--- a/src/musubi/embedding/chunked.py
+++ b/src/musubi/embedding/chunked.py
@@ -1,0 +1,124 @@
+"""Length-aware Embedder wrapper.
+
+SPLADE-v3 has a hard 512-token input cap (``max_position_embeddings`` baked
+into the model). The existing :class:`Embedder` protocol abstracts the model
+behind a "give me an embedding for this text" interface, but in practice the
+limit leaks up to callers — long inputs hit the encoder and return HTTP 413.
+
+:class:`ChunkedEmbedder` closes that leak. It wraps any :class:`Embedder` and
+honors the sparse encoder's contract by:
+
+1. tokenizing each input with the BGE-M3 tokenizer (already cached at
+   process scope in :mod:`musubi.planes.artifact.chunking`);
+2. routing inputs that exceed a conservative window through a sliding
+   token-window chunker;
+3. embedding all chunks (batched across inputs in a single downstream call);
+4. **max-pooling** the per-chunk sparse vectors into one aggregate per input
+   — the canonical aggregation for SPLADE-style term-presence vectors.
+
+Dense + rerank pass through unchanged. BGE-M3 supports 8192 tokens natively,
+and rerank inputs are short by convention; neither needs chunking today. If
+the deployed TEI dense server is ever configured to cap dense at 512, dense
+gets the same treatment with mean-pooling (not implemented here; add when
+the constraint is real).
+
+Why max-pool for sparse: SPLADE vectors are sparse over vocabulary; each
+non-zero entry asserts "this term has weight W in the document." Max across
+chunks preserves "term X appears in this document with weight ≥W," matching
+the underlying retrieval semantic. Averaging dilutes single-chunk terms;
+summing inflates. Max is the SPLADE long-doc standard.
+
+The BGE-M3 tokenizer is used for counting because it's already loaded; SPLADE
+uses a different tokenizer (WordPiece vs SentencePiece) so the count is
+approximate. The 460-token window (vs the 512 hard cap) absorbs the slop.
+"""
+
+from __future__ import annotations
+
+from musubi.embedding.base import Embedder
+from musubi.planes.artifact.chunking import TokenSlidingChunker
+
+_DEFAULT_SPARSE_WINDOW_TOKENS = 460
+_DEFAULT_SPARSE_OVERLAP_TOKENS = 64
+
+
+def _max_pool_sparse(vectors: list[dict[int, float]]) -> dict[int, float]:
+    """Per-vocabulary-index max across a list of sparse vectors.
+
+    Empty input yields an empty vector. Single-vector input yields a copy
+    of that vector (no aliasing into caller state).
+    """
+    if not vectors:
+        return {}
+    if len(vectors) == 1:
+        return dict(vectors[0])
+    pooled: dict[int, float] = {}
+    for vec in vectors:
+        for idx, weight in vec.items():
+            current = pooled.get(idx)
+            if current is None or weight > current:
+                pooled[idx] = weight
+    return pooled
+
+
+class ChunkedEmbedder(Embedder):
+    """Wrap an :class:`Embedder` so long inputs are sparse-chunked + pooled.
+
+    Dense and rerank delegate unchanged. ``embed_sparse`` always tokenizes
+    each input via the sliding-window chunker — inputs that fit in one window
+    take the single-chunk path (one downstream embedding, no pooling); inputs
+    that don't are split into overlapping windows and max-pooled into a single
+    output vector per input.
+
+    Chunks across all input texts are flattened into one downstream batch so
+    we keep the round-trip count to one per :meth:`embed_sparse` call regardless
+    of how many inputs were long.
+    """
+
+    def __init__(
+        self,
+        wrapped: Embedder,
+        *,
+        sparse_window_tokens: int = _DEFAULT_SPARSE_WINDOW_TOKENS,
+        sparse_overlap_tokens: int = _DEFAULT_SPARSE_OVERLAP_TOKENS,
+    ) -> None:
+        self._wrapped = wrapped
+        self._chunker = TokenSlidingChunker(
+            window_tokens=sparse_window_tokens,
+            overlap_tokens=sparse_overlap_tokens,
+        )
+
+    async def embed_dense(self, texts: list[str]) -> list[list[float]]:
+        return await self._wrapped.embed_dense(texts)
+
+    async def embed_sparse(self, texts: list[str]) -> list[dict[int, float]]:
+        if not texts:
+            return []
+
+        per_input_chunks: list[list[str]] = []
+        for text in texts:
+            chunks = self._chunker.chunk(text)
+            if not chunks:
+                # Whitespace-only or empty input; let the downstream embedder
+                # decide. Preserves existing fake/TEI behavior for edge text.
+                per_input_chunks.append([text])
+            else:
+                per_input_chunks.append([c.content for c in chunks])
+
+        flat_inputs: list[str] = []
+        spans: list[tuple[int, int]] = []
+        cursor = 0
+        for sublist in per_input_chunks:
+            spans.append((cursor, cursor + len(sublist)))
+            flat_inputs.extend(sublist)
+            cursor += len(sublist)
+
+        flat_vectors = await self._wrapped.embed_sparse(flat_inputs)
+
+        return [_max_pool_sparse(flat_vectors[start:end]) for start, end in spans]
+
+    async def rerank(self, query: str, candidates: list[str]) -> list[float]:
+        return await self._wrapped.rerank(query, candidates)
+
+
+__all__ = ["ChunkedEmbedder"]

--- a/tests/test_chunked_embedder.py
+++ b/tests/test_chunked_embedder.py
@@ -213,6 +213,24 @@ async def test_empty_sparse_input_returns_empty_and_skips_downstream() -> None:
     assert spy.embed_sparse_calls == [], "no downstream call for empty input"
 
 
+async def test_whitespace_only_input_forwards_original_text() -> None:
+    """TokenSlidingChunker trims whitespace and emits a RawChunk with
+    empty content. The wrapper must detect this and forward the original
+    whitespace string downstream so cache keys + per-embedder behavior
+    stay consistent with the pre-wrap contract."""
+    spy = _SpyEmbedder()
+    embedder = ChunkedEmbedder(spy)
+
+    out = await embedder.embed_sparse(["   "])
+
+    assert len(out) == 1
+    assert isinstance(out[0], dict)
+    assert len(spy.embed_sparse_calls) == 1
+    assert spy.embed_sparse_calls[0] == ["   "], (
+        "downstream must receive the original whitespace, not chunked ''"
+    )
+
+
 # ---------------------------------------------------------------------------
 # 7. Protocol conformance
 # ---------------------------------------------------------------------------

--- a/tests/test_chunked_embedder.py
+++ b/tests/test_chunked_embedder.py
@@ -1,0 +1,223 @@
+"""Test contract for :class:`ChunkedEmbedder`.
+
+The wrapper enforces SPLADE-v3's 512-token input ceiling by sliding-window
+chunking + max-pool aggregation. Tests cover:
+
+1. Short inputs pass through with one downstream call (no aggregation).
+2. Long inputs split into multiple chunks, max-pooled to one output vector
+   per input.
+3. Max-pool correctness on hand-crafted chunk vectors.
+4. Mixed batches preserve input order and per-input vector identity.
+5. Dense + rerank delegate unchanged regardless of input length.
+6. Empty input returns empty output.
+
+The wrapped embedder is a spy that records every call, so we can assert on
+both the shape of the output AND the batching pattern (one flattened call
+per :meth:`embed_sparse` invocation, regardless of input count).
+"""
+
+from __future__ import annotations
+
+from musubi.embedding import ChunkedEmbedder, FakeEmbedder
+from musubi.embedding.base import Embedder
+from musubi.embedding.chunked import _max_pool_sparse
+
+
+class _SpyEmbedder(Embedder):
+    """Records each call so tests can assert on batching pattern.
+
+    Delegates to :class:`FakeEmbedder` for actual vectors so outputs stay
+    deterministic.
+    """
+
+    def __init__(self) -> None:
+        self._inner = FakeEmbedder()
+        self.embed_sparse_calls: list[list[str]] = []
+        self.embed_dense_calls: list[list[str]] = []
+        self.rerank_calls: list[tuple[str, list[str]]] = []
+
+    async def embed_dense(self, texts: list[str]) -> list[list[float]]:
+        self.embed_dense_calls.append(list(texts))
+        return await self._inner.embed_dense(texts)
+
+    async def embed_sparse(self, texts: list[str]) -> list[dict[int, float]]:
+        self.embed_sparse_calls.append(list(texts))
+        return await self._inner.embed_sparse(texts)
+
+    async def rerank(self, query: str, candidates: list[str]) -> list[float]:
+        self.rerank_calls.append((query, list(candidates)))
+        return await self._inner.rerank(query, candidates)
+
+
+def _long_english_text(approx_tokens: int) -> str:
+    """Build a deterministic English paragraph of roughly ``approx_tokens``
+    BGE-M3 tokens. Uses a fixed sentence so tests are reproducible."""
+    sentence = (
+        "The quick brown fox jumps over the lazy dog while observability "
+        "engineers debate retention policies and chunk-window overlaps. "
+    )
+    # ~22 BGE-M3 tokens per sentence in practice; over-shoot to be safe.
+    n = max(1, approx_tokens // 18 + 2)
+    return sentence * n
+
+
+# ---------------------------------------------------------------------------
+# 1. Short input pass-through
+# ---------------------------------------------------------------------------
+
+
+async def test_short_input_takes_single_chunk_path() -> None:
+    spy = _SpyEmbedder()
+    embedder = ChunkedEmbedder(spy)
+
+    out = await embedder.embed_sparse(["hello world"])
+
+    assert len(out) == 1
+    assert isinstance(out[0], dict)
+    # One downstream call, with one input — no fan-out.
+    assert len(spy.embed_sparse_calls) == 1
+    assert len(spy.embed_sparse_calls[0]) == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. Long input chunked and pooled
+# ---------------------------------------------------------------------------
+
+
+async def test_long_input_chunked_into_multiple_windows() -> None:
+    spy = _SpyEmbedder()
+    embedder = ChunkedEmbedder(spy, sparse_window_tokens=64, sparse_overlap_tokens=8)
+
+    # ~600 tokens worth of text; with window=64 / overlap=8, this guarantees
+    # the chunker produces multiple windows. Window is shrunk for the test
+    # so we don't have to construct genuinely SPLADE-overflowing text.
+    text = _long_english_text(approx_tokens=600)
+
+    out = await embedder.embed_sparse([text])
+
+    assert len(out) == 1, "one input -> one output vector"
+    assert isinstance(out[0], dict)
+    # Downstream got >1 chunk in its one batched call.
+    assert len(spy.embed_sparse_calls) == 1
+    assert len(spy.embed_sparse_calls[0]) > 1, "long input should produce multiple chunks"
+
+
+# ---------------------------------------------------------------------------
+# 3. Max-pool correctness
+# ---------------------------------------------------------------------------
+
+
+def test_max_pool_empty() -> None:
+    assert _max_pool_sparse([]) == {}
+
+
+def test_max_pool_single_vector_returns_copy() -> None:
+    vec = {5: 0.7, 11: 0.2}
+    out = _max_pool_sparse([vec])
+    assert out == vec
+    assert out is not vec, "must not alias caller's dict"
+
+
+def test_max_pool_takes_per_index_max() -> None:
+    a = {5: 0.8, 9: 0.1}
+    b = {5: 0.3, 7: 0.5, 9: 0.4}
+    c = {7: 0.9, 11: 0.6}
+    pooled = _max_pool_sparse([a, b, c])
+    assert pooled == {5: 0.8, 7: 0.9, 9: 0.4, 11: 0.6}
+
+
+# ---------------------------------------------------------------------------
+# 4. Mixed batch — short + long together
+# ---------------------------------------------------------------------------
+
+
+async def test_mixed_batch_preserves_per_input_identity() -> None:
+    spy = _SpyEmbedder()
+    embedder = ChunkedEmbedder(spy, sparse_window_tokens=64, sparse_overlap_tokens=8)
+
+    short = "tiny"
+    long_text = _long_english_text(approx_tokens=600)
+
+    out = await embedder.embed_sparse([short, long_text, "another short"])
+
+    assert len(out) == 3, "output count must match input count"
+    assert all(isinstance(v, dict) for v in out)
+
+    # Exactly one downstream call, flattened across all inputs.
+    assert len(spy.embed_sparse_calls) == 1
+    flat = spy.embed_sparse_calls[0]
+    # short -> 1 chunk, long -> N>1 chunks, short -> 1 chunk. Total > 3.
+    assert len(flat) > 3
+    # First input's chunk is the short text itself.
+    assert flat[0] == short
+    # Last input's chunk is the other short text.
+    assert flat[-1] == "another short"
+
+
+async def test_mixed_batch_short_input_vector_matches_unwrapped() -> None:
+    """Short inputs (single chunk) should produce the same vector that the
+    underlying embedder would produce for that exact text. Max-pool of one
+    vector is that vector."""
+    inner = FakeEmbedder()
+    spy = _SpyEmbedder()
+    embedder = ChunkedEmbedder(spy, sparse_window_tokens=64, sparse_overlap_tokens=8)
+
+    short = "trust but verify"
+    [wrapped_out] = await embedder.embed_sparse([short])
+    [direct_out] = await inner.embed_sparse([short])
+    assert wrapped_out == direct_out
+
+
+# ---------------------------------------------------------------------------
+# 5. Dense + rerank pass-through
+# ---------------------------------------------------------------------------
+
+
+async def test_dense_passes_through_unchanged() -> None:
+    spy = _SpyEmbedder()
+    embedder = ChunkedEmbedder(spy)
+
+    long_text = _long_english_text(approx_tokens=600)
+    out = await embedder.embed_dense([long_text, "short"])
+
+    assert len(out) == 2
+    # No chunking applied to dense; one call with both inputs as given.
+    assert len(spy.embed_dense_calls) == 1
+    assert spy.embed_dense_calls[0] == [long_text, "short"]
+
+
+async def test_rerank_passes_through_unchanged() -> None:
+    spy = _SpyEmbedder()
+    embedder = ChunkedEmbedder(spy)
+
+    long_text = _long_english_text(approx_tokens=600)
+    scores = await embedder.rerank("query", [long_text, "candidate"])
+
+    assert len(scores) == 2
+    assert len(spy.rerank_calls) == 1
+    assert spy.rerank_calls[0] == ("query", [long_text, "candidate"])
+
+
+# ---------------------------------------------------------------------------
+# 6. Empty input
+# ---------------------------------------------------------------------------
+
+
+async def test_empty_sparse_input_returns_empty_and_skips_downstream() -> None:
+    spy = _SpyEmbedder()
+    embedder = ChunkedEmbedder(spy)
+
+    out = await embedder.embed_sparse([])
+
+    assert out == []
+    assert spy.embed_sparse_calls == [], "no downstream call for empty input"
+
+
+# ---------------------------------------------------------------------------
+# 7. Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_chunked_embedder_implements_embedder_protocol() -> None:
+    embedder = ChunkedEmbedder(FakeEmbedder())
+    assert isinstance(embedder, Embedder)


### PR DESCRIPTION
## Summary

- Long inputs to `/v1/episodic` were silently failing: tei-sparse rejected anything over 512 tokens with HTTP 413, and the FastAPI write raised an uncaught exception. **Information-dense memories — multi-paragraph milestone summaries — were exactly the writes that bounced.** Tonight three Kong/sumi milestone captures hit this and lost their entire write.
- `ChunkedEmbedder` wraps the `Embedder` composite and honors SPLADE-v3's `max_position_embeddings=512` contract via the existing `TokenSlidingChunker` (already used by the artifact plane) plus per-chunk max-pool aggregation. All five planes (episodic / thoughts / concept / curated / artifact) become length-agnostic at the embedder layer.
- Dense + rerank pass through unchanged. Probed `tei-dense` `/info` live: `max_input_length=8192` for BGE-M3, no chunking needed.

## Why max-pool for sparse

SPLADE vectors are sparse over vocabulary; each non-zero entry asserts "this term has weight W in the document." Max across chunks preserves "term X appears in this document with weight ≥W," matching the underlying retrieval semantic. Averaging dilutes single-chunk terms; summing inflates. Max is the SPLADE long-doc standard.

## Why 460-token window (under 512 cap)

The chunker reuses the existing BGE-M3 tokenizer (XLM-Roberta SentencePiece), but SPLADE-v3 uses a different tokenizer (DistilBERT WordPiece). The ~10% mismatch is absorbed by the conservative window. Future enhancement: load SPLADE-v3's exact tokenizer — non-blocking.

## Test plan

- [x] `tests/test_chunked_embedder.py` — 11 new tests: short pass-through, long chunking, max-pool correctness, mixed batches, dense/rerank delegation, empty input, Embedder protocol conformance. 11/11 pass (1.4s).
- [x] Full unit suite: `uv run pytest tests/ --ignore=tests/integration` — 1314 passed, 195 skipped, 0 failures.
- [x] `uv run mypy src/musubi/embedding/chunked.py src/musubi/embedding/__init__.py src/musubi/api/bootstrap.py` — clean.
- [x] `uv run ruff check src/musubi/embedding/chunked.py tests/test_chunked_embedder.py src/musubi/api/bootstrap.py` — clean.
- [ ] Post-merge: deploy via `ansible-playbook deploy/ansible/update.yml -e changed_services='[\"core\"]'`, replay one of tonight's bounced milestones via `mcp__musubi__memory_capture`, query for tail content to confirm recall (the proof that aggregation actually preserves tail searchability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)