### PR TITLE
feat(observability): lifecycle-worker /metrics exposition

### DIFF
--- a/src/musubi/lifecycle/runner.py
+++ b/src/musubi/lifecycle/runner.py
@@ -339,6 +339,17 @@ async def _main_async() -> None:
         deployment_environment=settings.otel_deployment_environment,
     )
 
+    # Start `/metrics` HTTP exposition. The four lifecycle jobs
+    # (maturation, synthesis, promotion, reflection) register
+    # `musubi_lifecycle_job_duration_seconds` + `_errors_total` against
+    # `default_registry()` and increment per tick — without this server,
+    # those increments never reach Prometheus and operators cannot answer
+    # "did synthesis run? how long? did it error?" from the metrics
+    # layer. See musubi#344.
+    from musubi.observability.scrape_server import start_metrics_server
+
+    start_metrics_server(settings.lifecycle_metrics_port)
+
     qdrant = build_qdrant_client(
         host=settings.qdrant_host,
         port=settings.qdrant_port,

--- a/src/musubi/observability/scrape_server.py
+++ b/src/musubi/observability/scrape_server.py
@@ -5,10 +5,11 @@ shares :func:`musubi.observability.registry.default_registry`). The
 worker is a pure asyncio tick loop — no API surface — so the in-process
 Registry has no exposition path without something like this.
 
-Pattern mirrors the API's `/v1/ops/metrics` endpoint
-(``musubi.observability.metrics_middleware``) — same renderer
-(:func:`render_text_format`), same Registry singleton — but exposed via
-stdlib ``http.server`` in a daemon thread instead of through FastAPI.
+Pattern mirrors the API's `/v1/ops/metrics` endpoint (served by
+``musubi.api.routers.ops`` over the same renderer
+:func:`render_text_format` and the same :func:`default_registry`
+singleton) — but exposed via stdlib ``http.server`` in a daemon thread
+instead of through FastAPI.
 """
 
 from __future__ import annotations
@@ -84,6 +85,15 @@ def start_metrics_server(
             httpd.serve_forever()
         except Exception:
             logger.exception("metrics-server crashed")
+        finally:
+            # Always close the server socket — if serve_forever raises,
+            # the listening port would otherwise remain bound until the
+            # process exits, blocking subsequent restarts inside the
+            # same container until the kernel reclaims the descriptor.
+            try:
+                httpd.server_close()
+            except Exception:
+                logger.exception("metrics-server close on crash failed")
 
     thread = threading.Thread(target=_serve, name="metrics-server", daemon=True)
     thread.start()

--- a/src/musubi/observability/scrape_server.py
+++ b/src/musubi/observability/scrape_server.py
@@ -23,6 +23,21 @@ from musubi.observability.registry import default_registry, render_text_format
 logger = logging.getLogger(__name__)
 
 
+class _ReusableHTTPServer(HTTPServer):
+    """`HTTPServer` with `SO_REUSEADDR` so lifecycle-worker restarts are reliable.
+
+    Stdlib `HTTPServer` inherits `socketserver.TCPServer.allow_reuse_address
+    = False`. On a fast container restart, recent Prometheus scrape sockets
+    can sit in `TIME_WAIT` for ~60s, and binding the same port without
+    SO_REUSEADDR raises `EADDRINUSE` — making the worker crash-loop until
+    the kernel releases the port. Setting `True` lets the new process bind
+    immediately. Safe here because port `lifecycle_metrics_port` is
+    process-exclusive within the container (one worker per container).
+    """
+
+    allow_reuse_address = True
+
+
 class _MetricsHandler(BaseHTTPRequestHandler):
     """Serve `GET /metrics` from the process-wide registry; 404 elsewhere."""
 
@@ -60,7 +75,7 @@ def start_metrics_server(
     ``.start()`` it. Pass ``port=0`` to let the OS pick a port (tests
     use this; production passes a fixed port from settings).
     """
-    httpd = HTTPServer((host, port), _MetricsHandler)
+    httpd = _ReusableHTTPServer((host, port), _MetricsHandler)
 
     def _serve() -> None:
         bound_port = httpd.server_address[1]

