### PR TITLE
feat(retrieve): mode=recent (slice-retrieve-recent)

### DIFF
--- a/docs/Musubi/07-interfaces/canonical-api.md
+++ b/docs/Musubi/07-interfaces/canonical-api.md
@@ -216,7 +216,16 @@ POST   /v1/retrieve                          # body = RetrievalQuery
 POST   /v1/retrieve/stream                   # NDJSON stream for large K
 ```
 
-Single entry point for fast and deep path. Mode selected by `query.mode`. See [[05-retrieval/orchestration]].
+Single entry point for the retrieve pipeline. Mode selected by `query.mode`. See [[05-retrieval/orchestration]].
+
+| `mode` | What it does | Requires `query_text` | Default `state_filter` |
+| --- | --- | --- | --- |
+| `fast` | Latency-budgeted hybrid + recency + reinforcement scoring (≤400ms). Default for interactive callers. | yes | `(matured, promoted)` |
+| `deep` | Full hybrid + cross-encoder rerank + lineage hydration (≤5s). Default for prompt-supplement use cases. | yes | `(matured, promoted)` |
+| `blended` | Deep without the reranker — when you need lineage + cross-plane but not the rerank cost. | yes | `(matured, promoted)` |
+| `recent` | Time-ordered scroll, no ranking. Newest-first. Used by `musubi_recent`. | no (ignored if provided) | `(provisional, matured, promoted)` |
+
+`mode='recent'` additionally accepts `since` (epoch-seconds floor) and `tags` (AND filter). Per [[_slices/slice-retrieve-recent]]. Cross-modal fanout (`<tenant>/*/episodic`) works the same way as for ranked modes.
 
 #### Cross-plane retrieve: one call, not N
 

--- a/docs/Musubi/_inbox/locks/slice-retrieve-recent.lock
+++ b/docs/Musubi/_inbox/locks/slice-retrieve-recent.lock
@@ -1,0 +1,5 @@
+slice: slice-retrieve-recent
+owner: aoi-claude-opus
+started: 2026-05-18T01:30:00Z
+issue: 288
+pr: 343

--- a/docs/Musubi/_slices/slice-retrieve-recent.md
+++ b/docs/Musubi/_slices/slice-retrieve-recent.md
@@ -3,10 +3,11 @@ title: "Slice: Retrieve mode=recent"
 slice_id: slice-retrieve-recent
 section: _slices
 type: slice
-status: blocked
+status: in-progress
+owner: aoi-claude-opus
 phase: "8 Post-1.0"
-tags: [section/slices, status/blocked, type/slice, api, retrieve, recency]
-updated: 2026-04-29
+tags: [section/slices, status/in-progress, type/slice, api, retrieve, recency]
+updated: 2026-05-17
 reviewed: false
 depends-on: ["[[_slices/slice-api-v0-read]]", "[[_slices/slice-api-retrieve-wildcards]]"]
 blocks: ["[[_slices/slice-mcp-canonical-tools]]", "[[_slices/slice-livekit-canonical-tools]]", "[[_slices/slice-openclaw-canonical-tools]]"]
@@ -16,7 +17,13 @@ blocks: ["[[_slices/slice-mcp-canonical-tools]]", "[[_slices/slice-livekit-canon
 
 > Add `mode=recent` to `POST /v1/retrieve` — query-less, time-ordered scroll across the namespace fanout. Required by the canonical `musubi_recent` agent tool ([[07-interfaces/agent-tools]]) so an agent can answer "what was I just doing?" without a query string.
 
-**Phase:** 8 Post-1.0 · **Status:** `blocked` (on [[_slices/slice-api-retrieve-wildcards]])
+**Phase:** 8 Post-1.0 · **Status:** `in-progress` (picked up 2026-05-17 — `slice-api-retrieve-wildcards` merged 2026-04-24 via PR #268; the tracker had stayed `blocked` for ~3 weeks past the actual unblock)
+
+## Design decisions (locked at pickup, 2026-05-17)
+
+- **`query_text` provided with `mode="recent"`:** accept-and-ignore with a WARN-level log. Voice MCP callers pass stray context; 422 creates noise the assistant has to apologize about. Strict can be added later; lenient is hard to back out of.
+- **`since` shape:** `float` (epoch seconds) only. Canonical internal type. ISO conversion is one line client-side.
+- **Default `state_filter` for `mode="recent"`:** `("provisional", "matured", "promoted")` — deliberately includes `provisional` (different from fast/deep defaults of `("matured", "promoted")`). The mode's purpose is "what just happened" and provisional is the freshest tier; excluding it defeats the use case.
 
 ## Why this slice exists
 
@@ -33,28 +40,25 @@ The canonical agent-tools surface ([[13-decisions/0032-agent-tools-canonical-sur
 
 ## Owned paths
 
-This slice is `blocked` on [[_slices/slice-api-retrieve-wildcards]] (currently `in-progress`). The files this slice will touch are mostly owned by that active slice and **MUST NOT** be claimed here while it is in flight — see the "Anticipated paths at pickup" section below. When this slice transitions to `in-progress`, the slice author moves the anticipated-paths list into this section.
+New:
 
-For now, this slice claims **no active paths** — it's a tracking spec, not a worker.
+- `src/musubi/retrieve/recent.py`
+- `tests/retrieve/test_recent.py`
 
-## Anticipated paths at pickup
+Modified:
 
-The slice author who claims this slice (after [[_slices/slice-api-retrieve-wildcards]] merges) will add these into ## Owned paths:
+- `src/musubi/retrieve/orchestration.py` — extend `RetrievalQuery.mode` Literal, add `since`, dispatch branch in `_run_single`
+- `src/musubi/api/routers/retrieve.py` — extend `RetrieveQuery` (router-level), validator for query_text-optional iff mode=recent
+- `src/musubi/sdk/async_client.py`, `src/musubi/sdk/client.py` — expose mode + since
+- `openapi.yaml` — extend `RetrieveQuery` schema
+- `docs/Musubi/07-interfaces/canonical-api.md` — §Retrieve modes table
+- `tests/retrieve/test_orchestration.py` — mode=recent dispatch
+- `tests/api/test_retrieve_router.py` — end-to-end mode=recent
+- `tests/sdk/test_async_client.py` — SDK call shape
 
-Owned outright:
+Out of scope (separate PR):
 
-- src/musubi/retrieve/orchestration.py
-- tests/retrieve/test_orchestration.py
-- openapi.yaml
-- docs/Musubi/07-interfaces/canonical-api.md
-
-Released by [[_slices/slice-api-retrieve-wildcards]] when it merges:
-
-- src/musubi/api/routers/retrieve.py
-- src/musubi/sdk/async_client.py
-- src/musubi/sdk/client.py
-- tests/api/test_retrieve_router.py
-- tests/sdk/test_async_client.py
+- `src/musubi/adapters/mcp/tools.py:193` — MCP `musubi_recent` stub → real call. Folded into a follow-up PR so this one reviews cleanly as a backend addition and the MCP wiring is its own change.
 
 ## Forbidden paths
 

--- a/docs/Musubi/_slices/slice-retrieve-recent.md
+++ b/docs/Musubi/_slices/slice-retrieve-recent.md
@@ -40,21 +40,30 @@ The canonical agent-tools surface ([[13-decisions/0032-agent-tools-canonical-sur
 
 ## Owned paths
 
-New:
+This slice's exclusive paths — files introduced by this slice that no
+other slice claims:
 
 - `src/musubi/retrieve/recent.py`
 - `tests/retrieve/test_recent.py`
+- `tests/api/test_retrieve_recent.py`
 
-Modified:
+## Extends (not owned)
 
-- `src/musubi/retrieve/orchestration.py` — extend `RetrievalQuery.mode` Literal, add `since`, dispatch branch in `_run_single`
-- `src/musubi/api/routers/retrieve.py` — extend `RetrieveQuery` (router-level), validator for query_text-optional iff mode=recent
-- `src/musubi/sdk/async_client.py`, `src/musubi/sdk/client.py` — expose mode + since
-- `openapi.yaml` — extend `RetrieveQuery` schema
-- `docs/Musubi/07-interfaces/canonical-api.md` — §Retrieve modes table
-- `tests/retrieve/test_orchestration.py` — mode=recent dispatch
-- `tests/api/test_retrieve_router.py` — end-to-end mode=recent
-- `tests/sdk/test_async_client.py` — SDK call shape
+This slice also modifies files owned by previously-shipped slices.
+Listed here for review traceability; the hygiene check tracks exclusive
+ownership in `## Owned paths` above, so these aren't re-claimed here.
+
+- `src/musubi/retrieve/orchestration.py` (owned by `slice-retrieval-orchestration`)
+  — extend `RetrievalQuery.mode` Literal, add `since`/`tags`, model-validator
+  for query_text-required-iff-not-recent, dispatch branch in `_run_single`.
+- `src/musubi/api/routers/retrieve.py` (owned by `slice-api-retrieve-wildcards`)
+  — extend `RetrieveQuery` body model, thread `since`/`tags` into query_body.
+- `src/musubi/sdk/{async_client,client}.py` (owned by `slice-api-retrieve-wildcards`)
+  — expose `since`/`tags` parameters; default `query_text=""`.
+- `openapi.yaml` (owned by `slice-api-v0-write`) — extend `RetrieveQuery`
+  schema with `mode` enum, `since`, `tags`, optional query_text.
+- `docs/Musubi/07-interfaces/canonical-api.md` (owned by `slice-api-thoughts-stream`)
+  — add §Retrieve modes table including `recent`.
 
 Out of scope (separate PR):
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2274,10 +2274,16 @@ components:
         query_text:
           type: string
           title: Query Text
+          default: ""
+          description: |
+            Required for `mode` in `fast|deep|blended` (the server returns 400
+            if empty for those modes). Optional for `mode='recent'` — if
+            provided, the server logs a WARN and ignores it.
         mode:
           type: string
           title: Mode
           default: fast
+          enum: [fast, deep, blended, recent]
         limit:
           type: integer
           title: Limit
@@ -2293,6 +2299,27 @@ components:
           type: boolean
           title: Include Archived
           default: false
+        since:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Since
+          description: |
+            Recent-mode only. Inclusive lower bound on `created_epoch`
+            (epoch seconds). Rows older than `since` are excluded. ISO
+            strings are NOT accepted — convert client-side via
+            `datetime.timestamp()`.
+        tags:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Tags
+          description: |
+            Recent-mode tag filter (AND across all listed tags — a row
+            must contain every tag to match). Empty list and `null` both
+            mean no filter. Other modes accept this field without effect.
         state_filter:
           anyOf:
           - items:
@@ -2301,19 +2328,22 @@ components:
           - type: 'null'
           title: State Filter
           description: |
-            Lifecycle states to include. `null` resolves to
-            `('matured', 'promoted')` — the v1.0/v1.1 default. Set to
-            `['provisional', 'matured', 'promoted']` for explicit recall
-            of fresh deliberate stores before maturation has run.
-            In `mode='fast'`, `include_archived: true` augments the default
-            with `('demoted', 'archived', 'superseded')`. In `mode='deep'`
-            and `mode='blended'` `include_archived` is currently ignored —
-            pass `state_filter` explicitly when those modes need
-            archive-side states.
+            Lifecycle states to include. For `fast|deep|blended`, `null`
+            resolves to `('matured', 'promoted')` — the v1.0/v1.1 default.
+            For `mode='recent'`, `null` resolves to
+            `('provisional', 'matured', 'promoted')` — recent mode's purpose
+            is "what just happened," provisional is the freshest tier,
+            excluding it by default would defeat the use case.
+            Set explicitly to `['provisional', 'matured', 'promoted']` for
+            ranked-mode recall of fresh deliberate stores before maturation
+            has run. In `mode='fast'`, `include_archived: true` augments
+            the default with `('demoted', 'archived', 'superseded')`. In
+            `mode='deep'` and `mode='blended'` `include_archived` is
+            currently ignored — pass `state_filter` explicitly when those
+            modes need archive-side states.
       type: object
       required:
       - namespace
-      - query_text
       title: RetrieveQuery
     RetrieveResponse:
       properties:

--- a/src/musubi/api/routers/retrieve.py
+++ b/src/musubi/api/routers/retrieve.py
@@ -68,22 +68,51 @@ class RetrieveQuery(BaseModel):
             "Writes reject `*`; wildcards are read-only. See ADR 0031."
         ),
     )
-    query_text: str
+    # query_text required for fast/deep/blended; optional for recent.
+    # Orchestration-side validator enforces non-empty for ranked modes;
+    # router accepts the empty string at the boundary so MCP callers don't
+    # have to know the mode-specific rule.
+    query_text: str = ""
     mode: str = "fast"
     limit: int = 10
     planes: list[str] | None = None
     include_archived: bool = False
+    #: Inclusive epoch-seconds floor — only consumed by ``mode="recent"``.
+    #: Ignored by other modes (which rank with their own recency-weighting).
+    since: float | None = Field(
+        default=None,
+        description=(
+            "Recent-mode only: inclusive lower bound on `created_epoch`. "
+            "Rows older than `since` are excluded. ISO-format timestamps "
+            "are NOT accepted — convert client-side via "
+            "`datetime.timestamp()`."
+        ),
+    )
+    #: Tag-AND filter — a row must contain every listed tag to match.
+    #: Currently consumed only by ``mode="recent"``; accepted by other
+    #: modes without effect (forward-compat).
+    tags: list[str] | None = Field(
+        default=None,
+        description=(
+            "Recent-mode tag filter. AND semantics — a row must contain "
+            "every listed tag to match. Empty list and `null` both mean "
+            "no filter."
+        ),
+    )
     state_filter: list[str] | None = Field(
         default=None,
         description=(
             "Lifecycle states to include. Default `null` resolves to "
-            "`('matured', 'promoted')` — same as before this field existed, "
-            "so existing callers see no behaviour change. Set to "
-            "`['provisional', 'matured', 'promoted']` for explicit recall "
-            "where you want fresh deliberate `memory_store` rows visible "
-            "before they age through the maturation cron. "
-            "Note: in `mode='fast'`, `include_archived: true` augments the "
-            "default by adding `('demoted', 'archived', 'superseded')`. "
+            "`('matured', 'promoted')` for fast/deep/blended (matching the "
+            "pre-`recent` behaviour). For `mode='recent'`, the default is "
+            "`('provisional', 'matured', 'promoted')` — recent's purpose "
+            "is 'what just happened', so the freshest tier is included by "
+            "default. Set explicitly for `['provisional', 'matured', "
+            "'promoted']` recall on ranked modes when you want fresh "
+            "deliberate `memory_store` rows visible before they age "
+            "through the maturation cron. "
+            "Note: in `mode='fast'`, `include_archived: true` augments "
+            "the default by adding `('demoted', 'archived', 'superseded')`. "
             "In `mode='deep'` and `mode='blended'`, `include_archived` is "
             "currently ignored — pass `state_filter` explicitly when those "
             "modes need archive-side states."
@@ -346,6 +375,10 @@ async def retrieve(
     }
     if body.state_filter is not None:
         query_body["state_filter"] = body.state_filter
+    if body.since is not None:
+        query_body["since"] = body.since
+    if body.tags is not None:
+        query_body["tags"] = body.tags
 
     orchestration_result = await run_orchestration_retrieve(
         client=qdrant,

--- a/src/musubi/api/routers/retrieve.py
+++ b/src/musubi/api/routers/retrieve.py
@@ -33,8 +33,10 @@ everything interesting happens behind the orchestration boundary.
 
 from __future__ import annotations
 
+from typing import Literal
+
 from fastapi import APIRouter, Body, Depends, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from qdrant_client import QdrantClient
 
 from musubi.api.dependencies import (
@@ -69,11 +71,18 @@ class RetrieveQuery(BaseModel):
         ),
     )
     # query_text required for fast/deep/blended; optional for recent.
-    # Orchestration-side validator enforces non-empty for ranked modes;
-    # router accepts the empty string at the boundary so MCP callers don't
-    # have to know the mode-specific rule.
+    # Enforced by the router-side model_validator below so the wire-level
+    # response stays at 422 (FastAPI body validation) for ranked-mode
+    # callers that omit query_text — preserves the pre-slice contract
+    # rather than turning it into a 400 from the orchestration layer.
     query_text: str = ""
-    mode: str = "fast"
+    # `Literal` matches the `enum` constraint in openapi.yaml. Without
+    # this, the pydantic body model would accept any string while the
+    # published schema told clients only four values were valid; pydantic
+    # would silently pass through and orchestration would emit a 400
+    # `bad_query`. Keeping the two surfaces in sync produces a 422 here
+    # for unknown values, matching every other ranked-mode validation.
+    mode: Literal["fast", "deep", "blended", "recent"] = "fast"
     limit: int = 10
     planes: list[str] | None = None
     include_archived: bool = False
@@ -107,8 +116,8 @@ class RetrieveQuery(BaseModel):
             "pre-`recent` behaviour). For `mode='recent'`, the default is "
             "`('provisional', 'matured', 'promoted')` — recent's purpose "
             "is 'what just happened', so the freshest tier is included by "
-            "default. Set explicitly for `['provisional', 'matured', "
-            "'promoted']` recall on ranked modes when you want fresh "
+            "default. Set explicitly to `['provisional', 'matured', "
+            "'promoted']` for recall on ranked modes when you want fresh "
             "deliberate `memory_store` rows visible before they age "
             "through the maturation cron. "
             "Note: in `mode='fast'`, `include_archived: true` augments "
@@ -118,6 +127,27 @@ class RetrieveQuery(BaseModel):
             "modes need archive-side states."
         ),
     )
+
+    @model_validator(mode="after")
+    def _require_query_text_for_ranked_modes(self) -> RetrieveQuery:
+        """Match the orchestration-side rule at the wire boundary.
+
+        Pre-slice, `query_text` was a required `str` field and FastAPI
+        body validation rejected a missing one with **422**. Now that
+        `query_text` defaults to `""` (so `mode="recent"` can omit it),
+        a ranked-mode caller missing `query_text` would be caught by
+        the orchestration validator and surface as a **400** —
+        a wire-level status-code change for existing callers.
+
+        Enforcing the same cross-field rule here keeps the contract at
+        422 for ranked-mode bodies missing `query_text`, matching every
+        other body-validation error from FastAPI.
+        """
+        if self.mode != "recent" and not self.query_text.strip():
+            raise ValueError(
+                f"query_text is required for mode={self.mode!r} (only mode='recent' may omit it)"
+            )
+        return self
 
 
 # orchestration.RetrievalError.kind → (HTTP status, typed error code).

--- a/src/musubi/retrieve/orchestration.py
+++ b/src/musubi/retrieve/orchestration.py
@@ -7,7 +7,7 @@ import logging
 from collections.abc import Sequence
 from typing import Any, Literal, cast
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, ValidationError, model_validator
 from qdrant_client import QdrantClient
 
 from musubi.embedding.base import Embedder
@@ -25,6 +25,7 @@ from musubi.retrieve.deep import (
     RetrievalQuery as DeepRetrievalQuery,
 )
 from musubi.retrieve.fast import run_fast_retrieve
+from musubi.retrieve.recent import run_recent_retrieve
 from musubi.types.common import Err, LifecycleState, Ok, Result
 
 logger = logging.getLogger(__name__)
@@ -46,14 +47,25 @@ class NamespaceTarget(BaseModel):
 
 class RetrievalQuery(BaseModel):
     namespace: str = Field(min_length=1)
-    query_text: str = Field(min_length=1)
-    mode: Literal["fast", "deep", "blended"] = "deep"
+    # query_text is required for fast/deep/blended; ignored for recent.
+    # The model_validator below enforces non-empty for the non-recent modes.
+    query_text: str = ""
+    mode: Literal["fast", "deep", "blended", "recent"] = "deep"
     limit: int = Field(default=25, ge=1, le=100)
     planes: list[str] = Field(default_factory=lambda: ["curated", "concept", "episodic"])
     include_lineage: bool = True
     include_archived: bool = False
     presences: list[str] | None = None
     state_filter: list[LifecycleState] | None = None
+    #: Inclusive epoch-seconds floor for ``mode="recent"``. Ignored by
+    #: other modes (they rank with their own recency-weighting). Per
+    #: [[_slices/slice-retrieve-recent]] design decisions: ``float`` only;
+    #: ISO conversion is a one-line client-side call.
+    since: float | None = None
+    #: Tag-AND filter — a row must contain every listed tag to match.
+    #: Composes with ``mode="recent"``; the other modes don't currently
+    #: consume this field but accept it without error for forward compat.
+    tags: list[str] | None = None
     #: Per-plane namespace fanout. When set, each target drives one
     #: single-plane pipeline run and results are merged by score.
     #: Set by the router from :func:`retrieve._resolve_targets` — callers
@@ -61,6 +73,21 @@ class RetrievalQuery(BaseModel):
     #: orchestrator derives a default single-plane target from the
     #: top-level ``namespace``.
     namespace_targets: list[NamespaceTarget] | None = None
+
+    @model_validator(mode="after")
+    def _require_query_text_for_ranked_modes(self) -> RetrievalQuery:
+        """Enforce: fast/deep/blended require non-empty query_text; recent doesn't.
+
+        ``mode="recent"`` with a `query_text` is accept-and-ignore (the
+        dispatch branch logs a WARN). The validator is for the inverse —
+        a ranked-mode caller without a query_text would silently retrieve
+        garbage; reject loudly at the boundary.
+        """
+        if self.mode != "recent" and not self.query_text.strip():
+            raise ValueError(
+                f"query_text is required for mode={self.mode!r} (only mode='recent' may omit it)"
+            )
+        return self
 
 
 class RetrievalResult(BaseModel):
@@ -326,6 +353,74 @@ async def _run_single(
                     d_res.value, warnings, include_payload=not getattr(parsed_query, "brief", False)
                 )
             )
+
+        elif mode == "recent":
+            # Recent mode: pure time-ordered scroll. No embedder. No rerank.
+            # Per slice-retrieve-recent. If query_text was passed, log and
+            # ignore (accept-and-ignore design decision).
+            if parsed_query.query_text:
+                logger.warning(
+                    "retrieve mode=recent ignoring query_text "
+                    "(slice-retrieve-recent: accept-and-ignore at boundary)"
+                )
+            # Recent's default state_filter deliberately includes provisional
+            # (mode purpose is "what just happened"; provisional is the
+            # freshest tier). Per slice-retrieve-recent design decisions.
+            recent_states: tuple[LifecycleState, ...] = (
+                cast(Any, tuple(parsed_query.state_filter))
+                if parsed_query.state_filter
+                else ("provisional", "matured", "promoted")
+            )
+            r_res = await asyncio.wait_for(
+                run_recent_retrieve(
+                    client=client,
+                    namespace=target_namespace,
+                    collection="musubi_" + plane,
+                    limit=parsed_query.limit,
+                    since=parsed_query.since,
+                    tags=parsed_query.tags,
+                    state_filter=recent_states,
+                ),
+                # Generous vs spec's 200ms p99 budget; scroll on an indexed
+                # field is fast, but Qdrant cold-cache + network jitter
+                # benefit from headroom. The timeout is a safety net, not a
+                # latency contract.
+                timeout=2.0,
+            )
+            if isinstance(r_res, Err):
+                map_kind: Literal["bad_query", "internal"] = (
+                    "internal" if r_res.error.status_code >= 500 else "bad_query"
+                )
+                return Err(error=RetrievalError(kind=map_kind, detail=r_res.error.detail))
+
+            recent_results: list[RetrievalResult] = []
+            for recent_hit in r_res.value.results:
+                stored_namespace = recent_hit.payload.get("namespace")
+                recent_results.append(
+                    RetrievalResult(
+                        object_id=recent_hit.object_id,
+                        namespace=str(stored_namespace) if stored_namespace else target_namespace,
+                        plane=str(recent_hit.payload.get("plane", plane)),
+                        title=recent_hit.payload.get("title"),
+                        snippet=recent_hit.snippet,
+                        # Recent has no relevance scoring; row order is
+                        # the signal. Score = created_epoch so cross-target
+                        # merge in the fanout preserves newest-first.
+                        score=recent_hit.created_epoch,
+                        score_components={
+                            "relevance": 0.0,
+                            "recency": 1.0,
+                            "reinforcement": 0.0,
+                        },
+                        lineage=_summarize_lineage(recent_hit.payload),
+                        payload=(
+                            recent_hit.payload
+                            if not getattr(parsed_query, "brief", False)
+                            else None
+                        ),
+                    )
+                )
+            return Ok(value=recent_results)
 
         elif mode == "fast":
             # Fast timeout (400ms)

--- a/src/musubi/retrieve/recent.py
+++ b/src/musubi/retrieve/recent.py
@@ -105,6 +105,15 @@ async def run_recent_retrieve(
         for tag in tags:
             must.append(models.FieldCondition(key="tags", match=models.MatchValue(value=tag)))
 
+    # IMPORTANT — `order_by` on Qdrant scroll requires the key to be a
+    # declared payload index on the target collection. `created_epoch`
+    # is indexed on every plane that uses it for ordering (verified via
+    # `musubi.planes.thoughts.plane` which already scrolls with the same
+    # `order_by=created_epoch DESC`). New planes that want recent-mode
+    # support must declare the index at collection creation; otherwise
+    # this call fails at runtime with a Qdrant error. `order_by` is also
+    # incompatible with offset-based pagination — current code asks for
+    # the first `capped_limit` rows only, which is the supported shape.
     try:
         records, _ = client.scroll(
             collection_name=collection,
@@ -136,13 +145,37 @@ async def run_recent_retrieve(
     for record in records:
         payload = dict(record.payload or {})
         if not payload:
+            # Surfacing the skip as DEBUG (not WARN) — for recent mode
+            # this is more likely to bite than ranked modes ("give me
+            # everything since X" callers expect every row), but a row
+            # with NO payload at all has nothing to project. The DEBUG
+            # log lets operators investigate data-quality drift without
+            # being woken up.
+            logger.debug(
+                "recent retrieve skipping empty-payload point id=%s",
+                record.id,
+            )
             continue
+        # Explicit `is None` rather than `or 0.0` so a legitimately old
+        # row with `created_epoch=0.0` isn't indistinguishable from a
+        # missing field. A row missing `created_epoch` is a data-quality
+        # signal worth logging; the score still falls back to 0.0 so the
+        # row isn't dropped.
+        raw_ce = payload.get("created_epoch")
+        if raw_ce is None:
+            logger.debug(
+                "recent retrieve row missing created_epoch object_id=%s",
+                payload.get("object_id") or record.id,
+            )
+            created_epoch = 0.0
+        else:
+            created_epoch = float(raw_ce)
         hits.append(
             RecentHit(
                 object_id=str(payload.get("object_id") or record.id),
                 payload=payload,
                 snippet=_snippet(payload),
-                created_epoch=float(payload.get("created_epoch") or 0.0),
+                created_epoch=created_epoch,
             )
         )
 

--- a/src/musubi/retrieve/recent.py
+++ b/src/musubi/retrieve/recent.py
@@ -1,0 +1,162 @@
+"""Time-ordered scroll retrieval — the backend for ``musubi_recent``.
+
+Per [[_slices/slice-retrieve-recent]]. Pure Qdrant scroll, ordered by
+``created_epoch`` DESC, filtered by namespace + state + optional ``since``
+range + optional ``tags``. **No embedder. No rerank.**
+
+Per-target callable (mirrors :func:`musubi.retrieve.fast.run_fast_retrieve`)
+so the orchestrator's existing wildcard / cross-plane fanout invokes this
+once per ``(namespace, collection)`` target unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from qdrant_client import QdrantClient, models
+
+from musubi.types.common import Err, LifecycleState, Namespace, Ok, Result
+
+logger = logging.getLogger(__name__)
+
+# Recent mode includes `provisional` by default — different from fast/deep
+# (which default to matured+promoted). Recent is "what just happened";
+# excluding the freshest tier defeats the use case. Spec'd in
+# [[_slices/slice-retrieve-recent]] design-decisions section.
+_DEFAULT_STATES: tuple[LifecycleState, ...] = ("provisional", "matured", "promoted")
+
+# Hard server-side cap. Matches the cap convention across other retrieve
+# modes; callers requesting higher are silently clamped.
+_MAX_LIMIT = 50
+
+
+@dataclass(frozen=True, slots=True)
+class RecentRetrievalError:
+    """Typed error returned by the recent retrieval boundary."""
+
+    code: str
+    detail: str
+    status_code: int
+
+
+@dataclass(frozen=True, slots=True)
+class RecentHit:
+    """One time-ordered retrieval hit."""
+
+    object_id: str
+    payload: dict[str, Any]
+    snippet: str
+    created_epoch: float
+
+
+@dataclass(frozen=True, slots=True)
+class RecentRetrieveResult:
+    """Successful recent retrieval response."""
+
+    results: list[RecentHit]
+    status_code: int = 200
+
+
+async def run_recent_retrieve(
+    client: QdrantClient,
+    *,
+    namespace: Namespace,
+    collection: str,
+    limit: int = 10,
+    since: float | None = None,
+    tags: Sequence[str] | None = None,
+    state_filter: Sequence[LifecycleState] | None = None,
+) -> Result[RecentRetrieveResult, RecentRetrievalError]:
+    """Scroll ``collection`` filtered by ``namespace``, ordered newest-first.
+
+    No embedder call. No rerank call. Server-side cap of ``_MAX_LIMIT``.
+    ``since`` is interpreted as inclusive epoch seconds (``created_epoch >=
+    since``). ``tags`` filter is AND across all entries — a row must
+    contain every listed tag to match.
+    """
+    if limit <= 0:
+        return Err(
+            error=RecentRetrievalError(
+                code="invalid_limit",
+                detail="limit must be positive",
+                status_code=400,
+            )
+        )
+    capped_limit = min(limit, _MAX_LIMIT)
+    states = tuple(state_filter) if state_filter else _DEFAULT_STATES
+
+    # `must` is typed broadly because qdrant_client.models.Filter accepts a
+    # union of condition kinds (FieldCondition, IsEmptyCondition, etc.) and
+    # the list-invariance rule would reject a narrower `list[FieldCondition]`
+    # at the Filter call site.
+    must: list[Any] = [
+        models.FieldCondition(key="namespace", match=models.MatchValue(value=namespace)),
+        models.FieldCondition(key="state", match=models.MatchAny(any=[str(s) for s in states])),
+    ]
+    if since is not None:
+        must.append(models.FieldCondition(key="created_epoch", range=models.Range(gte=since)))
+    # Tags filter: AND across all listed tags. Each tag is its own
+    # FieldCondition on the array — Qdrant treats array-key match as
+    # "contains this value", so AND-ing them yields "contains every".
+    if tags:
+        for tag in tags:
+            must.append(models.FieldCondition(key="tags", match=models.MatchValue(value=tag)))
+
+    try:
+        records, _ = client.scroll(
+            collection_name=collection,
+            scroll_filter=models.Filter(must=must),
+            limit=capped_limit,
+            with_payload=True,
+            order_by=models.OrderBy(
+                key="created_epoch",
+                direction=models.Direction.DESC,
+            ),
+        )
+    except Exception as exc:
+        logger.error(
+            "recent retrieve scroll failed (collection=%s namespace=%s): %s",
+            collection,
+            namespace,
+            exc,
+            exc_info=True,
+        )
+        return Err(
+            error=RecentRetrievalError(
+                code="index_unavailable",
+                detail=str(exc),
+                status_code=503,
+            )
+        )
+
+    hits: list[RecentHit] = []
+    for record in records:
+        payload = dict(record.payload or {})
+        if not payload:
+            continue
+        hits.append(
+            RecentHit(
+                object_id=str(payload.get("object_id") or record.id),
+                payload=payload,
+                snippet=_snippet(payload),
+                created_epoch=float(payload.get("created_epoch") or 0.0),
+            )
+        )
+
+    return Ok(value=RecentRetrieveResult(results=hits))
+
+
+def _snippet(payload: dict[str, Any], max_chars: int = 300) -> str:
+    content = str(payload.get("content") or payload.get("title") or "")
+    return content[:max_chars]
+
+
+__all__ = [
+    "RecentHit",
+    "RecentRetrievalError",
+    "RecentRetrieveResult",
+    "run_recent_retrieve",
+]

--- a/src/musubi/sdk/async_client.py
+++ b/src/musubi/sdk/async_client.py
@@ -80,12 +80,25 @@ class AsyncMusubiClient:
         self,
         *,
         namespace: str,
-        query_text: str,
+        query_text: str = "",
         mode: str = "fast",
         limit: int = 10,
         planes: list[str] | None = None,
+        since: float | None = None,
+        tags: list[str] | None = None,
         request_id: str | None = None,
     ) -> dict[str, Any]:
+        """Retrieve from Musubi.
+
+        ``query_text`` defaults to empty — required by the server for
+        ``mode`` in ``fast|deep|blended`` (server returns 400 otherwise),
+        and optional for ``mode="recent"`` (the slice-retrieve-recent
+        backend ignores any value passed with `recent`).
+
+        ``since`` is epoch seconds (``float``); ``tags`` is the AND filter.
+        Both are consumed only by ``mode="recent"``; other modes accept
+        them without effect.
+        """
         body: dict[str, Any] = {
             "namespace": namespace,
             "query_text": query_text,
@@ -94,6 +107,10 @@ class AsyncMusubiClient:
         }
         if planes is not None:
             body["planes"] = planes
+        if since is not None:
+            body["since"] = since
+        if tags is not None:
+            body["tags"] = tags
         return await self._json(
             "POST",
             "/retrieve",

--- a/src/musubi/sdk/client.py
+++ b/src/musubi/sdk/client.py
@@ -124,12 +124,21 @@ class MusubiClient:
         self,
         *,
         namespace: str,
-        query_text: str,
+        query_text: str = "",
         mode: str = "fast",
         limit: int = 10,
         planes: list[str] | None = None,
+        since: float | None = None,
+        tags: list[str] | None = None,
         request_id: str | None = None,
     ) -> dict[str, Any]:
+        """Retrieve from Musubi (sync mirror of ``AsyncMusubiClient.retrieve``).
+
+        ``query_text`` defaults to empty — required by the server for
+        ``mode`` in ``fast|deep|blended``, optional for ``mode="recent"``.
+        ``since`` is epoch seconds; ``tags`` is the AND filter. Both are
+        consumed only by ``mode="recent"``.
+        """
         body: dict[str, Any] = {
             "namespace": namespace,
             "query_text": query_text,
@@ -138,6 +147,10 @@ class MusubiClient:
         }
         if planes is not None:
             body["planes"] = planes
+        if since is not None:
+            body["since"] = since
+        if tags is not None:
+            body["tags"] = tags
         return self._json(
             "POST",
             "/retrieve",

--- a/tests/api/test_retrieve_recent.py
+++ b/tests/api/test_retrieve_recent.py
@@ -112,14 +112,22 @@ def test_retrieve_recent_results_are_newest_first(
 
 
 def test_retrieve_recent_with_query_text_is_accept_and_ignore(
-    client: TestClient, episodic: EpisodicPlane, api_settings: object
+    client: TestClient,
+    episodic: EpisodicPlane,
+    api_settings: object,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Slice design decision: mode=recent + query_text → ignore, log WARN.
 
     422 would force assistant-side error handling for a no-op problem.
-    Accept-and-ignore is the forgiving boundary behaviour. We assert 200
-    plus the row count matches what an un-queried recent call would return.
+    Accept-and-ignore is the forgiving boundary behaviour. We assert 200,
+    the row count matches what an un-queried recent call would return,
+    AND that the WARN log line actually fires — if someone later removes
+    the warning, the contract documented in the slice spec quietly
+    breaks; the caplog assert locks it in.
     """
+    import logging
+
     from tests.api.conftest import mint_token
 
     _seed(episodic, "aoi/command-chair/episodic", "alpha")
@@ -130,19 +138,68 @@ def test_retrieve_recent_with_query_text_is_accept_and_ignore(
         scopes=["aoi/*/*:r"],
         presence="aoi/command-chair",
     )
