### PR TITLE
feat(lifecycle): per-family synthesis with candidates pool

### DIFF
--- a/src/musubi/lifecycle/synthesis.py
+++ b/src/musubi/lifecycle/synthesis.py
@@ -246,12 +246,21 @@ class SynthesisCursor:
     def _family_of(value: str) -> str:
         """Reduce a namespace-like input to the identity family.
 
-        Accepts either an identity family (no slash) or a namespace
-        (with slashes); returns the first path component in both
-        cases. This lets pre-migration callers pass a namespace and
-        get the right cursor without changing their signature.
+        Thin wrapper around the public ``musubi.types.common.family_of``
+        with the additional concession that bare-family inputs (no
+        slash) pass through as-is. ``family_of`` itself raises on
+        inputs without a separator because the public contract is
+        "give me a namespace, get back the family"; this wrapper
+        exists because cursor callers legitimately pass either form
+        (e.g. the scheduler passes "aoi" while legacy callers pass
+        "aoi/command-chair"). Centralising on the public helper for
+        the namespace case keeps the two implementations from drifting.
         """
-        return value.split("/", 1)[0] if "/" in value else value
+        if "/" not in value:
+            return value
+        from musubi.types.common import family_of
+
+        return family_of(value)
 
     # ------------------------------------------------------------------
     # Cursor — high-water mark per identity family
@@ -296,8 +305,13 @@ class SynthesisCursor:
     # Candidates — per-memory eligibility, not lost on cursor advance
     # ------------------------------------------------------------------
 
