### PR TITLE
fix(embedding): raise TEI client char-truncate from 2048 to 32000

### DIFF
--- a/src/musubi/embedding/tei.py
+++ b/src/musubi/embedding/tei.py
@@ -44,7 +44,15 @@ from musubi.embedding.base import EmbeddingError
 
 _DEFAULT_TIMEOUT = 30.0
 _DEFAULT_MAX_BATCH_SIZE = 64
-_DEFAULT_MAX_INPUT_CHARS = 2048
+# Char-level safety belt against pathological inputs (~10s of KB). Sized
+# under BGE-M3's 8192-token native ceiling at a conservative ~4 chars/token,
+# so the dense encoder sees the full document on every realistic input.
+# The sparse path is independently length-aware via ChunkedEmbedder; this
+# truncate now matters only for the dense client and only at the upper
+# extreme. Before this raise it was 2048 — symmetric to the bug
+# ChunkedEmbedder closed for sparse, the dense path was silently losing
+# the tail of any long document.
+_DEFAULT_MAX_INPUT_CHARS = 32000
 _DEFAULT_RETRY_BACKOFF = 0.05
 
 # Per-client connection pool. 100 max inflight is generous — Musubi's worst

--- a/src/musubi/embedding/tei.py
+++ b/src/musubi/embedding/tei.py
@@ -44,15 +44,30 @@ from musubi.embedding.base import EmbeddingError
 
 _DEFAULT_TIMEOUT = 30.0
 _DEFAULT_MAX_BATCH_SIZE = 64
-# Char-level safety belt against pathological inputs (~10s of KB). Sized
-# under BGE-M3's 8192-token native ceiling at a conservative ~4 chars/token,
-# so the dense encoder sees the full document on every realistic input.
-# The sparse path is independently length-aware via ChunkedEmbedder; this
-# truncate now matters only for the dense client and only at the upper
-# extreme. Before this raise it was 2048 — symmetric to the bug
-# ChunkedEmbedder closed for sparse, the dense path was silently losing
-# the tail of any long document.
-_DEFAULT_MAX_INPUT_CHARS = 32000
+
+# Char-level safety belts. Split per-client because each model has a
+# different input contract and not every call site is wrapped in a
+# length-aware helper:
+#
+# DENSE: BGE-M3 accepts up to 8192 tokens natively. 32000 chars is an
+# English-leaning heuristic (~4 chars/token) — for CJK-heavy text it can
+# still overshoot the token cap; treat it as a "stop pathological MB-sized
+# inputs" guard, not a precise token bound. Pre-raise this was 2048,
+# silently losing the tail of any long English document from the dense
+# vector — symmetric to the bug ChunkedEmbedder closed for sparse.
+#
+# SPARSE: SPLADE-v3 has a hard 512-token cap. The length-aware path is
+# ChunkedEmbedder (wrapped around the composite embedder), but not every
+# call site goes through that wrapper — the lifecycle-worker constructs
+# TEISparseClient directly. Keep the sparse ceiling at the pre-raise
+# 2048 value so that direct-construction path stays bounded; deliberate
+# long-text callers route through ChunkedEmbedder.
+#
+# RERANKER: rerank inputs are short query + candidate strings by
+# convention. 2048 is plenty.
+_DEFAULT_MAX_INPUT_CHARS_DENSE = 32000
+_DEFAULT_MAX_INPUT_CHARS_SPARSE = 2048
+_DEFAULT_MAX_INPUT_CHARS_RERANKER = 2048
 _DEFAULT_RETRY_BACKOFF = 0.05
 
 # Per-client connection pool. 100 max inflight is generous — Musubi's worst
@@ -253,7 +268,7 @@ class TEIDenseClient:
         base_url: str,
         timeout: float = _DEFAULT_TIMEOUT,
         max_batch_size: int = _DEFAULT_MAX_BATCH_SIZE,
-        max_input_chars: int = _DEFAULT_MAX_INPUT_CHARS,
+        max_input_chars: int = _DEFAULT_MAX_INPUT_CHARS_DENSE,
         retry_backoff: float = _DEFAULT_RETRY_BACKOFF,
         limits: httpx.Limits = _DEFAULT_LIMITS,
     ) -> None:
@@ -299,7 +314,7 @@ class TEISparseClient:
         base_url: str,
         timeout: float = _DEFAULT_TIMEOUT,
         max_batch_size: int = _DEFAULT_MAX_BATCH_SIZE,
