### PR TITLE
fix(synthesis): substitute generic rationale when LLM returns empty

### DIFF
--- a/scripts/force_synthesis.py
+++ b/scripts/force_synthesis.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""One-shot: force a synthesis sweep for all (or one) identity families.
+
+The lifecycle worker only runs the synthesis sweep once a day at 03:00 UTC.
+This script bypasses the cron and invokes `synthesis_run` directly for
+every discovered identity family, using the same code path the worker
+would take. Useful for:
+
+- Verifying a fresh deploy actually produces concepts (don't wait 24h)
+- Re-running synthesis after a cursor reset (see also: scripts/backfill_identity_family.py)
+- Debugging "why didn't synthesis create concepts for family X" without
+  waiting for the daily tick
+
+USAGE (from the musubi host, inside the core container):
+
+    sudo docker cp scripts/force_synthesis.py musubi-core-1:/tmp/
+    sudo docker exec -e MUSUBI_FORCE_SYNTHESIS_CONFIRM=1 musubi-core-1 \\
+        python3 /tmp/force_synthesis.py
+
+WITHOUT the confirm env var, the script lists families that WOULD be
+processed and exits (dry run). With the confirm var set, runs synthesis
+for each family and prints a report.
+
+To target a single family:
+
+    sudo docker exec -e MUSUBI_FORCE_SYNTHESIS_CONFIRM=1 \\
+        -e MUSUBI_FORCE_FAMILY=aoi musubi-core-1 \\
+        python3 /tmp/force_synthesis.py
+
+Safe to run repeatedly: synthesis is idempotent given the cursor +
+candidates pool. Calling it twice in a row produces zero new clusters
+on the second run because the first run already removed clustered
+memories and upserted unclustered ones as candidates.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+
+def main() -> int:
+    from musubi.config import get_settings
+    from musubi.embedding.tei import TEIDenseClient, TEIRerankerClient, TEISparseClient
+    from musubi.lifecycle.events import LifecycleEventSink
+    from musubi.lifecycle.maturation import default_ollama_client
+    from musubi.lifecycle.synthesis import (
+        SynthesisCursor,
+        _discover_identity_families,
+        synthesis_run,
+    )
+    from musubi.storage import build_qdrant_client
+
+    # Build the same composite embedder the runner uses.
+    class _Composite:
+        def __init__(self, dense, sparse, reranker):
+            self.dense = dense
+            self.sparse = sparse
+            self.reranker = reranker
+
+        async def embed_dense(self, texts):
+            return await self.dense.embed_dense(texts)
+
+        async def embed_sparse(self, texts):
+            return await self.sparse.embed_sparse(texts)
+
+        async def rerank(self, query, candidates):
+            return await self.reranker.rerank(query, candidates)
+
+    settings = get_settings()
+    qdrant = build_qdrant_client(
+        host=settings.qdrant_host,
+        port=settings.qdrant_port,
+        api_key=settings.qdrant_api_key.get_secret_value(),
+        https=not settings.musubi_allow_plaintext,
+    )
+    sink = LifecycleEventSink(db_path=settings.lifecycle_sqlite_path)
+    cursor = SynthesisCursor(db_path=settings.lifecycle_sqlite_path)
+    ollama = default_ollama_client()
+    embedder = _Composite(
+        dense=TEIDenseClient(base_url=str(settings.tei_dense_url)),
+        sparse=TEISparseClient(base_url=str(settings.tei_sparse_url)),
+        reranker=TEIRerankerClient(base_url=str(settings.tei_reranker_url)),
+    )
+
+    families = _discover_identity_families(qdrant)
+    target_family = os.environ.get("MUSUBI_FORCE_FAMILY", "").strip()
+    if target_family:
+        if target_family not in families:
+            print(
+                f"FATAL: family {target_family!r} not found. Discovered: {families}",
+                file=sys.stderr,
+            )
+            return 2
+        families = [target_family]
+
+    confirm = os.environ.get("MUSUBI_FORCE_SYNTHESIS_CONFIRM", "") == "1"
+
+    print(f"=== Force synthesis ({'EXECUTING' if confirm else 'DRY RUN'}) ===")
+    print(f"Families to process: {families}")
+    print()
+
+    if not confirm:
+        print("DRY RUN — set MUSUBI_FORCE_SYNTHESIS_CONFIRM=1 to execute.")
+        return 0
+
+    async def _run_all():
+        for family in families:
+            print(f"[{family}]", flush=True)
+            try:
+                report = await synthesis_run(
+                    client=qdrant,
+                    sink=sink,
+                    ollama=ollama,  # type: ignore[arg-type]
+                    embedder=embedder,  # type: ignore[arg-type]
+                    cursor=cursor,
+                    namespace=family,
+                )
+                print(
+                    f"  selected={report.memories_selected} "
+                    f"clusters={report.clusters_formed} "
+                    f"created={report.concepts_created} "
+                    f"reinforced={report.concepts_reinforced} "
+                    f"contradictions={report.contradictions_detected} "
+                    f"candidates_carried={report.candidates_carried_forward} "
+                    f"pruned={report.candidates_pruned}",
+                    flush=True,
+                )
+            except Exception as exc:
+                print(f"  FAILED: {type(exc).__name__}: {exc}", flush=True)
+
+    asyncio.run(_run_all())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/musubi/llm/ollama.py
+++ b/src/musubi/llm/ollama.py
@@ -245,10 +245,20 @@ class HttpxOllamaClient:
             self._write_debug("synthesis", raw, reason=str(exc))
             log.warning("ollama-synthesis-validate-failed err=%s", exc)
             return None
+        # SynthesizedConcept enforces `synthesis_rationale: min_length=1`,
+        # but small LLMs occasionally return an empty `rationale` field
+        # (even though the schema asks for one). Substitute a generic-but-
+        # valid fallback so a single weak response doesn't crash the
+        # synthesis sweep for the entire identity family.
+        rationale = parsed.rationale or (
+            f"Auto-synthesized from {len(cluster.memories)} matured episodics "
+            f"clustering on shared tags / dense similarity. Rationale not "
+            f"provided by the LLM."
+        )
         return SynthesisOutput(
             title=parsed.title,
             content=parsed.content,
-            rationale=parsed.rationale,
+            rationale=rationale,
             tags=list(parsed.tags),
             importance=parsed.importance,
             contradicts_notice=parsed.contradicts_notice,

--- a/uv.lock
+++ b/uv.lock
@@ -753,7 +753,7 @@ wheels = [
 
 [[package]]
 name = "musubi"
-version = "1.6.0"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

A live v1.7.0 synthesis run on the host today processed the `aoi` identity family and crashed:

```
ValidationError: 1 validation error for SynthesizedConcept
synthesis_rationale
  String should have at least 1 character
```

`_SynthesisResponse` (in `musubi.llm.ollama`) allowed empty rationale (`str = ""`), but `SynthesizedConcept.synthesis_rationale` enforces `min_length=1`. Mismatch. Small LLMs occasionally emit `"rationale": ""` even when prompted otherwise — when that happens, a single weak response blocks synthesis for the entire identity family.

## Fix

In `HttpxOllamaClient.synthesize_cluster`: substitute a generic-but-valid fallback when `parsed.rationale` is empty. The fallback is factually correct (a cluster did form via the tag-group + threshold pipeline) and always non-empty, so the concept plane's invariant holds and other clusters in the same run continue cleanly.

## Plus

`scripts/force_synthesis.py` — operator tool that invokes `synthesis_run` on demand for one or all identity families, using the same code path the daily worker would. Lets operators verify a deploy without waiting 24h, debug "why didn't family X produce concepts" interactively, or re-run after a cursor reset. Mirror of `scripts/backfill_identity_family.py` for the synthesis side.

## Test plan

- [x] `uv run pytest tests/llm/ tests/lifecycle/test_synthesis.py` — 72 passed, 6 skipped.
- [x] `uv run mypy src tests` + `uv run ruff format --check && uv run ruff check` — clean.
- [x] Verified live: force_synthesis ran with previous v1.7.0 image and produced 7 new concepts for nyla/yua before the aoi family's empty-rationale crash. Re-running post-merge should produce concepts for aoi without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)