-    def upsert_candidate(self, family: str, memory_object_id: str, now_epoch: float) -> None:
-        """Mark a memory as a synthesis candidate; bump attempts on repeat."""
+    def upsert_candidate(self, family: str, memory_object_id: str, *, now_epoch: float) -> None:
+        """Mark a memory as a synthesis candidate; bump attempts on repeat.
+
+        ``now_epoch`` is keyword-only for consistency with the sibling
+        timing-aware methods (``get_candidates``, ``prune_aged_candidates``)
+        and so call sites read self-documentingly.
+        """
         with self._connect() as conn:
             conn.execute(
                 "INSERT INTO synthesis_candidates "
@@ -509,15 +523,15 @@ async def synthesis_run(
     # Step 1b: Pull unclustered candidates from prior sweeps within TTL.
     # Candidates are stored by object_id (KSUID), but Qdrant identifies
     # points by point_id (UUID5 derived from object_id) — translate via
-    # the episodic plane's `_point_id` helper so retrieve actually finds them.
-    from musubi.planes.episodic.plane import _point_id as _episodic_point_id
+    # the episodic plane's public `episodic_point_id` helper.
+    from musubi.planes.episodic.plane import episodic_point_id
 
     candidate_ids = cursor.get_candidates(family, ttl_sec=cfg.candidate_ttl_sec, now_epoch=now)
     candidate_ids_to_fetch = [oid for oid in candidate_ids if oid not in seen_ids]
     if candidate_ids_to_fetch:
         retrieved = client.retrieve(
             collection_name=collection_for_plane("episodic"),
-            ids=[_episodic_point_id(oid) for oid in candidate_ids_to_fetch],
+            ids=[episodic_point_id(oid) for oid in candidate_ids_to_fetch],
             with_payload=True,
             with_vectors=True,
         )
@@ -547,7 +561,7 @@ async def synthesis_run(
         # scanned memories and existing candidates we just re-pulled
         # (the latter bumping their attempts counter).
         for mwv in memories_with_vectors:
-            cursor.upsert_candidate(family, mwv.memory.object_id, now)
+            cursor.upsert_candidate(family, mwv.memory.object_id, now_epoch=now)
         if memories_with_vectors:
             cursor.set(family, max_epoch)
         pruned = cursor.prune_aged_candidates(family, ttl_sec=cfg.candidate_ttl_sec, now_epoch=now)
@@ -727,7 +741,7 @@ async def synthesis_run(
         if mwv.memory.object_id not in clustered_memory_ids
     ]
     for oid in unclustered_ids:
-        cursor.upsert_candidate(family, oid, now)
+        cursor.upsert_candidate(family, oid, now_epoch=now)
     pruned = cursor.prune_aged_candidates(family, ttl_sec=cfg.candidate_ttl_sec, now_epoch=now)
 
     # Step 6: Cursor (high-water mark only — eligibility is in candidates)

--- a/src/musubi/lifecycle/synthesis.py
+++ b/src/musubi/lifecycle/synthesis.py
@@ -174,15 +174,64 @@ def _threshold_cluster(
 # ---------------------------------------------------------------------------
 
 _CURSOR_SCHEMA = """
+-- v1 cursor: per-namespace high-water mark. Left in place for any code
+-- that still consults it, but new code (v1.5.5+) uses
+-- `synthesis_family_cursor` keyed on identity_family.
 CREATE TABLE IF NOT EXISTS synthesis_cursor (
     namespace TEXT PRIMARY KEY,
     last_processed_epoch REAL NOT NULL
 );
+
+-- v2 cursor: per-identity-family. Federates synthesis across substrates
+-- (aoi/voice + aoi/command-chair share one cursor for identity_family="aoi").
+CREATE TABLE IF NOT EXISTS synthesis_family_cursor (
+    identity_family TEXT PRIMARY KEY,
+    last_processed_epoch REAL NOT NULL
+);
+
+-- Candidate pool: memories that have been seen but haven't yet
+-- participated in a successful cluster. Carried forward across runs
+-- (within a TTL window) so slow-accumulating patterns can eventually
+-- cluster as more peer memories arrive — fixing the cursor-skip flaw
+-- where memories that didn't cluster on first pass were lost forever.
+CREATE TABLE IF NOT EXISTS synthesis_candidates (
+    identity_family TEXT NOT NULL,
+    memory_object_id TEXT NOT NULL,
+    first_seen_epoch REAL NOT NULL,
+    last_attempt_epoch REAL NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (identity_family, memory_object_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_candidates_age
+    ON synthesis_candidates(identity_family, first_seen_epoch);
 """
 
 
 class SynthesisCursor:
-    """Tracks the last run per-namespace to avoid re-processing matured episodics."""
+    """Tracks synthesis state across runs.
+
+    Two coordinated stores:
+
+    1. **Per-identity-family cursor** — high-water mark of "memories
+       scanned so far." Used as a performance optimization to skip
+       already-seen matured episodics during the new-memory pull.
+       This is NOT a correctness gate — eligibility for clustering
+       is determined by the candidates table, not by whether a
+       memory's epoch is above the cursor.
+
+    2. **Candidate pool** — per-(family, memory) state for "this
+       memory has been seen but didn't successfully cluster yet."
+       Carried forward across runs within a TTL window so slow-
+       accumulating patterns can eventually form clusters when peer
+       memories arrive in later runs. Successful clustering removes
+       the candidate row; aging past TTL removes it without success.
+
+    The pre-v1.5.5 `get(namespace)` / `set(namespace)` methods are
+    retained for any callers that haven't migrated yet, but they now
+    map to the family-keyed cursor underneath: namespaces of the form
+    `<tenant>/<presence>` reduce to `<tenant>` for cursor lookup.
+    """
 
     def __init__(self, *, db_path: Path) -> None:
         self._db_path = Path(db_path)
@@ -193,22 +242,125 @@ class SynthesisCursor:
     def _connect(self) -> sqlite3.Connection:
         return sqlite3.connect(str(self._db_path))
 
-    def get(self, namespace: str) -> float:
+    @staticmethod
+    def _family_of(value: str) -> str:
+        """Reduce a namespace-like input to the identity family.
+
+        Accepts either an identity family (no slash) or a namespace
+        (with slashes); returns the first path component in both
+        cases. This lets pre-migration callers pass a namespace and
+        get the right cursor without changing their signature.
+        """
+        return value.split("/", 1)[0] if "/" in value else value
+
+    # ------------------------------------------------------------------
+    # Cursor — high-water mark per identity family
+    # ------------------------------------------------------------------
+
+    def get(self, namespace_or_family: str) -> float:
+        family = self._family_of(namespace_or_family)
         with self._connect() as conn:
             row = conn.execute(
-                "SELECT last_processed_epoch FROM synthesis_cursor WHERE namespace = ?",
-                (namespace,),
+                "SELECT last_processed_epoch FROM synthesis_family_cursor "
+                "WHERE identity_family = ?",
+                (family,),
             ).fetchone()
         return float(row[0]) if row else 0.0
 
-    def set(self, namespace: str, value: float) -> None:
+    def set(self, namespace_or_family: str, value: float) -> None:
+        family = self._family_of(namespace_or_family)
         with self._connect() as conn:
             conn.execute(
-                "INSERT INTO synthesis_cursor (namespace, last_processed_epoch) "
-                "VALUES (?, ?) ON CONFLICT(namespace) DO UPDATE SET "
+                "INSERT INTO synthesis_family_cursor "
+                "(identity_family, last_processed_epoch) VALUES (?, ?) "
+                "ON CONFLICT(identity_family) DO UPDATE SET "
                 "last_processed_epoch = excluded.last_processed_epoch",
-                (namespace, value),
+                (family, value),
             )
+            conn.commit()
+
+    def reset(self, family: str | None = None) -> None:
+        """Clear cursor state. Used by the backfill CLI to force a
+        full re-synthesis pass across all matured memories."""
+        with self._connect() as conn:
+            if family is None:
+                conn.execute("DELETE FROM synthesis_family_cursor")
+            else:
+                conn.execute(
+                    "DELETE FROM synthesis_family_cursor WHERE identity_family = ?",
+                    (family,),
+                )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    # Candidates — per-memory eligibility, not lost on cursor advance
+    # ------------------------------------------------------------------
+
+    def upsert_candidate(self, family: str, memory_object_id: str, now_epoch: float) -> None:
+        """Mark a memory as a synthesis candidate; bump attempts on repeat."""
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO synthesis_candidates "
+                "(identity_family, memory_object_id, first_seen_epoch, "
+                "last_attempt_epoch, attempts) VALUES (?, ?, ?, ?, 1) "
+                "ON CONFLICT(identity_family, memory_object_id) DO UPDATE SET "
+                "last_attempt_epoch = excluded.last_attempt_epoch, "
+                "attempts = synthesis_candidates.attempts + 1",
+                (family, memory_object_id, now_epoch, now_epoch),
+            )
+            conn.commit()
+
+    def get_candidates(self, family: str, *, ttl_sec: float, now_epoch: float) -> list[str]:
+        """Return memory object_ids currently within the candidate TTL window.
+
+        Memories older than TTL are NOT returned here (they're filtered
+        out as if they had been pruned, even if `prune_aged_candidates`
+        hasn't run yet — defense against a worker restart between sweeps).
+        """
+        cutoff = now_epoch - ttl_sec
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT memory_object_id FROM synthesis_candidates "
+                "WHERE identity_family = ? AND first_seen_epoch >= ?",
+                (family, cutoff),
+            ).fetchall()
+        return [str(row[0]) for row in rows]
+
+    def remove_candidates(self, family: str, memory_object_ids: list[str]) -> None:
+        """Remove successfully-clustered memories from the candidate pool."""
+        if not memory_object_ids:
+            return
+        placeholders = ",".join("?" * len(memory_object_ids))
+        with self._connect() as conn:
+            conn.execute(
+                f"DELETE FROM synthesis_candidates WHERE identity_family = ? "
+                f"AND memory_object_id IN ({placeholders})",
+                (family, *memory_object_ids),
+            )
+            conn.commit()
+
+    def prune_aged_candidates(self, family: str, *, ttl_sec: float, now_epoch: float) -> int:
+        """Delete candidate rows older than TTL. Returns number pruned."""
+        cutoff = now_epoch - ttl_sec
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "DELETE FROM synthesis_candidates "
+                "WHERE identity_family = ? AND first_seen_epoch < ?",
+                (family, cutoff),
+            )
+            conn.commit()
+            return cursor.rowcount or 0
+
+    def reset_candidates(self, family: str | None = None) -> None:
+        """Clear the candidate pool. Used by backfill CLI."""
+        with self._connect() as conn:
+            if family is None:
+                conn.execute("DELETE FROM synthesis_candidates")
+            else:
+                conn.execute(
+                    "DELETE FROM synthesis_candidates WHERE identity_family = ?",
+                    (family,),
+                )
             conn.commit()
 
 
@@ -219,18 +371,41 @@ class SynthesisCursor:
 
 @dataclass(frozen=True)
 class SynthesisConfig:
-    """Parameters for the synthesis job."""
+    """Parameters for the synthesis job.
 
-    cluster_threshold: float = 0.80
+    Defaults are the generous ones — same for every identity, no
+    per-family stripping. The per-family override path exists for
+    data-driven tuning later (auto-tune from each family's pairwise
+    distribution) but ships empty in v1.5.5.
+    """
+
+    cluster_threshold: float = 0.70
     match_threshold: float = 0.85
     contradiction_min_similarity: float = 0.75
     contradiction_max_similarity: float = 0.85
+    # min_cluster_size stays at 3 — the concept plane enforces a "min 3
+    # source memories per concept" invariant (see _MIN_MERGED_FROM in
+    # musubi.planes.concept.plane). A concept by definition is a pattern
+    # across at least three observations, not two. Relaxing this would
+    # weaken the meaning of "concept" downstream.
     min_cluster_size: int = 3
+    # Candidates pool: memories that didn't cluster on their first pass
+    # stay eligible for the next sweep until this many seconds elapse.
+    # 30 days is a human-scale window — slow-accumulating patterns over
+    # weeks still find each other; truly stranded memories eventually
+    # age out instead of dragging on every sweep forever.
+    candidate_ttl_sec: int = 30 * 86400
 
 
 @dataclass(frozen=True)
 class SynthesisReport:
-    """Results of a single synthesis run."""
+    """Results of a single synthesis run.
+
+    The `namespace` field carries the identity family in the v1.5.5+
+    flow (e.g. "aoi"), not a full tenant/presence/plane namespace.
+    Renamed semantically but kept its name for backward-compat with any
+    log scrapers / dashboards that parse it.
+    """
 
     namespace: str
     memories_selected: int
@@ -239,11 +414,21 @@ class SynthesisReport:
     concepts_reinforced: int
     contradictions_detected: int
     cursor_advanced_to: float | None = None
+    candidates_pruned: int = 0
+    candidates_carried_forward: int = 0
 
 
 # ---------------------------------------------------------------------------
 # The Job
 # ---------------------------------------------------------------------------
+
+
+_FAMILY_SYNTHESIS_PRESENCE = "shared"
+"""Convention: family-level synthesis writes concepts to
+``<family>/shared/concept``. The `shared` presence already means
+"identity-level, not substrate-specific" (see e.g. aoi/shared/episodic
+which carries Aoi's joy entry, visual identity, codeword authority
+— all identity-wide things)."""
 
 
 @_instrument_synthesis_job
@@ -255,16 +440,34 @@ async def synthesis_run(
     cursor: SynthesisCursor,
     namespace: str,
     config: SynthesisConfig | None = None,
+    *,
+    now_epoch: float | None = None,
 ) -> SynthesisReport:
-    """Run the synthesis loop for a single namespace."""
+    """Run the synthesis loop for one identity family.
+
+    The ``namespace`` parameter accepts either a bare identity family
+    ("aoi") or a legacy namespace ("aoi/command-chair"); both reduce
+    to the same family via the cursor helper. Synthesis scopes to
+    every matured episodic with `identity_family=<family>`,
+    regardless of which substrate captured it.
+
+    The flow now uses the candidates pool to retain memories that
+    didn't cluster on a previous pass — they remain eligible for
+    `candidate_ttl_sec` (default 30 days), so slow-accumulating
+    patterns can eventually form clusters once peer memories arrive.
+
+    Concepts are written to ``<family>/shared/concept``.
+    """
     cfg = config or SynthesisConfig()
-    cursor_val = cursor.get(namespace)
+    family = cursor._family_of(namespace)
+    now = now_epoch if now_epoch is not None else time.time()
+    cursor_val = cursor.get(family)
     memories_with_vectors: list[MemoryWithVector] = []
+    seen_ids: set[str] = set()
 
-    eps_ns = f"{namespace}/episodic"
-    conc_ns = f"{namespace}/concept"
+    conc_ns = f"{family}/{_FAMILY_SYNTHESIS_PRESENCE}/concept"
 
-    # Step 1: Selection
+    # Step 1a: Pull new matured memories (above the cursor high-water mark).
     offset: Any = None
     max_epoch = cursor_val
     while True:
@@ -272,7 +475,9 @@ async def synthesis_run(
             collection_name=collection_for_plane("episodic"),
             scroll_filter=models.Filter(
                 must=[
-                    models.FieldCondition(key="namespace", match=models.MatchValue(value=eps_ns)),
+                    models.FieldCondition(
+                        key="identity_family", match=models.MatchValue(value=family)
+                    ),
                     models.FieldCondition(key="state", match=models.MatchValue(value="matured")),
                     models.FieldCondition(key="updated_epoch", range=models.Range(gt=cursor_val)),
                 ]
@@ -295,16 +500,67 @@ async def synthesis_run(
                     memories_with_vectors.append(
                         MemoryWithVector(memory, cast(list[float], vector))
                     )
+                    seen_ids.add(memory.object_id)
                     if memory.updated_epoch and memory.updated_epoch > max_epoch:
                         max_epoch = memory.updated_epoch
         if offset is None:
             break
 
+    # Step 1b: Pull unclustered candidates from prior sweeps within TTL.
+    # Candidates are stored by object_id (KSUID), but Qdrant identifies
+    # points by point_id (UUID5 derived from object_id) — translate via
+    # the episodic plane's `_point_id` helper so retrieve actually finds them.
+    from musubi.planes.episodic.plane import _point_id as _episodic_point_id
+
+    candidate_ids = cursor.get_candidates(family, ttl_sec=cfg.candidate_ttl_sec, now_epoch=now)
+    candidate_ids_to_fetch = [oid for oid in candidate_ids if oid not in seen_ids]
+    if candidate_ids_to_fetch:
+        retrieved = client.retrieve(
+            collection_name=collection_for_plane("episodic"),
+            ids=[_episodic_point_id(oid) for oid in candidate_ids_to_fetch],
+            with_payload=True,
+            with_vectors=True,
+        )
+        for r in retrieved:
+            if (
+                r.payload
+                and r.vector
+                and isinstance(r.vector, dict)
+                and DENSE_VECTOR_NAME in r.vector
+            ):
+                # Belt: only accept if still matured (a candidate could
+                # have been demoted/archived since being marked).
+                if r.payload.get("state") != "matured":
+                    continue
+                memory = EpisodicMemory.model_validate(r.payload)
+                vector = r.vector[DENSE_VECTOR_NAME]
+                if isinstance(vector, list):
+                    memories_with_vectors.append(
+                        MemoryWithVector(memory, cast(list[float], vector))
+                    )
+                    seen_ids.add(memory.object_id)
+
     if len(memories_with_vectors) < cfg.min_cluster_size:
+        # Not enough memories to form even the smallest cluster. Every
+        # one of them gets upserted as a candidate so it stays eligible
+        # for the next sweep when more peers may arrive — both newly
+        # scanned memories and existing candidates we just re-pulled
+        # (the latter bumping their attempts counter).
+        for mwv in memories_with_vectors:
+            cursor.upsert_candidate(family, mwv.memory.object_id, now)
         if memories_with_vectors:
-            cursor.set(namespace, max_epoch)
+            cursor.set(family, max_epoch)
+        pruned = cursor.prune_aged_candidates(family, ttl_sec=cfg.candidate_ttl_sec, now_epoch=now)
         return SynthesisReport(
-            namespace, len(memories_with_vectors), 0, 0, 0, 0, cursor_advanced_to=max_epoch
+            namespace=family,
+            memories_selected=len(memories_with_vectors),
+            clusters_formed=0,
+            concepts_created=0,
+            concepts_reinforced=0,
+            contradictions_detected=0,
+            cursor_advanced_to=max_epoch,
+            candidates_pruned=pruned,
+            candidates_carried_forward=len(memories_with_vectors),
         )
 
     # Step 2: Clustering
@@ -334,6 +590,7 @@ async def synthesis_run(
     concepts_reinforced = 0
     contradictions_detected = 0
     current_run_concepts: list[SynthesizedConcept] = []
+    clustered_memory_ids: set[str] = set()
 
     for cluster_mwvs in clusters:
         cluster_memories = [mwv.memory for mwv in cluster_mwvs]
@@ -341,28 +598,41 @@ async def synthesis_run(
             output = await ollama.synthesize_cluster(SynthesisInput(cluster_memories))
             if not output:
                 logger.error("LLM unavailable during synthesis_run, skipping run")
+                # Don't advance the cursor or remove candidates on early
+                # exit — let the next sweep retry from the same state.
                 return SynthesisReport(
-                    namespace,
-                    len(memories_with_vectors),
-                    len(clusters),
-                    concepts_created,
-                    concepts_reinforced,
-                    contradictions_detected,
+                    namespace=family,
+                    memories_selected=len(memories_with_vectors),
+                    clusters_formed=len(clusters),
+                    concepts_created=concepts_created,
+                    concepts_reinforced=concepts_reinforced,
+                    contradictions_detected=contradictions_detected,
+                    candidates_carried_forward=len(candidate_ids),
                 )
         except Exception as e:
             logger.warning("Synthesis failed for cluster, skipping: %s", e)
             continue
 
+        # Cluster successfully synthesized — mark its members as clustered.
+        for m in cluster_memories:
+            clustered_memory_ids.add(m.object_id)
+
         embed_text = f"{output.title}\n\n{output.rationale}"
         content_vector = (await embedder.embed_dense([embed_text]))[0]
 
+        # Existing-match query federates: an old concept living in
+        # `<family>/voice/concept` can be reinforced by a new cluster
+        # discovered from `<family>/command-chair/episodic`, because
+        # both share identity_family=<family>.
         existing_matches = client.query_points(
             collection_name=collection_for_plane("concept"),
             query=content_vector,
             using=DENSE_VECTOR_NAME,
             query_filter=models.Filter(
                 must=[
-                    models.FieldCondition(key="namespace", match=models.MatchValue(value=conc_ns)),
+                    models.FieldCondition(
+                        key="identity_family", match=models.MatchValue(value=family)
+                    ),
                     models.FieldCondition(
                         key="state", match=models.MatchAny(any=["matured", "promoted"])
                     ),
@@ -372,23 +642,24 @@ async def synthesis_run(
         ).points
 
         matched_concept_id = None
+        matched_concept_ns = None
         if existing_matches and existing_matches[0].score >= cfg.match_threshold:
-            matched_concept_id = (
-                cast(str, existing_matches[0].payload["object_id"])
-                if existing_matches[0].payload
-                else None
-            )
+            payload = existing_matches[0].payload or {}
+            matched_concept_id = cast(str | None, payload.get("object_id"))
+            matched_concept_ns = cast(str | None, payload.get("namespace"))
 
-        if matched_concept_id:
+        if matched_concept_id and matched_concept_ns:
             for memory in cluster_memories:
                 await concept_plane.reinforce(
-                    namespace=conc_ns,
+                    namespace=matched_concept_ns,
                     object_id=matched_concept_id,
                     additional_source=memory.object_id,
                 )
 
             concepts_reinforced += 1
-            refreshed = await concept_plane.get(namespace=conc_ns, object_id=matched_concept_id)
+            refreshed = await concept_plane.get(
+                namespace=matched_concept_ns, object_id=matched_concept_id
+            )
             if refreshed:
                 current_run_concepts.append(refreshed)
         else:
@@ -422,7 +693,12 @@ async def synthesis_run(
                         (concept_a.object_id, concept_b.object_id),
                         (concept_b.object_id, concept_a.object_id),
                     ]:
-                        curr = await concept_plane.get(namespace=conc_ns, object_id=cid)
+                        curr = await concept_plane.get(
+                            namespace=concept_a.namespace
+                            if cid == concept_a.object_id
+                            else concept_b.namespace,
+                            object_id=cid,
+                        )
                         if curr:
                             new_contradicts = list({*curr.contradicts, other_id})
                             client.set_payload(
@@ -438,17 +714,35 @@ async def synthesis_run(
                             )
                     contradictions_detected += 1
 
-    # Step 6: Cursor
-    cursor.set(namespace, max_epoch)
+    # Step 5: Candidates pool maintenance
+    # - Remove members of successful clusters (they've done their job).
+    # - Upsert any memory that DIDN'T cluster so it stays eligible
+    #   for the next sweep until TTL expires.
+    # - Prune candidates older than TTL.
+    if clustered_memory_ids:
+        cursor.remove_candidates(family, list(clustered_memory_ids))
+    unclustered_ids = [
+        mwv.memory.object_id
+        for mwv in memories_with_vectors
+        if mwv.memory.object_id not in clustered_memory_ids
+    ]
+    for oid in unclustered_ids:
+        cursor.upsert_candidate(family, oid, now)
+    pruned = cursor.prune_aged_candidates(family, ttl_sec=cfg.candidate_ttl_sec, now_epoch=now)
+
+    # Step 6: Cursor (high-water mark only — eligibility is in candidates)
+    cursor.set(family, max_epoch)
 
     return SynthesisReport(
-        namespace=namespace,
+        namespace=family,
         memories_selected=len(memories_with_vectors),
         clusters_formed=len(clusters),
         concepts_created=concepts_created,
         concepts_reinforced=concepts_reinforced,
         contradictions_detected=contradictions_detected,
         cursor_advanced_to=max_epoch,
+        candidates_pruned=pruned,
+        candidates_carried_forward=len(unclustered_ids),
     )
 
 
@@ -457,16 +751,18 @@ async def synthesis_run(
 # ---------------------------------------------------------------------------
 
 
-def _discover_episodic_namespaces(client: QdrantClient, *, page_size: int = 1000) -> list[str]:
-    """Enumerate `<tenant>/<presence>` prefixes currently present in the
-    episodic collection.
+def _discover_identity_families(client: QdrantClient, *, page_size: int = 1000) -> list[str]:
+    """Enumerate identity families present in the episodic collection.
 
-    The synthesis sweep runs per-namespace; discovery at tick time keeps
-    the runner from needing a re-deploy when a new user / presence shows
-    up. Paginates until Qdrant returns ``offset=None`` so a new
-    namespace whose records don't fall in the first page can't be
-    silently dropped. ``page_size`` tunes memory pressure, not the
-    ceiling of namespaces discoverable.
+    Synthesis runs per-identity-family. Discovery at tick time keeps
+    the runner from needing a re-deploy when a new identity shows up.
+    Paginates until Qdrant returns ``offset=None`` so a new identity
+    whose records don't fall in the first page can't be silently
+    dropped.
+
+    Prefers reading the indexed ``identity_family`` payload field
+    directly; falls back to deriving from ``namespace`` for pre-v1.5.5
+    points that haven't been backfilled yet.
     """
     discovered: set[str] = set()
     offset: Any = None
@@ -476,25 +772,31 @@ def _discover_episodic_namespaces(client: QdrantClient, *, page_size: int = 1000
                 collection_name=collection_for_plane("episodic"),
                 limit=page_size,
                 offset=offset,
-                with_payload=["namespace"],
+                with_payload=["namespace", "identity_family"],
                 with_vectors=False,
             )
         except Exception:
-            logger.exception("synthesis-ns-discovery-failed")
+            logger.exception("synthesis-family-discovery-failed")
             return []
         for rec in records:
             if not rec.payload:
                 continue
-            full = rec.payload.get("namespace")
-            if not isinstance(full, str):
+            fam = rec.payload.get("identity_family")
+            if isinstance(fam, str) and fam:
+                discovered.add(fam)
                 continue
-            # Per-plane suffix convention: `<tenant>/<presence>/<plane>`.
-            # Strip the trailing `/episodic` to get the synthesis-run form.
-            if full.endswith("/episodic"):
-                discovered.add(full[: -len("/episodic")])
+            # Fall back to namespace prefix for un-backfilled points.
+            ns = rec.payload.get("namespace")
+            if isinstance(ns, str) and "/" in ns:
+                discovered.add(ns.split("/", 1)[0])
         if offset is None:
             break
     return sorted(discovered)
+
+
+# Back-compat alias for any caller importing the old name. New code uses
+# _discover_identity_families directly.
+_discover_episodic_namespaces = _discover_identity_families
 
 
 def build_synthesis_jobs(
@@ -522,11 +824,11 @@ def build_synthesis_jobs(
     lock_path = lock_dir / "synthesis.lock"
 
     async def _run_all() -> None:
-        namespaces = _discover_episodic_namespaces(client)
-        if not namespaces:
-            logger.info("synthesis-no-namespaces-found")
+        families = _discover_identity_families(client)
+        if not families:
+            logger.info("synthesis-no-families-found")
             return
-        for ns in namespaces:
+        for family in families:
             try:
                 report = await synthesis_run(
                     client=client,
@@ -534,20 +836,23 @@ def build_synthesis_jobs(
                     ollama=ollama,
                     embedder=embedder,
                     cursor=cursor,
-                    namespace=ns,
+                    namespace=family,  # family identifier; legacy param name
                     config=config,
                 )
                 logger.info(
-                    "synthesis-done ns=%s selected=%d clusters=%d created=%d reinforced=%d contradictions=%d",
-                    ns,
+                    "synthesis-done family=%s selected=%d clusters=%d created=%d "
+                    "reinforced=%d contradictions=%d candidates_carried=%d pruned=%d",
+                    report.namespace,
                     report.memories_selected,
                     report.clusters_formed,
                     report.concepts_created,
                     report.concepts_reinforced,
                     report.contradictions_detected,
+                    report.candidates_carried_forward,
+                    report.candidates_pruned,
                 )
             except Exception:
-                logger.exception("synthesis-failed ns=%s", ns)
+                logger.exception("synthesis-failed family=%s", family)
 
     def _runner() -> None:
         with file_lock(lock_path) as acquired:

--- a/src/musubi/planes/episodic/plane.py
+++ b/src/musubi/planes/episodic/plane.py
@@ -63,9 +63,21 @@ _VISIBLE_STATES_WITH_DEMOTED: tuple[LifecycleState, ...] = ("matured", "demoted"
 MergeStrategy = Literal["replace", "longer-wins"]
 
 
-def _point_id(object_id: str) -> str:
-    """Return the deterministic Qdrant point ID for a given KSUID."""
+def episodic_point_id(object_id: str) -> str:
+    """Return the deterministic Qdrant point ID for an episodic KSUID.
+
+    Public because cross-module callers (e.g. the lifecycle synthesis
+    candidate-fetch path) need to translate object_ids → point_ids to
+    `client.retrieve()` episodic points. Keeping this private would
+    force those callers into reach-into-private-helper patterns that
+    silently break on refactor.
+    """
     return str(uuid.uuid5(_POINT_NS, object_id))
+
+
+# Backwards-compatible alias for in-module callers; removable once all
+# internal references are migrated to the public name.
+_point_id = episodic_point_id
 
 
 def _sparse_to_model(sparse: dict[int, float]) -> models.SparseVector:

--- a/tests/lifecycle/test_synthesis.py
+++ b/tests/lifecycle/test_synthesis.py
@@ -301,6 +301,125 @@ async def test_cluster_by_dense_similarity_within_tag_group(
     assert report.clusters_formed == 2
 
 
+# ---------------------------------------------------------------------------
+# Candidates pool — the v1.5.5 cursor-skip fix
+# ---------------------------------------------------------------------------
+
+
+def test_candidates_upsert_and_get_within_ttl(cursor: SynthesisCursor) -> None:
+    """A memory marked as a candidate is visible to subsequent calls
+    within the TTL window."""
+    cursor.upsert_candidate("aoi", "mem-1", now_epoch=100.0)
+    cursor.upsert_candidate("aoi", "mem-2", now_epoch=100.0)
+    cursor.upsert_candidate("yua", "mem-99", now_epoch=100.0)
+
+    aoi_candidates = cursor.get_candidates("aoi", ttl_sec=3600.0, now_epoch=200.0)
+    assert sorted(aoi_candidates) == ["mem-1", "mem-2"]
+    yua_candidates = cursor.get_candidates("yua", ttl_sec=3600.0, now_epoch=200.0)
+    assert yua_candidates == ["mem-99"]
+
+
+def test_candidates_filtered_by_ttl_window(cursor: SynthesisCursor) -> None:
+    """Candidates whose first_seen_epoch is older than `now - ttl`
+    are not returned, even if `prune_aged_candidates` hasn't run."""
+    cursor.upsert_candidate("aoi", "old-mem", now_epoch=100.0)
+    cursor.upsert_candidate("aoi", "fresh-mem", now_epoch=900.0)
+
+    # ttl=500: old-mem (first_seen=100) is past cutoff (1000-500=500)
+    visible = cursor.get_candidates("aoi", ttl_sec=500.0, now_epoch=1000.0)
+    assert visible == ["fresh-mem"]
+
+
+def test_candidates_remove_on_successful_cluster(cursor: SynthesisCursor) -> None:
+    """When a memory clusters, it's removed from the candidate pool."""
+    cursor.upsert_candidate("aoi", "mem-a", now_epoch=100.0)
+    cursor.upsert_candidate("aoi", "mem-b", now_epoch=100.0)
+    cursor.upsert_candidate("aoi", "mem-c", now_epoch=100.0)
+
+    cursor.remove_candidates("aoi", ["mem-a", "mem-c"])
+
+    remaining = cursor.get_candidates("aoi", ttl_sec=3600.0, now_epoch=200.0)
+    assert remaining == ["mem-b"]
+
+
+def test_candidates_pruned_after_ttl(cursor: SynthesisCursor) -> None:
+    """Aging past TTL physically deletes the row, returning the count
+    pruned. This is the housekeeping path that prevents the candidates
+    table from growing unboundedly."""
+    cursor.upsert_candidate("aoi", "ancient-1", now_epoch=100.0)
+    cursor.upsert_candidate("aoi", "ancient-2", now_epoch=100.0)
+    cursor.upsert_candidate("aoi", "fresh", now_epoch=900.0)
+
+    pruned = cursor.prune_aged_candidates("aoi", ttl_sec=500.0, now_epoch=1000.0)
+    assert pruned == 2
+    remaining = cursor.get_candidates("aoi", ttl_sec=3600.0, now_epoch=1000.0)
+    assert remaining == ["fresh"]
+
+
+def test_candidates_per_family_isolation(cursor: SynthesisCursor) -> None:
+    """Operations on one family's candidates don't touch another's."""
+    cursor.upsert_candidate("aoi", "shared-id", now_epoch=100.0)
+    cursor.upsert_candidate("yua", "shared-id", now_epoch=100.0)
+
+    cursor.remove_candidates("aoi", ["shared-id"])
+    assert cursor.get_candidates("aoi", ttl_sec=3600.0, now_epoch=200.0) == []
+    assert cursor.get_candidates("yua", ttl_sec=3600.0, now_epoch=200.0) == ["shared-id"]
+
+
+def test_cursor_get_set_accepts_namespace_or_family(cursor: SynthesisCursor) -> None:
+    """The cursor's `get`/`set` accept either an identity family ("aoi")
+    or a full namespace ("aoi/command-chair/episodic"); both reduce to
+    the same family-keyed entry. This keeps pre-v1.5.5 callers working
+    without signature changes."""
+    cursor.set("aoi/command-chair/episodic", 42.0)
+    assert cursor.get("aoi/voice/episodic") == 42.0
+    assert cursor.get("aoi") == 42.0
+
+
+async def test_cursor_skip_fix_unclustered_memories_carry_forward(
+    qdrant: QdrantClient,
+    ns: str,
+    sink: LifecycleEventSink,
+    cursor: SynthesisCursor,
+    embedder: FakeEmbedder,
+) -> None:
+    """The headline v1.5.5 fix: a memory that doesn't cluster on its
+    first synthesis pass stays eligible for the next pass via the
+    candidate pool. Pre-v1.5.5, it would have been cursor-skipped
+    forever.
+
+    Setup:
+    1. Write 2 memories with shared tag — too few to cluster (min=3).
+    2. Run synthesis. Expect 0 clusters BUT both memories upserted as
+       candidates.
+    3. Write 1 more memory with the same tag.
+    4. Run synthesis again. Expect 1 cluster combining ALL THREE
+       (the two carried-forward candidates + the new memory).
+    """
+    eps_ns = _ns(ns, "episodic")
+
+    # Pass 1: 2 memories, no cluster
+    for _ in range(2):
+        await _inject_episodic(qdrant, embedder, eps_ns, "carry forward", tags=["topic"])
+    ollama = FakeSynthesisOllama()
+    report1 = await synthesis_run(qdrant, sink, ollama, embedder, cursor, ns)
+    assert report1.clusters_formed == 0
+    assert report1.memories_selected == 2
+    assert report1.candidates_carried_forward >= 2, (
+        "unclustered memories should be retained in the candidate pool"
+    )
+
+    # Pass 2: third memory arrives — combined pool should cluster
+    await _inject_episodic(qdrant, embedder, eps_ns, "carry forward", tags=["topic"])
+    report2 = await synthesis_run(qdrant, sink, ollama, embedder, cursor, ns)
+    assert report2.memories_selected == 3, (
+        "candidates from pass 1 must be re-pulled together with the new memory"
+    )
+    assert report2.clusters_formed == 1, (
+        "the new memory + 2 carried-forward candidates form a cluster"
+    )
+
+
 async def test_cluster_min_size_3_enforced(
     qdrant: QdrantClient,
     ns: str,
@@ -308,7 +427,11 @@ async def test_cluster_min_size_3_enforced(
     cursor: SynthesisCursor,
     embedder: FakeEmbedder,
 ) -> None:
-    """Bullet 6 — min_cluster_size=3."""
+    """Bullet 6 — min_cluster_size=3 (default).
+
+    A concept must aggregate at least three episodic sources — the
+    concept plane enforces this via `_MIN_MERGED_FROM=3`. Two memories
+    are not yet a pattern; they're a duplicate."""
     eps_ns = _ns(ns, "episodic")
     for i in range(2):
         await _inject_episodic(qdrant, embedder, eps_ns, "too small", tags=["tag"])
@@ -561,7 +684,6 @@ async def test_contradictory_concepts_link_both_sides(
 ) -> None:
     """Bullet 16 — symmetric links."""
     eps_ns = _ns(ns, "episodic")
-    conc_ns = _ns(ns, "concept")
     for i in range(3):
         await _inject_episodic(qdrant, embedder, eps_ns, "content a", tags=["tag_a"])
     for i in range(3):
@@ -577,8 +699,11 @@ async def test_contradictory_concepts_link_both_sides(
     concepts, _ = qdrant.scroll(collection_name="musubi_concept", limit=2)
     payload1 = cast(dict[str, Any], concepts[0].payload)
     payload2 = cast(dict[str, Any], concepts[1].payload)
-    c1 = await cplane.get(namespace=conc_ns, object_id=payload1["object_id"])
-    c2 = await cplane.get(namespace=conc_ns, object_id=payload2["object_id"])
+    # Concepts are written to <family>/shared/concept in v1.5.5+, not to
+    # the original synthesis namespace. Use the actual stored namespace
+    # so this test works regardless of where synthesis routes its writes.
+    c1 = await cplane.get(namespace=payload1["namespace"], object_id=payload1["object_id"])
+    c2 = await cplane.get(namespace=payload2["namespace"], object_id=payload2["object_id"])
     assert c1 is not None and c2 is not None
     assert c2.object_id in c1.contradicts
     assert c1.object_id in c2.contradicts
@@ -827,29 +952,35 @@ class _FakeQdrantForDiscovery:
         return self._pages.pop(0)
 
 
-def test_discover_namespaces_happy_path_strips_episodic_suffix() -> None:
+def test_discover_returns_identity_families_not_full_namespaces() -> None:
+    """v1.5.5+ discovery returns identity families (first path component)
+    instead of `<tenant>/<presence>` prefixes. Synthesis runs per-family,
+    federating across substrates."""
     client = _FakeQdrantForDiscovery(
         [
             (
                 [
-                    _FakeRecord({"namespace": "eric/aoi/episodic"}),
-                    _FakeRecord({"namespace": "eric/aoi/episodic"}),  # dedupe
-                    _FakeRecord({"namespace": "eric/ops/episodic"}),
+                    _FakeRecord({"namespace": "eric/aoi/episodic", "identity_family": "eric"}),
+                    _FakeRecord(
+                        {"namespace": "eric/aoi/episodic", "identity_family": "eric"}
+                    ),  # dedupe
+                    _FakeRecord({"namespace": "eric/ops/episodic", "identity_family": "eric"}),
+                    _FakeRecord({"namespace": "alice/voice/episodic", "identity_family": "alice"}),
                 ],
-                None,  # single page — done.
+                None,
             ),
         ]
     )
     result = _discover_episodic_namespaces(cast(Any, client))
-    assert result == ["eric/aoi", "eric/ops"]
+    assert result == ["alice", "eric"]
 
 
-def test_discover_namespaces_paginates_until_offset_none() -> None:
-    """A namespace whose records are on page 2 must not be silently
+def test_discover_paginates_until_offset_none() -> None:
+    """An identity whose records are on page 2 must not be silently
     dropped — the scroll must keep iterating until Qdrant signals
     ``offset is None``."""
-    page1 = [_FakeRecord({"namespace": "eric/aoi/episodic"})]
-    page2 = [_FakeRecord({"namespace": "alice/ghost/episodic"})]
+    page1 = [_FakeRecord({"namespace": "eric/aoi/episodic", "identity_family": "eric"})]
+    page2 = [_FakeRecord({"namespace": "alice/ghost/episodic", "identity_family": "alice"})]
     client = _FakeQdrantForDiscovery(
         [
             (page1, "cursor-1"),
@@ -857,12 +988,12 @@ def test_discover_namespaces_paginates_until_offset_none() -> None:
         ]
     )
     result = _discover_episodic_namespaces(cast(Any, client))
-    assert result == ["alice/ghost", "eric/aoi"]
+    assert result == ["alice", "eric"]
     # Second scroll call must carry the offset returned by the first.
     assert client.calls[1]["offset"] == "cursor-1"
 
 
-def test_discover_namespaces_returns_empty_on_scroll_exception() -> None:
+def test_discover_returns_empty_on_scroll_exception() -> None:
     class _BoomClient:
         def scroll(self, **_: Any) -> tuple[list[_FakeRecord], Any]:
             raise RuntimeError("qdrant down")
@@ -870,19 +1001,27 @@ def test_discover_namespaces_returns_empty_on_scroll_exception() -> None:
     assert _discover_episodic_namespaces(cast(Any, _BoomClient())) == []
 
 
-def test_discover_namespaces_skips_non_string_or_missing_payload() -> None:
+def test_discover_falls_back_to_namespace_prefix_when_identity_family_missing() -> None:
+    """Pre-v1.5.5 points may not have identity_family populated yet
+    (backfill hasn't run). Discovery falls back to deriving the family
+    from the namespace prefix so the new synthesis flow still works
+    against not-yet-backfilled data."""
     client = _FakeQdrantForDiscovery(
         [
             (
                 [
                     _FakeRecord(None),  # missing payload
-                    _FakeRecord({}),  # no namespace key
-                    _FakeRecord({"namespace": 42}),  # non-string
-                    _FakeRecord({"namespace": "eric/aoi/concept"}),  # wrong plane
-                    _FakeRecord({"namespace": "eric/aoi/episodic"}),  # kept
+                    _FakeRecord({}),  # empty payload
+                    _FakeRecord({"namespace": 42}),  # non-string namespace
+                    _FakeRecord(
+                        {"namespace": "eric/aoi/concept"}
+                    ),  # no identity_family — fall back
+                    _FakeRecord(
+                        {"namespace": "eric/aoi/episodic", "identity_family": "eric"}
+                    ),  # canonical
                 ],
                 None,
             ),
         ]
     )
-    assert _discover_episodic_namespaces(cast(Any, client)) == ["eric/aoi"]
+    assert _discover_episodic_namespaces(cast(Any, client)) == ["eric"]


### PR DESCRIPTION
## Summary

Third stair on the identity-family federation staircase. **Depends on #332** (foundation) and **#334** (retrieval). Rebuilds the synthesis lifecycle around identity-family scope + a candidates pool that closes the cursor-skip flaw that left 232 matured episodics stranded with only 3 concepts ever produced.

PR base is `feat/identity-family-retrieval-federation` (#334's branch) so review/merge order stays: #332 → #334 → this one.

## The load-bearing fix

Tonight's audit found that the synthesis worker advanced its per-namespace cursor regardless of clustering success. A memory that didn't cluster on its first pass was permanently excluded from future synthesis attempts. Across 11 namespaces with 232 matured episodics, only 3 concepts had ever been generated.

The candidates pool fixes this: memories that don't cluster on a pass stay eligible in a SQLite-tracked candidate pool (default 30-day TTL), re-pulled on every subsequent sweep until they either join a successful cluster (removed from pool) or age past TTL (pruned).

## What changed

**SynthesisCursor expanded:**
- New `synthesis_family_cursor` table keyed on `identity_family`.
- New `synthesis_candidates` table tracking per-(family, memory) state.
- Methods: `upsert_candidate`, `get_candidates`, `remove_candidates`, `prune_aged_candidates`, `reset`, `reset_candidates`.
- Existing `get`/`set` accept either family or namespace form (back-compat).
- The v1 `synthesis_cursor` table stays in place but is no longer read.

**`synthesis_run` rewritten:**
- Filters episodics by `identity_family` instead of namespace — federates across substrates.
- Pulls new memories (above high-water cursor) AND candidates carried forward (within TTL).
- After clustering: clustered → removed from pool, unclustered → upserted as candidates, aged → pruned.
- Cursor advance is now a perf optimization only; correctness is in candidates.
- Concepts go to `<family>/shared/concept` (single family-level concept namespace).
- Concept matching for reinforce uses `identity_family` filter so clusters in `aoi/voice` can reinforce concepts synthesized earlier from `aoi/command-chair`.

**Discovery renamed** `_discover_episodic_namespaces` → `_discover_identity_families`. Returns identity families. Prefers indexed `identity_family` field; falls back to namespace prefix for not-yet-backfilled points. Old name kept as alias.

**Defaults adjusted:**
- `cluster_threshold`: 0.80 → 0.70 (looser clustering for diverse-content namespaces).
- `min_cluster_size` stays at 3 (concept plane enforces `_MIN_MERGED_FROM=3` as a design invariant — "a concept is a pattern across ≥3 observations").
- `candidate_ttl_sec=30 days` (human-scale memory accumulation window).

## Test plan

- [x] 7 new unit tests for candidate-pool methods (upsert/get/remove/prune/per-family-isolation + namespace/family input forms).
- [x] **Headline test** `test_cursor_skip_fix_unclustered_memories_carry_forward` — proves the load-bearing fix end-to-end: 2 memories that can't cluster (0 clusters, 2 carried forward) + 1 bridging memory → 3 memories cluster on second sweep. Pre-v1.5.5 the first 2 would have been cursor-skipped forever.
- [x] Discovery tests updated to assert new return shape; back-compat fallback covered.
- [x] Contradiction test updated to look up concepts at their actual stored namespace.
- [x] `uv run pytest tests/ --ignore=tests/integration` — 1341 passed, 195 skipped, 0 failures.
- [x] `uv run mypy src tests` + `uv run ruff format --check && uv run ruff check` — clean.
- [ ] Post-deploy v1.5.5: run backfill (from #332), let synthesis tick run once, verify concepts surface in `<family>/shared/concept` namespaces for families that previously had selected>0 clusters=0.

## What's NOT in scope (future PRs)

- Hybrid (dense + sparse) similarity for clustering — still pure-dense; sparse contribution is a tuning improvement.
- Cross-tag fallback pass — within-tag clustering only.
- `musubi lifecycle resynthesize` CLI — the standalone backfill from #332 covers identity_family population; a future PR adds full CLI for cursor reset + re-synthesis on demand.
- Voice-agent prompt rewrite (lives in openclaw-livekit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)