-        max_input_chars: int = _DEFAULT_MAX_INPUT_CHARS,
+        max_input_chars: int = _DEFAULT_MAX_INPUT_CHARS_SPARSE,
         retry_backoff: float = _DEFAULT_RETRY_BACKOFF,
         limits: httpx.Limits = _DEFAULT_LIMITS,
     ) -> None:
@@ -348,7 +363,7 @@ class TEIRerankerClient:
         *,
         base_url: str,
         timeout: float = _DEFAULT_TIMEOUT,
-        max_input_chars: int = _DEFAULT_MAX_INPUT_CHARS,
+        max_input_chars: int = _DEFAULT_MAX_INPUT_CHARS_RERANKER,
         retry_backoff: float = _DEFAULT_RETRY_BACKOFF,
         limits: httpx.Limits = _DEFAULT_LIMITS,
     ) -> None:

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -335,12 +335,14 @@ async def test_batch_encode_above_64_chunks_requests(httpx_mock: HTTPXMock) -> N
     assert len(httpx_mock.get_requests()) == 2
 
 
-async def test_truncate_content_to_default_safety_belt(httpx_mock: HTTPXMock) -> None:
-    """Char-truncate is now a safety belt at ~32k chars (under BGE-M3's 8192
-    native ceiling), not the practical limit it was at 2048. Inputs shorter
-    than the ceiling pass through unchanged; pathological inputs get cut at
-    the ceiling so the dense encoder never sees obviously-malformed
-    multi-MB blobs."""
+async def test_dense_client_truncates_to_default_safety_belt(httpx_mock: HTTPXMock) -> None:
+    """Dense char-truncate is now a safety belt at ~32k chars (under
+    BGE-M3's 8192 native ceiling), not the practical limit it was at 2048.
+    Inputs shorter than the ceiling pass through unchanged; pathological
+    inputs get cut at the ceiling so the dense encoder never sees
+    obviously-malformed multi-MB blobs."""
+    import json as _json
+
     long_text = "x" * 32002
     httpx_mock.add_response(
         url="http://tei-dense/embed",
@@ -353,16 +355,19 @@ async def test_truncate_content_to_default_safety_belt(httpx_mock: HTTPXMock) ->
 
     request = httpx_mock.get_request()
     assert request is not None
-    payload = request.content.decode()
-    assert "x" * 32000 in payload
-    assert "x" * 32001 not in payload
+    body = _json.loads(request.content.decode())
+    assert len(body["inputs"][0]) == 32000
 
 
-async def test_long_realistic_content_not_truncated(httpx_mock: HTTPXMock) -> None:
+async def test_dense_client_passes_long_realistic_content_untouched(
+    httpx_mock: HTTPXMock,
+) -> None:
     """A realistic long memory (~5000 chars) must pass through the dense
     client without truncation. Before the raise from 2048 to 32000, any
     content over ~2k chars silently lost its tail from the dense vector —
     symmetric to the SPLADE truncation B1 closed for sparse."""
+    import json as _json
+
     long_text = "x" * 5000
     httpx_mock.add_response(
         url="http://tei-dense/embed",
@@ -375,8 +380,54 @@ async def test_long_realistic_content_not_truncated(httpx_mock: HTTPXMock) -> No
 
     request = httpx_mock.get_request()
     assert request is not None
-    payload = request.content.decode()
-    assert "x" * 5000 in payload, "5000-char input must reach the encoder intact"
+    body = _json.loads(request.content.decode())
+    assert body["inputs"][0] == long_text
+
+
+async def test_sparse_client_keeps_pre_raise_safety_belt(httpx_mock: HTTPXMock) -> None:
+    """SPLADE-v3's input contract (512 tokens) hasn't moved. Sparse client
+    callers that don't go through ChunkedEmbedder (e.g. the lifecycle
+    worker constructing TEISparseClient directly) still rely on the
+    char-level 2048 guard to keep individual unwrapped writes from
+    tripping 413s. Pinning the test so the dense raise doesn't drag
+    sparse along with it."""
+    import json as _json
+
+    long_text = "x" * 3000
+    httpx_mock.add_response(
+        url="http://tei-sparse/embed_sparse",
+        method="POST",
+        json=[[]],
+    )
+
+    client = TEISparseClient(base_url="http://tei-sparse")
+    await client.embed_sparse([long_text])
+
+    request = httpx_mock.get_request()
+    assert request is not None
+    body = _json.loads(request.content.decode())
+    assert len(body["inputs"][0]) == 2048
+
+
+async def test_reranker_client_keeps_pre_raise_safety_belt(httpx_mock: HTTPXMock) -> None:
+    """Reranker inputs are short query + candidate strings by convention.
+    The 2048-char belt stays put."""
+    import json as _json
+
+    long_query = "q" * 3000
+    httpx_mock.add_response(
+        url="http://tei-reranker/rerank",
+        method="POST",
+        json=[{"index": 0, "score": 0.5}],
+    )
+
+    client = TEIRerankerClient(base_url="http://tei-reranker")
+    await client.rerank(long_query, ["candidate"])
+
+    request = httpx_mock.get_request()
+    assert request is not None
+    body = _json.loads(request.content.decode())
+    assert len(body["query"]) == 2048
 
 
 async def test_query_cache_hit_on_repeat() -> None:

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -335,8 +335,13 @@ async def test_batch_encode_above_64_chunks_requests(httpx_mock: HTTPXMock) -> N
     assert len(httpx_mock.get_requests()) == 2
 
 
-async def test_truncate_content_to_2048_chars(httpx_mock: HTTPXMock) -> None:
-    long_text = "x" * 2050
+async def test_truncate_content_to_default_safety_belt(httpx_mock: HTTPXMock) -> None:
+    """Char-truncate is now a safety belt at ~32k chars (under BGE-M3's 8192
+    native ceiling), not the practical limit it was at 2048. Inputs shorter
+    than the ceiling pass through unchanged; pathological inputs get cut at
+    the ceiling so the dense encoder never sees obviously-malformed
+    multi-MB blobs."""
+    long_text = "x" * 32002
     httpx_mock.add_response(
         url="http://tei-dense/embed",
         method="POST",
@@ -349,8 +354,29 @@ async def test_truncate_content_to_2048_chars(httpx_mock: HTTPXMock) -> None:
     request = httpx_mock.get_request()
     assert request is not None
     payload = request.content.decode()
-    assert "x" * 2048 in payload
-    assert "x" * 2049 not in payload
+    assert "x" * 32000 in payload
+    assert "x" * 32001 not in payload
+
+
+async def test_long_realistic_content_not_truncated(httpx_mock: HTTPXMock) -> None:
+    """A realistic long memory (~5000 chars) must pass through the dense
+    client without truncation. Before the raise from 2048 to 32000, any
+    content over ~2k chars silently lost its tail from the dense vector —
+    symmetric to the SPLADE truncation B1 closed for sparse."""
+    long_text = "x" * 5000
+    httpx_mock.add_response(
+        url="http://tei-dense/embed",
+        method="POST",
+        json=[[0.0] * DENSE_SIZE],
+    )
+
+    client = TEIDenseClient(base_url="http://tei-dense")
+    await client.embed_dense([long_text])
+
+    request = httpx_mock.get_request()
+    assert request is not None
+    payload = request.content.decode()
+    assert "x" * 5000 in payload, "5000-char input must reach the encoder intact"
 
 
 async def test_query_cache_hit_on_repeat() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -753,7 +753,7 @@ wheels = [
 
 [[package]]
 name = "musubi"
-version = "1.5.2"
+version = "1.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Symmetric to the B1 sparse fix in v1.5.3. ChunkedEmbedder closed the SPLADE 512-token hole; this PR closes the corresponding dense hole.

**Before:** `TEIDenseClient` char-truncated every input to 2048 chars before sending. BGE-M3 supports 8192 tokens natively (verified via `/info`). A long memory's full text was in storage, sparse vector covered everything via chunking + max-pool, but the dense vector only saw chars 0–2048. Hybrid retrieval was lopsided — tail content was findable only via sparse signal.

**After:** 32000-char ceiling (~8000 tokens at 4 chars/tok avg, under BGE-M3's 8192 native cap). Truncate stays as a safety belt against pathological multi-MB inputs; in normal operation, dense sees the same document the writer intended.

This was the third architectural hole surfaced during tonight's lifecycle audit — first the SPLADE truncation (fixed v1.5.3), second the Dockerfile cache permissions (fixed v1.5.3), now the symmetric dense truncation.

## Test plan

- [x] `tests/test_embedding.py` — replaced pinned-2048 test with default-safety-belt test at the new ceiling; added regression test for a realistic 5000-char input passing through intact.
- [x] `uv run pytest tests/test_embedding.py tests/test_chunked_embedder.py` — 54 passed, 16 skipped, 0 failures.
- [x] `uv run ruff format --check . && uv run ruff check . && uv run mypy src tests` — all clean.
- [ ] Post-merge: cascades through release-please → digest pin → ansible deploy → live verify (will be folded into the v1.5.4 verification arc alongside the larger lifecycle redesign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)