### PR TITLE
feat(retrieve): federate hybrid retrieval by identity_family

### DIFF
--- a/src/musubi/retrieve/fast.py
+++ b/src/musubi/retrieve/fast.py
@@ -377,11 +377,12 @@ def _cache_key(
     """Cache key scoped to identity family, not exact namespace.
 
     Retrieval federates at the identity level (see
-    `musubi.retrieve.hybrid._build_filter`), so two queries from
-    different presences of the same identity (`aoi/command-chair` vs
-    `aoi/voice`) produce identical results and SHOULD share a cache
-    entry. Keying on the full namespace would split that cache and
-    miss on every cross-substrate query.
+    ``musubi.retrieve.hybrid._build_filter``), so two queries from
+    different presences of the same identity — e.g. caller namespaces
+    ``aoi/command-chair/episodic`` vs ``aoi/voice/episodic`` — produce
+    identical results and SHOULD share a cache entry. Keying on the
+    full namespace would split that cache and miss on every cross-
+    substrate query.
     """
     from musubi.types.common import family_of
 

--- a/src/musubi/retrieve/fast.py
+++ b/src/musubi/retrieve/fast.py
@@ -374,7 +374,18 @@ def _cache_key(
     limit: int,
     state_filter: Sequence[LifecycleState],
 ) -> tuple[Any, ...]:
-    return (namespace, query, tuple(collections), limit, tuple(state_filter))
+    """Cache key scoped to identity family, not exact namespace.
+
+    Retrieval federates at the identity level (see
+    `musubi.retrieve.hybrid._build_filter`), so two queries from
+    different presences of the same identity (`aoi/command-chair` vs
+    `aoi/voice`) produce identical results and SHOULD share a cache
+    entry. Keying on the full namespace would split that cache and
+    miss on every cross-substrate query.
+    """
+    from musubi.types.common import family_of
+
+    return (family_of(namespace), query, tuple(collections), limit, tuple(state_filter))
 
 
 __all__ = [

--- a/src/musubi/retrieve/hybrid.py
+++ b/src/musubi/retrieve/hybrid.py
@@ -348,15 +348,29 @@ def _build_filter(
 
     Federates at the identity level: the filter scopes to
     ``identity_family`` (derived from the namespace's first path
-    component) rather than the exact namespace. This makes
-    ``aoi/command-chair``, ``aoi/voice``, ``aoi/shared`` etc. all
-    visible to one another as one continuous Aoi memory stream — same
-    for every identity in the house. Per-substrate forensic queries
-    can post-filter on `payload["namespace"]` from results; for
+    component) rather than the exact namespace. Every presence of one
+    identity — e.g. ``aoi/command-chair/episodic``,
+    ``aoi/voice/episodic``, ``aoi/shared/episodic`` — carries
+    ``identity_family="aoi"`` and is therefore visible to retrieval
+    from any of the others. Per-substrate forensic queries can
+    post-filter on ``payload["namespace"]`` from the result set; for
     semantic retrieval, identity is the right scope.
 
-    See `family_of` in musubi.types.common; see the v1.5.5 federation
-    PR for the architectural rationale.
+    **Migration contract.** This filter assumes every persisted point
+    carries ``identity_family`` in its payload. New writes get the
+    field automatically via the ``MusubiObject`` validator; existing
+    points are populated by ``scripts/backfill_identity_family.py``.
+    The deploy order is therefore:
+
+        1. Deploy the version that adds the field + validator (#332).
+        2. Run the backfill script — confirm 100% updated.
+        3. Deploy this version (the retrieval change).
+
+    Steps 1 and 3 can be the same release if step 2 runs in between.
+    Skipping step 2 will silently exclude pre-deploy points from
+    retrieval until backfill catches up.
+
+    See ``family_of`` in ``musubi.types.common``.
     """
     must: list[models.Condition] = [
         models.FieldCondition(

--- a/src/musubi/retrieve/hybrid.py
+++ b/src/musubi/retrieve/hybrid.py
@@ -14,7 +14,7 @@ from qdrant_client import QdrantClient, models
 from musubi.config import get_settings
 from musubi.embedding.base import Embedder
 from musubi.store.specs import DENSE_VECTOR_NAME, SPARSE_VECTOR_NAME, collection_has_sparse
-from musubi.types.common import Err, LifecycleState, Namespace, Ok, Result
+from musubi.types.common import Err, LifecycleState, Namespace, Ok, Result, family_of
 
 HYBRID_PREFETCH_LIMIT = 50
 _DEFAULT_VISIBLE_STATES: tuple[LifecycleState, ...] = ("matured", "promoted")
@@ -344,8 +344,25 @@ def _build_filter(
     state_filter: Sequence[LifecycleState] | None,
     include_archived: bool,
 ) -> models.Filter:
+    """Build the Qdrant filter for a hybrid search.
+
+    Federates at the identity level: the filter scopes to
+    ``identity_family`` (derived from the namespace's first path
+    component) rather than the exact namespace. This makes
+    ``aoi/command-chair``, ``aoi/voice``, ``aoi/shared`` etc. all
+    visible to one another as one continuous Aoi memory stream — same
+    for every identity in the house. Per-substrate forensic queries
+    can post-filter on `payload["namespace"]` from results; for
+    semantic retrieval, identity is the right scope.
+
+    See `family_of` in musubi.types.common; see the v1.5.5 federation
+    PR for the architectural rationale.
+    """
     must: list[models.Condition] = [
-        models.FieldCondition(key="namespace", match=models.MatchValue(value=namespace))
+        models.FieldCondition(
+            key="identity_family",
+            match=models.MatchValue(value=family_of(namespace)),
+        )
     ]
     states = state_filter
     if states is None and not include_archived:

--- a/tests/retrieve/test_hybrid.py
+++ b/tests/retrieve/test_hybrid.py
@@ -188,13 +188,19 @@ async def test_identity_family_filter_applied_not_namespace() -> None:
     musubi.retrieve.hybrid for the rationale."""
     spy, _result = await _call()
 
+    from musubi.types.common import family_of
+
     conditions = _filter_conditions(spy.calls[0])
-    # Identity-family filter IS present
+    # Identity-family filter IS present — coupled to family_of() so this
+    # test exercises the same derivation logic the runtime uses, not a
+    # hard-coded expected value that would silently rot if NAMESPACE
+    # changes.
+    expected_family = family_of(NAMESPACE)
     assert any(
         isinstance(condition, models.FieldCondition)
         and condition.key == "identity_family"
         and isinstance(condition.match, models.MatchValue)
-        and condition.match.value == "tenant"  # first component of NAMESPACE
+        and condition.match.value == expected_family
         for condition in conditions
     ), "filter must scope to identity_family for cross-substrate federation"
 

--- a/tests/retrieve/test_hybrid.py
+++ b/tests/retrieve/test_hybrid.py
@@ -180,17 +180,30 @@ async def test_rrf_fusion_requested_server_side() -> None:
 
 
 @pytest.mark.asyncio
-async def test_namespace_filter_always_applied() -> None:
+async def test_identity_family_filter_applied_not_namespace() -> None:
+    """Hybrid retrieval filters on `identity_family` (the federation key),
+    not on the exact namespace. The caller passes "tenant/presence/plane"
+    but the filter scopes to "tenant" so every substrate under that
+    identity is visible to the search. See `_build_filter` in
+    musubi.retrieve.hybrid for the rationale."""
     spy, _result = await _call()
 
     conditions = _filter_conditions(spy.calls[0])
+    # Identity-family filter IS present
     assert any(
         isinstance(condition, models.FieldCondition)
-        and condition.key == "namespace"
+        and condition.key == "identity_family"
         and isinstance(condition.match, models.MatchValue)
-        and condition.match.value == NAMESPACE
+        and condition.match.value == "tenant"  # first component of NAMESPACE
         for condition in conditions
-    )
+    ), "filter must scope to identity_family for cross-substrate federation"
+
+    # Exact-namespace filter is GONE — federation means we no longer
+    # gate retrieval at substrate granularity.
+    assert not any(
+        isinstance(condition, models.FieldCondition) and condition.key == "namespace"
+        for condition in conditions
+    ), "namespace filter should not be present — identity_family is the scope"
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -753,7 +753,7 @@ wheels = [
 
 [[package]]
 name = "musubi"
-version = "1.5.4"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Second stair on the identity-family federation staircase. **Depends on #332** (foundation: identity_family field + Qdrant index + backfill). Switches hybrid retrieval from per-namespace filtering to per-identity-family filtering — so a search from `aoi/command-chair` sees memories captured in `aoi/voice`, `aoi/shared`, etc. as one continuous Aoi memory stream.

PR base is `feat/identity-family-federation` (#332's branch) so review/merge order is enforced: #332 first, then this one.

## Eric's framing

> "yes aoi/* is Aoi. Use the namespaces to know where it came from and in troubleshooting bugs to follow the path... but in retrieval and knowledge, it is all just Aoi."

## What changed

- **`musubi.retrieve.hybrid._build_filter`**: Qdrant filter scopes to `identity_family = family_of(namespace)` instead of the exact namespace. Every retrieval module (`fast`, `blended`, `deep`, `orchestration`) routes through this single chokepoint, so federation applies uniformly. No parameter threading needed — the simplest possible architectural change for the load-bearing effect.
- **`musubi.retrieve.fast._cache_key`**: key on identity family instead of full namespace. Same-identity queries from different presences now share cache entries.
- Replaced `test_namespace_filter_always_applied` with `test_identity_family_filter_applied_not_namespace`. Pins the new contract: `identity_family` IS present, `namespace` is GONE from the filter.

## What stays per-namespace

- **Storage**: every point retains its full namespace for provenance/debug/forensics.
- **Plane CRUD** (get/update/delete by object_id within a namespace): unchanged. Federation is a *retrieval* concern.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/integration` — 1334 passed, 195 skipped, 0 failures.
- [x] `uv run mypy src tests` + `uv run ruff format --check . && uv run ruff check .` — clean.
- [ ] Post-deploy v1.5.5: Aoi recall test from design doc — from command-chair-Aoi, search for `aoi/voice` content (2026-05-09 vision-model design conversation). Confirm it surfaces in default search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)