--- a/src/musubi/observability/scrape_server.py
+++ b/src/musubi/observability/scrape_server.py
@@ -1,0 +1,82 @@
+"""Minimal HTTP `/metrics` exposition for processes without a FastAPI app.
+
+Used by the lifecycle-worker (and any future standalone process that
+shares :func:`musubi.observability.registry.default_registry`). The
+worker is a pure asyncio tick loop — no API surface — so the in-process
+Registry has no exposition path without something like this.
+
+Pattern mirrors the API's `/v1/ops/metrics` endpoint
+(``musubi.observability.metrics_middleware``) — same renderer
+(:func:`render_text_format`), same Registry singleton — but exposed via
+stdlib ``http.server`` in a daemon thread instead of through FastAPI.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+from musubi.observability.registry import default_registry, render_text_format
+
+logger = logging.getLogger(__name__)
+
+
+class _MetricsHandler(BaseHTTPRequestHandler):
+    """Serve `GET /metrics` from the process-wide registry; 404 elsewhere."""
+
+    def do_GET(self) -> None:
+        if self.path != "/metrics":
+            self.send_response(404)
+            self.end_headers()
+            return
+        body = render_text_format(default_registry()).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: Any) -> None:
+        # Suppress default access logging: Prometheus scrapes at 15s
+        # intervals; one log line per scrape is steady-state noise. Real
+        # errors still surface via ``log_error`` / exception logging.
+        return
+
+
+def start_metrics_server(
+    port: int,
+    *,
+    host: str = "0.0.0.0",
+) -> threading.Thread:
+    """Start the metrics HTTP server in a daemon thread; return the thread.
+
+    Daemon so process shutdown is never blocked on the server. ``host``
+    defaults to all interfaces — production deploys do not host-bind the
+    port (Prometheus reaches it via the compose internal network).
+
+    The thread is started before return; the caller does not need to
+    ``.start()`` it. Pass ``port=0`` to let the OS pick a port (tests
+    use this; production passes a fixed port from settings).
+    """
+    httpd = HTTPServer((host, port), _MetricsHandler)
+
+    def _serve() -> None:
+        bound_port = httpd.server_address[1]
+        logger.info("metrics-server listening on %s:%d/metrics", host, bound_port)
+        try:
+            httpd.serve_forever()
+        except Exception:
+            logger.exception("metrics-server crashed")
+
+    thread = threading.Thread(target=_serve, name="metrics-server", daemon=True)
+    thread.start()
+    # Attach the server so callers (tests) can read the bound port + shut
+    # it down deterministically. Not part of the public API contract;
+    # production callers ignore both.
+    thread.httpd = httpd  # type: ignore[attr-defined]
+    return thread
+
+
+__all__ = ["start_metrics_server"]

--- a/src/musubi/settings.py
+++ b/src/musubi/settings.py
@@ -94,6 +94,17 @@ class Settings(BaseSettings):
     # ------------------------------------------------------------------
     musubi_grpc: bool = Field(default=False, description="Expose the gRPC API alongside REST.")
 
+    lifecycle_metrics_port: int = Field(
+        default=8101,
+        description=(
+            "Port the lifecycle-worker exposes Prometheus `/metrics` on. "
+            "Worker has no FastAPI surface, so this is a stdlib HTTP server "
+            "started by `musubi.observability.scrape_server.start_metrics_server` "
+            "during worker boot. Bound on 0.0.0.0; production deploys reach it "
+            "via the compose internal network and do not host-bind."
+        ),
+    )
+
     musubi_artifact_archival_enabled: bool = Field(
         default=False,
         description=(

--- a/src/musubi/settings.py
+++ b/src/musubi/settings.py
@@ -96,6 +96,8 @@ class Settings(BaseSettings):
 
     lifecycle_metrics_port: int = Field(
         default=8101,
+        ge=1,
+        le=65535,
         description=(
             "Port the lifecycle-worker exposes Prometheus `/metrics` on. "
             "Worker has no FastAPI surface, so this is a stdlib HTTP server "

--- a/tests/observability/test_scrape_server.py
+++ b/tests/observability/test_scrape_server.py
@@ -1,0 +1,76 @@
+"""Test contract for `musubi.observability.scrape_server`.
+
+Smoke-level: boot the server on an OS-picked port, make a real HTTP GET
+against `/metrics`, assert 200 + Prometheus exposition shape. Then
+register a counter, increment it, scrape again — confirm the value
+shows up. This is enough to fail loudly if the server stops working
+without depending on Prometheus being installed.
+"""
+
+from __future__ import annotations
+
+import time
+import urllib.request
+
+import pytest
+
+from musubi.observability.registry import default_registry
+from musubi.observability.scrape_server import start_metrics_server
+
+
+@pytest.fixture
+def metrics_server() -> tuple[int, object]:
+    """Boot the server on an OS-picked port; tear down after the test."""
+    thread = start_metrics_server(port=0, host="127.0.0.1")
+    httpd = thread.httpd  # type: ignore[attr-defined]
+    port = httpd.server_address[1]
+    # Tiny wait so the thread is past serve_forever() entry. The poll
+    # loop below tolerates a slow boot, but a 1ms yield is enough to
+    # avoid most flake.
+    time.sleep(0.005)
+    yield port, httpd
+    httpd.shutdown()
+    httpd.server_close()
+
+
+def _get(port: int, path: str = "/metrics", timeout: float = 2.0) -> tuple[int, str]:
+    req = urllib.request.Request(f"http://127.0.0.1:{port}{path}")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.status, resp.read().decode("utf-8")
+
+
+def test_metrics_endpoint_returns_200(metrics_server: tuple[int, object]) -> None:
+    port, _ = metrics_server
+    status, _body = _get(port)
+    assert status == 200
+
+
+def test_metrics_endpoint_renders_exposition_format(
+    metrics_server: tuple[int, object],
+) -> None:
+    port, _ = metrics_server
+    # Register + increment a counter so the body is non-trivial.
+    reg = default_registry()
+    counter = reg.counter(
+        "musubi_scrape_server_test_total",
+        "test counter for scrape_server endpoint smoke",
+        labelnames=("variant",),
+    )
+    counter.labels(variant="alpha").inc(3)
+    counter.labels(variant="beta").inc(1)
+
+    status, body = _get(port)
+    assert status == 200
+    # Prometheus exposition format markers (# HELP, # TYPE).
+    assert "# HELP musubi_scrape_server_test_total" in body
+    assert "# TYPE musubi_scrape_server_test_total counter" in body
+    # Both label-value combinations are rendered.
+    assert 'musubi_scrape_server_test_total{variant="alpha"} 3' in body
+    assert 'musubi_scrape_server_test_total{variant="beta"} 1' in body
+
+
+def test_non_metrics_path_404s(metrics_server: tuple[int, object]) -> None:
+    port, _ = metrics_server
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        _get(port, path="/")
+    assert exc_info.value.code == 404

--- a/tests/observability/test_scrape_server.py
+++ b/tests/observability/test_scrape_server.py
@@ -10,6 +10,7 @@ without depending on Prometheus being installed.
 from __future__ import annotations
 
 import time
+import urllib.error
 import urllib.request
 from collections.abc import Iterator
 
@@ -25,13 +26,26 @@ def metrics_server() -> Iterator[tuple[int, object]]:
     thread = start_metrics_server(port=0, host="127.0.0.1")
     httpd = thread.httpd  # type: ignore[attr-defined]
     port = httpd.server_address[1]
-    # Tiny wait so the thread is past serve_forever() entry. The poll
-    # loop below tolerates a slow boot, but a 1ms yield is enough to
-    # avoid most flake.
-    time.sleep(0.005)
+    # Poll until the server is actually accepting connections. The
+    # thread is `start()`ed before the fixture sees it, but there is a
+    # brief window before `serve_forever()` enters its loop. Try a
+    # couple of GETs with short retry delays rather than a single
+    # arbitrary sleep — the alternative is flaky on slow runners.
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/metrics", timeout=0.2).close()
+            break
+        except (urllib.error.URLError, ConnectionError):
+            time.sleep(0.02)
     yield port, httpd
     httpd.shutdown()
     httpd.server_close()
+    # Join the server thread so we don't leak it across tests. The
+    # daemon flag stops process shutdown from blocking; an explicit
+    # join here stops a slow-shutting-down server from accumulating
+    # idle threads in long test runs.
+    thread.join(timeout=2.0)
 
 
 def _get(port: int, path: str = "/metrics", timeout: float = 2.0) -> tuple[int, str]:

--- a/tests/observability/test_scrape_server.py
+++ b/tests/observability/test_scrape_server.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import time
 import urllib.request
+from collections.abc import Iterator
 
 import pytest
 
@@ -19,7 +20,7 @@ from musubi.observability.scrape_server import start_metrics_server
 
 
 @pytest.fixture
-def metrics_server() -> tuple[int, object]:
+def metrics_server() -> Iterator[tuple[int, object]]:
     """Boot the server on an OS-picked port; tear down after the test."""
     thread = start_metrics_server(port=0, host="127.0.0.1")
     httpd = thread.httpd  # type: ignore[attr-defined]

--- a/tests/observability/test_scrape_server.py
+++ b/tests/observability/test_scrape_server.py
@@ -32,12 +32,24 @@ def metrics_server() -> Iterator[tuple[int, object]]:
     # couple of GETs with short retry delays rather than a single
     # arbitrary sleep — the alternative is flaky on slow runners.
     deadline = time.monotonic() + 1.0
+    boot_confirmed = False
     while time.monotonic() < deadline:
         try:
             urllib.request.urlopen(f"http://127.0.0.1:{port}/metrics", timeout=0.2).close()
+            boot_confirmed = True
             break
         except (urllib.error.URLError, ConnectionError):
             time.sleep(0.02)
+    if not boot_confirmed:
+        # Fall-through means the deadline elapsed without a successful
+        # GET — turn that into a clear failure here rather than letting
+        # the actual test fail later with a confusing connection error.
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=2.0)
+        pytest.fail(
+            f"metrics-server did not start accepting connections on 127.0.0.1:{port} within 1s"
+        )
     yield port, httpd
     httpd.shutdown()
     httpd.server_close()
@@ -64,10 +76,14 @@ def test_metrics_endpoint_renders_exposition_format(
     metrics_server: tuple[int, object],
 ) -> None:
     port, _ = metrics_server
-    # Register + increment a counter so the body is non-trivial.
+    # Per-test unique metric name so test reruns + future tests that
+    # reuse the global `default_registry()` singleton don't end up
+    # asserting against a counter that's already been incremented by
+    # a prior test in the same session.
+    metric_name = f"musubi_scrape_server_test_{time.monotonic_ns()}_total"
     reg = default_registry()
     counter = reg.counter(
-        "musubi_scrape_server_test_total",
+        metric_name,
         "test counter for scrape_server endpoint smoke",
         labelnames=("variant",),
     )
@@ -77,11 +93,11 @@ def test_metrics_endpoint_renders_exposition_format(
     status, body = _get(port)
     assert status == 200
     # Prometheus exposition format markers (# HELP, # TYPE).
-    assert "# HELP musubi_scrape_server_test_total" in body
-    assert "# TYPE musubi_scrape_server_test_total counter" in body
+    assert f"# HELP {metric_name}" in body
+    assert f"# TYPE {metric_name} counter" in body
     # Both label-value combinations are rendered.
-    assert 'musubi_scrape_server_test_total{variant="alpha"} 3' in body
-    assert 'musubi_scrape_server_test_total{variant="beta"} 1' in body
+    assert f'{metric_name}{{variant="alpha"}} 3' in body
+    assert f'{metric_name}{{variant="beta"}} 1' in body
 
 
 def test_non_metrics_path_404s(metrics_server: tuple[int, object]) -> None:


### PR DESCRIPTION
## Summary

Closes #344. The four lifecycle workers (maturation, synthesis, promotion, reflection) register `musubi_lifecycle_job_duration_seconds` and `musubi_lifecycle_job_errors_total` against `default_registry()` and increment them every tick — but the worker is a pure asyncio tick loop with no HTTP surface, so the metrics live in-process and die with it. Prometheus has never seen them.

This PR adds a standalone metrics exposition path: `musubi.observability.scrape_server.start_metrics_server()` runs a stdlib `http.server` in a daemon thread and serves `GET /metrics` by calling `render_text_format(default_registry())`. Same renderer as the API's `/v1/ops/metrics`; same Registry singleton; just exposed standalone instead of through FastAPI.

The lifecycle runner calls it during boot after `init_tracing()`, listening on `settings.lifecycle_metrics_port` (default 8101).

## What's in this PR

- `src/musubi/observability/scrape_server.py` (new) — daemon-thread HTTP server
- `src/musubi/lifecycle/runner.py` — call `start_metrics_server` during boot
- `src/musubi/settings.py` — new `lifecycle_metrics_port: int = 8101`
- `tests/observability/test_scrape_server.py` (new) — 3 tests: 200 on /metrics, exposition format renders, 404 on other paths

## Deploy side (separate PR in hw-ansible)

This PR is the musubi-side code only. The deploy side needs:

- Expose port 8101 in `lifecycle-worker` compose service definition
- Add `lifecycle-worker` scrape job to `prometheus.yml.j2`
- Replace the disabled healthcheck with one against `/metrics` so `restart: unless-stopped` actually fires if the server dies
- Apply via `musubi_update.yml -e '{"changed_services":["lifecycle-worker","prometheus"]}'`

Both PRs need to land for the metrics to actually flow to Mimir. Splitting because they're owned by different repos and reviewed differently.

## Test plan

- [x] `uv run pytest tests/observability tests/lifecycle` — 258 passed, 42 skipped, 0 failures
- [x] `uv run mypy src/musubi/observability/scrape_server.py src/musubi/lifecycle/runner.py src/musubi/settings.py` clean
- [x] `uv run ruff format --check && uv run ruff check` clean
- [ ] Post-merge + hw-ansible-side deploy: `curl http://lifecycle-worker:8101/metrics` from within the compose network returns 200 with `musubi_lifecycle_job_*` series
- [ ] `list_prometheus_metric_names regex="musubi_lifecycle.*"` on the central Mimir returns non-empty within 30s of a successful scrape

## Pattern context

Fourth instance the same evening of the "code shipped, exposition step skipped" pattern (other three captured in `harem-ops/wiki/gotchas/musubi-deploy-traps.md` §13-§17). This PR closes the metrics one; #345 tracks the `vault_reconcile` one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)