+    with caplog.at_level(logging.WARNING, logger="musubi.retrieve.orchestration"):
+        r = client.post(
+            "/v1/retrieve",
+            json={
+                "namespace": "aoi/command-chair/episodic",
+                "mode": "recent",
+                "query_text": "ignored field",
+                "limit": 10,
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 200, r.text
+    # Same 2 rows recent would return without a query_text.
+    assert len(r.json()["results"]) == 2
+    # Locks in the WARN-on-ignore design decision — if this assertion
+    # disappears, the silent-drop becomes possible again.
+    assert any(
+        "mode=recent ignoring query_text" in record.message and record.levelname == "WARNING"
+        for record in caplog.records
+    ), f"expected WARN log; got: {[r.message for r in caplog.records]}"
+
+
+@pytest.mark.parametrize("mode", ["fast", "deep", "blended"])
+def test_retrieve_ranked_modes_accept_since_and_tags_without_effect(
+    client: TestClient,
+    episodic: EpisodicPlane,
+    api_settings: object,
+    mode: str,
+) -> None:
+    """`since` and `tags` are recent-mode fields, but ranked modes accept
+    them without effect (forward-compat — documented behaviour in the
+    router model + openapi).
+
+    Caller passes both with a real `query_text`; assert 200 and that
+    rows come back. The fields are silently ignored, not filtered on.
+    """
+    from tests.api.conftest import mint_token
+
+    _seed(episodic, "aoi/command-chair/episodic", "anything")
+    token = mint_token(
+        api_settings,  # type: ignore[arg-type]
+        scopes=["aoi/*/*:r"],
+        presence="aoi/command-chair",
+    )
     r = client.post(
         "/v1/retrieve",
         json={
             "namespace": "aoi/command-chair/episodic",
-            "mode": "recent",
-            "query_text": "ignored field",
+            "mode": mode,
+            "query_text": "anything",
+            "since": 1.0,
+            "tags": ["nonexistent-tag-that-would-filter-everything"],
             "limit": 10,
         },
         headers={"Authorization": f"Bearer {token}"},
     )
+    # 200, not 400/422 — fields accepted. If the tags filter were
+    # actually applied here, the row wouldn't carry the tag and we'd
+    # see 0 results. We don't assert non-zero (depending on mode the
+    # similarity score may not surface the row) — just that the call
+    # succeeds and isn't 4xx'd by the new fields.
     assert r.status_code == 200, r.text
-    # Same 2 rows recent would return without a query_text.
-    assert len(r.json()["results"]) == 2
 
 
 def test_retrieve_recent_with_since_filter_excludes_old_rows(
@@ -197,7 +254,14 @@ def test_retrieve_ranked_modes_without_query_text_still_422(
     api_settings: object,
     mode: str,
 ) -> None:
-    """Adding mode=recent doesn't loosen query_text for the ranked modes."""
+    """Adding mode=recent doesn't loosen query_text for the ranked modes.
+
+    Pre-slice, `query_text` was a required string and FastAPI body
+    validation returned 422. The slice adds a router-side model_validator
+    (mirrors the orchestration rule) so the wire status stays 422 —
+    rather than turning into a 400 from the orchestration layer.
+    Locks in the wire contract for retry logic that branches on status.
+    """
     from tests.api.conftest import mint_token
 
     _seed(episodic, "aoi/command-chair/episodic", "anything")
@@ -215,6 +279,7 @@ def test_retrieve_ranked_modes_without_query_text_still_422(
         },
         headers={"Authorization": f"Bearer {token}"},
     )
-    # Validator-rejected at orchestration; router maps to 400 BAD_REQUEST.
-    assert r.status_code == 400, r.text
+    # Router-side model_validator catches the cross-field rule before
+    # orchestration even runs — preserves the pre-slice 422 contract.
+    assert r.status_code == 422, r.text
     assert "query_text" in r.text

--- a/tests/api/test_retrieve_recent.py
+++ b/tests/api/test_retrieve_recent.py
@@ -1,0 +1,220 @@
+"""End-to-end router test for slice-retrieve-recent.
+
+Covers the API-surface contract bullets that need a real FastAPI app +
+seeded Qdrant fixture:
+
+- POST /v1/retrieve with mode="recent" and no query_text returns 200
+  (today's pre-slice behaviour was 422 because query_text was required).
+- Results come back ordered newest-first (delegated to Qdrant's order_by;
+  this test asserts a multi-row response is sorted by `created_epoch`
+  descending end-to-end).
+- `mode="recent"` + `query_text` provided is accept-and-ignore (200, not
+  422 — the slice-retrieve-recent design decision).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import warnings
+
+import pytest
+from fastapi.testclient import TestClient
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+
+from musubi.planes.episodic import EpisodicPlane
+from musubi.types.episodic import EpisodicMemory
+
+
+def _seed(plane: EpisodicPlane, namespace: str, content: str) -> None:
+    async def _go() -> None:
+        saved = await plane.create(EpisodicMemory(namespace=namespace, content=content))
+        await plane.transition(
+            namespace=namespace,
+            object_id=saved.object_id,
+            to_state="matured",
+            actor="seed",
+            reason="seed",
+        )
+
+    asyncio.run(_go())
+
+
+# ---------------------------------------------------------------------------
+# Test contract: mode="recent" without query_text returns 200
+# ---------------------------------------------------------------------------
+
+
+def test_retrieve_recent_no_query_text_returns_200(
+    client: TestClient, episodic: EpisodicPlane, api_settings: object
+) -> None:
+    """Pre-slice, the API required query_text and this would 422."""
+    from tests.api.conftest import mint_token
+
+    _seed(episodic, "aoi/command-chair/episodic", "early write")
+    _seed(episodic, "aoi/command-chair/episodic", "later write")
+
+    token = mint_token(
+        api_settings,  # type: ignore[arg-type]
+        scopes=["aoi/*/*:r"],
+        presence="aoi/command-chair",
+    )
+    r = client.post(
+        "/v1/retrieve",
+        json={
+            "namespace": "aoi/command-chair/episodic",
+            "mode": "recent",
+            "limit": 10,
+            # No `query_text` — the whole point of this test.
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["mode"] == "recent"
+    # Both seeded rows present.
+    assert len(body["results"]) == 2
+
+
+def test_retrieve_recent_results_are_newest_first(
+    client: TestClient, episodic: EpisodicPlane, api_settings: object
+) -> None:
+    """Order is Qdrant's order_by=DESC on created_epoch.
+
+    The seeds are created sequentially; KSUID and created_epoch increase
+    monotonically. Recent mode must surface the LATER write first.
+    """
+    from tests.api.conftest import mint_token
+
+    _seed(episodic, "aoi/command-chair/episodic", "first")
+    _seed(episodic, "aoi/command-chair/episodic", "second")
+    _seed(episodic, "aoi/command-chair/episodic", "third")
+
+    token = mint_token(
+        api_settings,  # type: ignore[arg-type]
+        scopes=["aoi/*/*:r"],
+        presence="aoi/command-chair",
+    )
+    r = client.post(
+        "/v1/retrieve",
+        json={
+            "namespace": "aoi/command-chair/episodic",
+            "mode": "recent",
+            "limit": 10,
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    contents = [row["content"] for row in r.json()["results"]]
+    # Order is by created_epoch DESC — latest insert first.
+    assert contents == ["third", "second", "first"]
+
+
+def test_retrieve_recent_with_query_text_is_accept_and_ignore(
+    client: TestClient, episodic: EpisodicPlane, api_settings: object
+) -> None:
+    """Slice design decision: mode=recent + query_text → ignore, log WARN.
+
+    422 would force assistant-side error handling for a no-op problem.
+    Accept-and-ignore is the forgiving boundary behaviour. We assert 200
+    plus the row count matches what an un-queried recent call would return.
+    """
+    from tests.api.conftest import mint_token
+
+    _seed(episodic, "aoi/command-chair/episodic", "alpha")
+    _seed(episodic, "aoi/command-chair/episodic", "beta")
+
+    token = mint_token(
+        api_settings,  # type: ignore[arg-type]
+        scopes=["aoi/*/*:r"],
+        presence="aoi/command-chair",
+    )
+    r = client.post(
+        "/v1/retrieve",
+        json={
+            "namespace": "aoi/command-chair/episodic",
+            "mode": "recent",
+            "query_text": "ignored field",
+            "limit": 10,
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    # Same 2 rows recent would return without a query_text.
+    assert len(r.json()["results"]) == 2
+
+
+def test_retrieve_recent_with_since_filter_excludes_old_rows(
+    client: TestClient, episodic: EpisodicPlane, api_settings: object
+) -> None:
+    """`since` is an inclusive epoch-seconds floor.
+
+    Seeds two rows, captures the timestamp between them, and asserts the
+    older row is excluded.
+    """
+    import time
+
+    from tests.api.conftest import mint_token
+
+    _seed(episodic, "aoi/command-chair/episodic", "before-cutoff")
+    # Small wait so created_epoch differs across rows. The clock resolution
+    # on the test runner is sub-second; 50ms is comfortably > one tick.
+    time.sleep(0.05)
+    cutoff = time.time()
+    time.sleep(0.05)
+    _seed(episodic, "aoi/command-chair/episodic", "after-cutoff")
+
+    token = mint_token(
+        api_settings,  # type: ignore[arg-type]
+        scopes=["aoi/*/*:r"],
+        presence="aoi/command-chair",
+    )
+    r = client.post(
+        "/v1/retrieve",
+        json={
+            "namespace": "aoi/command-chair/episodic",
+            "mode": "recent",
+            "since": cutoff,
+            "limit": 10,
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    contents = [row["content"] for row in r.json()["results"]]
+    assert contents == ["after-cutoff"]
+
+
+# ---------------------------------------------------------------------------
+# Ranked modes still require query_text (orchestration-side validator).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", ["fast", "deep", "blended"])
+def test_retrieve_ranked_modes_without_query_text_still_422(
+    client: TestClient,
+    episodic: EpisodicPlane,
+    api_settings: object,
+    mode: str,
+) -> None:
+    """Adding mode=recent doesn't loosen query_text for the ranked modes."""
+    from tests.api.conftest import mint_token
+
+    _seed(episodic, "aoi/command-chair/episodic", "anything")
+    token = mint_token(
+        api_settings,  # type: ignore[arg-type]
+        scopes=["aoi/*/*:r"],
+        presence="aoi/command-chair",
+    )
+    r = client.post(
+        "/v1/retrieve",
+        json={
+            "namespace": "aoi/command-chair/episodic",
+            "mode": mode,
+            "limit": 10,
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    # Validator-rejected at orchestration; router maps to 400 BAD_REQUEST.
+    assert r.status_code == 400, r.text
+    assert "query_text" in r.text

--- a/tests/retrieve/test_recent.py
+++ b/tests/retrieve/test_recent.py
@@ -1,0 +1,237 @@
+"""Test contract for slice-retrieve-recent — backend (recent.py).
+
+Covers the unit-level contract bullets:
+- Results ordered newest-first (delegated to Qdrant `order_by`; we assert
+  the call shape).
+- `since` filter composes (assert filter membership).
+- `tags` AND filter composes (assert one FieldCondition per tag).
+- Limit cap (>50 clamped server-side).
+- `state_filter` default includes `provisional`.
+- No embedder construction or call (no embedder in the signature).
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+from qdrant_client import QdrantClient, models
+
+from musubi.retrieve.recent import (
+    _MAX_LIMIT,
+    RecentRetrievalError,
+    run_recent_retrieve,
+)
+from musubi.types.common import Err, Ok
+
+NAMESPACE = "aoi/command-chair/episodic"
+COLLECTION = "musubi_episodic"
+
+
+def _payload(object_id: str, *, created_epoch: float, **extra: Any) -> dict[str, Any]:
+    return {
+        "object_id": object_id,
+        "namespace": NAMESPACE,
+        "plane": "episodic",
+        "state": "matured",
+        "content": f"content {object_id}",
+        "created_epoch": created_epoch,
+        **extra,
+    }
+
+
+class _SpyQdrantClient:
+    """Records the last scroll call's args; returns canned points."""
+
+    def __init__(self, points: list[Any] | None = None) -> None:
+        self.points = points or []
+        self.last_kwargs: dict[str, Any] | None = None
+        self.scroll_calls = 0
+
+    def scroll(self, **kwargs: Any) -> tuple[list[Any], Any]:
+        self.scroll_calls += 1
+        self.last_kwargs = kwargs
+        return (self.points, None)
+
+
+def _client(points: list[Any] | None = None) -> tuple[QdrantClient, _SpyQdrantClient]:
+    spy = _SpyQdrantClient(points=points)
+    return cast(QdrantClient, spy), spy
+
+
+# ---------------------------------------------------------------------------
+# Filter-shape contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_orders_by_created_epoch_desc() -> None:
+    """Result order is delegated to Qdrant's `order_by`; assert call shape."""
+    client, spy = _client(points=[])
+    res = await run_recent_retrieve(
+        client=client, namespace=NAMESPACE, collection=COLLECTION, limit=5
+    )
+    assert isinstance(res, Ok)
+    assert spy.last_kwargs is not None
+    order_by = spy.last_kwargs["order_by"]
+    assert isinstance(order_by, models.OrderBy)
+    assert order_by.key == "created_epoch"
+    assert order_by.direction == models.Direction.DESC
+
+
+@pytest.mark.asyncio
+async def test_namespace_match_in_filter() -> None:
+    client, spy = _client(points=[])
+    await run_recent_retrieve(client=client, namespace=NAMESPACE, collection=COLLECTION)
+    must = spy.last_kwargs["scroll_filter"].must
+    ns_cond = next(c for c in must if c.key == "namespace")
+    assert ns_cond.match == models.MatchValue(value=NAMESPACE)
+
+
+@pytest.mark.asyncio
+async def test_since_filter_composes() -> None:
+    client, spy = _client(points=[])
+    await run_recent_retrieve(
+        client=client,
+        namespace=NAMESPACE,
+        collection=COLLECTION,
+        since=1779000000.0,
+    )
+    must = spy.last_kwargs["scroll_filter"].must
+    since_cond = next(c for c in must if c.key == "created_epoch")
+    assert since_cond.range == models.Range(gte=1779000000.0)
+
+
+@pytest.mark.asyncio
+async def test_since_unset_omits_range_condition() -> None:
+    client, spy = _client(points=[])
+    await run_recent_retrieve(client=client, namespace=NAMESPACE, collection=COLLECTION)
+    must = spy.last_kwargs["scroll_filter"].must
+    assert not any(c.key == "created_epoch" for c in must)
+
+
+@pytest.mark.asyncio
+async def test_tags_filter_is_and_across_entries() -> None:
+    """Each listed tag becomes its own FieldCondition — AND semantics."""
+    client, spy = _client(points=[])
+    await run_recent_retrieve(
+        client=client,
+        namespace=NAMESPACE,
+        collection=COLLECTION,
+        tags=["voice", "important"],
+    )
+    must = spy.last_kwargs["scroll_filter"].must
+    tag_conds = [c for c in must if c.key == "tags"]
+    assert len(tag_conds) == 2
+    values = {c.match.value for c in tag_conds}
+    assert values == {"voice", "important"}
+
+
+@pytest.mark.asyncio
+async def test_default_state_filter_includes_provisional() -> None:
+    """Recent's default differs from fast/deep — includes provisional.
+
+    This is the slice-retrieve-recent design decision: recent mode is "what
+    just happened," provisional is the freshest tier, excluding it defeats
+    the use case.
+    """
+    client, spy = _client(points=[])
+    await run_recent_retrieve(client=client, namespace=NAMESPACE, collection=COLLECTION)
+    must = spy.last_kwargs["scroll_filter"].must
+    state_cond = next(c for c in must if c.key == "state")
+    assert set(state_cond.match.any) == {"provisional", "matured", "promoted"}
+
+
+@pytest.mark.asyncio
+async def test_explicit_state_filter_overrides_default() -> None:
+    client, spy = _client(points=[])
+    await run_recent_retrieve(
+        client=client,
+        namespace=NAMESPACE,
+        collection=COLLECTION,
+        state_filter=["matured"],
+    )
+    must = spy.last_kwargs["scroll_filter"].must
+    state_cond = next(c for c in must if c.key == "state")
+    assert set(state_cond.match.any) == {"matured"}
+
+
+# ---------------------------------------------------------------------------
+# Limit cap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_limit_above_cap_is_clamped() -> None:
+    client, spy = _client(points=[])
+    await run_recent_retrieve(client=client, namespace=NAMESPACE, collection=COLLECTION, limit=999)
+    assert spy.last_kwargs["limit"] == _MAX_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_limit_under_cap_passes_through() -> None:
+    client, spy = _client(points=[])
+    await run_recent_retrieve(client=client, namespace=NAMESPACE, collection=COLLECTION, limit=7)
+    assert spy.last_kwargs["limit"] == 7
+
+
+@pytest.mark.asyncio
+async def test_limit_zero_returns_typed_error() -> None:
+    client, _ = _client(points=[])
+    res = await run_recent_retrieve(
+        client=client, namespace=NAMESPACE, collection=COLLECTION, limit=0
+    )
+    assert isinstance(res, Err)
+    assert res.error.code == "invalid_limit"
+    assert res.error.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Result packing
+# ---------------------------------------------------------------------------
+
+
+class _FakePoint:
+    def __init__(self, payload: dict[str, Any], point_id: str = "fakeid") -> None:
+        self.payload = payload
+        self.id = point_id
+
+
+@pytest.mark.asyncio
+async def test_returns_hits_in_qdrant_returned_order() -> None:
+    """Trust Qdrant's order — we hand it `order_by=DESC` and return what
+    it gives back without re-sorting client-side."""
+    points = [
+        _FakePoint(_payload("newer", created_epoch=2000.0)),
+        _FakePoint(_payload("older", created_epoch=1000.0)),
+    ]
+    client, _ = _client(points=points)
+    res = await run_recent_retrieve(
+        client=client, namespace=NAMESPACE, collection=COLLECTION, limit=5
+    )
+    assert isinstance(res, Ok)
+    assert [h.object_id for h in res.value.results] == ["newer", "older"]
+
+
+@pytest.mark.asyncio
+async def test_hit_snippet_truncates_content() -> None:
+    long = "x" * 1000
+    points = [_FakePoint(_payload("o1", created_epoch=1.0, content=long))]
+    client, _ = _client(points=points)
+    res = await run_recent_retrieve(client=client, namespace=NAMESPACE, collection=COLLECTION)
+    assert isinstance(res, Ok)
+    assert len(res.value.results[0].snippet) == 300
+
+
+@pytest.mark.asyncio
+async def test_scroll_exception_returns_503() -> None:
+    class _BoomClient:
+        def scroll(self, **kwargs: Any) -> Any:
+            raise RuntimeError("qdrant unreachable")
+
+    client = cast(QdrantClient, _BoomClient())
+    res = await run_recent_retrieve(client=client, namespace=NAMESPACE, collection=COLLECTION)
+    assert isinstance(res, Err)
+    assert isinstance(res.error, RecentRetrievalError)
+    assert res.error.code == "index_unavailable"
+    assert res.error.status_code == 503

--- a/tests/retrieve/test_recent.py
+++ b/tests/retrieve/test_recent.py
@@ -41,11 +41,18 @@ def _payload(object_id: str, *, created_epoch: float, **extra: Any) -> dict[str,
 
 
 class _SpyQdrantClient:
-    """Records the last scroll call's args; returns canned points."""
+    """Records the last scroll call's args; returns canned points.
+
+    ``last_kwargs`` is initialized to ``{}`` rather than ``None`` so
+    tests can index into it without first narrowing through an
+    ``assert is not None``. Every test calls ``run_recent_retrieve``
+    before inspecting, so the empty default is never observed in
+    practice — it's a type-friendliness shim.
+    """
 
     def __init__(self, points: list[Any] | None = None) -> None:
         self.points = points or []
-        self.last_kwargs: dict[str, Any] | None = None
+        self.last_kwargs: dict[str, Any] = {}
         self.scroll_calls = 0
 
     def scroll(self, **kwargs: Any) -> tuple[list[Any], Any]:


### PR DESCRIPTION
## Summary

Ships `mode="recent"` on `POST /v1/retrieve` — the backend for the canonical `musubi_recent` agent tool. Pure Qdrant scroll, ordered by `created_epoch` DESC, filtered by namespace + state + optional `since` + optional `tags`. **No embedder. No rerank.**

Per [[_slices/slice-retrieve-recent]] (refs #288).

## What was actually blocked

The slice tracker said `status: blocked` on `slice-api-retrieve-wildcards`. That wildcards slice **merged 3 weeks ago via PR #268** — the tracker just hadn't been updated. This PR flips the slice frontmatter to `in-progress`, fills owned-paths, and ships.

## Design decisions (locked at pickup, documented in slice spec)

1. **`mode="recent"` + `query_text` provided** → accept-and-ignore + WARN log. Voice MCP callers pass stray context; 422 forces assistant-side error handling for a no-op.
2. **`since` shape** → `float` (epoch seconds) only. Canonical internal type. ISO conversion is one client-side line.
3. **Default `state_filter` for recent** → `("provisional", "matured", "promoted")`. Different from fast/deep on purpose — recent is "what just happened," provisional is the freshest tier, excluding it defeats the use case.

## Test contract (from slice spec)

- [x] `POST /v1/retrieve` with `mode="recent"` and no `query_text` → 200 (was 422 pre-slice)
- [x] Results ordered by `created_at` descending (Qdrant `order_by`)
- [x] `since` filter excludes older rows
- [x] `tags` AND-filter composes
- [x] Cross-modal fanout via `<tenant>/*/episodic` (delegated to existing wildcard mechanism)
- [x] Plane filter narrows
- [x] Limit cap (>50 clamped to 50)
- [x] `mode="recent"` + `query_text` → accept-and-ignore
- [x] No embedder call (recent.py signature has none)
- [x] No rerank call
- [ ] Latency p99 ≤ 200ms — deferred to `slice-ops-gpu` per pattern

20 new tests (13 unit + 7 router e2e). Full test suite green:
- `uv run pytest tests/retrieve tests/api tests/sdk` → 381 passed, 47 skipped, 0 failures
- `uv run mypy` clean
- `uv run ruff format --check && uv run ruff check` clean

## What's NOT in this PR (follow-up)

- **MCP adapter wiring** (`src/musubi/adapters/mcp/tools.py:193`) — replaces the `musubi_recent` deferred-error stub with a real call to the new endpoint. Spec'd as `slice-mcp-canonical-tools`. Keeping it separate so this PR reviews as a backend-only addition. Once that follow-up ships, `musubi_recent` becomes live and #288 fully closes.

## Files touched

- `src/musubi/retrieve/recent.py` (new) — 162 LoC
- `src/musubi/retrieve/orchestration.py` — extended `RetrievalQuery` (`mode` Literal, `since`, `tags`, query_text-optional validator) + dispatch branch
- `src/musubi/api/routers/retrieve.py` — extended `RetrieveQuery` body model + query_body assembly
- `src/musubi/sdk/{client,async_client}.py` — extended `retrieve()` signatures
- `openapi.yaml` — RetrieveQuery schema (mode enum, since, tags, query_text default empty, required-list updated)
- `docs/Musubi/07-interfaces/canonical-api.md` — retrieve modes table
- `docs/Musubi/_slices/slice-retrieve-recent.md` — frontmatter flipped + design decisions
- `tests/retrieve/test_recent.py` (new) — 13 unit tests
- `tests/api/test_retrieve_recent.py` (new) — 7 router e2e tests

## Test plan
- [x] `uv run pytest tests/retrieve tests/api tests/sdk` clean
- [x] `uv run mypy src tests` clean (on touched modules)
- [x] `uv run ruff format --check && uv run ruff check` clean
- [ ] Post-merge: deploy via hw-ansible musubi_update.yml → call `POST /v1/retrieve` with `mode="recent"` against live qdrant → verify 200 + newest-first ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)