### PR TITLE
fix(api,test): clarify trigger-synthesis namespace semantics

### DIFF
--- a/src/musubi/api/routers/ops.py
+++ b/src/musubi/api/routers/ops.py
@@ -123,9 +123,25 @@ class TriggerSynthesisRequest(BaseModel):
 
 
 class TriggerSynthesisResponse(BaseModel):
-    """Same shape as ``musubi.lifecycle.synthesis.SynthesisReport``."""
+    """Same shape as ``musubi.lifecycle.synthesis.SynthesisReport``.
+
+    The ``namespace`` field carries the **identity family** (e.g. ``"aoi"``)
+    that synthesis actually clustered, NOT an echo of the input
+    namespace. Per v1.5.5+'s per-family synthesis (musubi#335), the loop
+    operates on identity-family scope; the field name is preserved for
+    backward-compat with log scrapers but the semantic shifted from
+    "input namespace echo" to "scope actually clustered." The new
+    ``identity_family`` field below makes this explicit for new
+    callers that want unambiguous semantics. See musubi#352 for the
+    investigation that surfaced this naming confusion.
+    """
 
     namespace: str
+    #: Identity family the synthesis loop actually clustered. Same value
+    #: as ``namespace`` today (kept aliased for the v1.5.5+ per-family
+    #: flow); the dual surface lets future callers depend on the
+    #: explicit name without breaking existing log scrapers.
+    identity_family: str
     memories_selected: int
     clusters_formed: int
     concepts_created: int
@@ -217,7 +233,11 @@ async def trigger_synthesis(
         namespace=request.namespace,
     )
     return TriggerSynthesisResponse(
+        # Both fields carry the same value (identity family the loop
+        # clustered). `namespace` is the back-compat alias; new callers
+        # should prefer `identity_family` for unambiguous semantics.
         namespace=report.namespace,
+        identity_family=report.namespace,
         memories_selected=report.memories_selected,
         clusters_formed=report.clusters_formed,
         concepts_created=report.concepts_created,

--- a/src/musubi/api/routers/ops.py
+++ b/src/musubi/api/routers/ops.py
@@ -148,6 +148,14 @@ class TriggerSynthesisResponse(BaseModel):
     concepts_reinforced: int
     contradictions_detected: int
     cursor_advanced_to: float | None
+    #: Carried-forward count from the SynthesisReport's candidates pool.
+    #: Added in PR #354 to match the full SynthesisReport shape; per
+    #: PR #335's candidates pool, this is the number of episodics that
+    #: didn't cluster on this pass and were upserted for the next sweep.
+    candidates_carried_forward: int = 0
+    #: Aged-out candidates pruned this run (>30-day TTL by default).
+    #: Also added in PR #354 to match the full SynthesisReport shape.
+    candidates_pruned: int = 0
 
 
 class _NoOpOllamaClient:
@@ -244,6 +252,8 @@ async def trigger_synthesis(
         concepts_reinforced=report.concepts_reinforced,
         contradictions_detected=report.contradictions_detected,
         cursor_advanced_to=report.cursor_advanced_to,
+        candidates_carried_forward=report.candidates_carried_forward,
+        candidates_pruned=report.candidates_pruned,
     )
 
 

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -312,7 +312,14 @@ async def test_concept_synthesis_flow_ollama_offline(
 
     # Graceful-degradation invariants: no crash + zero concepts (because
     # the loop skipped every cluster on the None response).
-    assert report["namespace"] == "eric/integration-test"
+    # Per v1.5.5+'s per-family synthesis (musubi#335), the report's
+    # `namespace` field carries the IDENTITY FAMILY the loop actually
+    # clustered ("eric") — NOT an echo of the input namespace
+    # ("eric/integration-test"). The new `identity_family` field added
+    # in musubi#352 makes this semantic explicit; assert against both
+    # to lock in the contract.
+    assert report["namespace"] == "eric"
+    assert report["identity_family"] == "eric"
     assert report["concepts_created"] == 0
     assert report["concepts_reinforced"] == 0
     # memories_selected / clusters_formed are shape-dependent on prior


### PR DESCRIPTION
## Summary

Closes #352. The synthesis loop operates on identity-family scope (per v1.5.5+ per-family synthesis, musubi#335) but the trigger-synthesis API response and integration test were written assuming input-namespace echo. Failure: `assert 'eric' == 'eric/integration-test'`.

## Fix

- **API side**: add `identity_family` field to `TriggerSynthesisResponse` for unambiguous semantics. `namespace` kept for back-compat. Docstring explains the post-v1.5.5+ semantic shift.
- **Test side**: assert `report["namespace"] == "eric"` (family return, not input echo). Also assert the new `identity_family` field is consistent.

Combined with musubi#350's HF_TOKEN + release-please-skip fixes, the integration suite reaches all-green for the first time in known history.

## Test plan
- [x] `uv run pytest tests/api tests/retrieve tests/lifecycle tests/observability` — 573 passed, 88 skipped, 0 failures
- [x] `uv run mypy` + `uv run ruff` clean
- [ ] Post-merge: integration suite passes all 13 active tests (was 12/13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)