### PR TITLE
feat(vault): wire vault_reconcile into lifecycle scheduler (partial musubi#345)

### DIFF
--- a/src/musubi/lifecycle/runner.py
+++ b/src/musubi/lifecycle/runner.py
@@ -228,13 +228,16 @@ def build_lifecycle_jobs(
     synthesis_jobs: Iterable[Job] | None = None,
     promotion_jobs: Iterable[Job] | None = None,
     reflection_jobs: Iterable[Job] | None = None,
+    vault_reconcile_jobs: Iterable[Job] | None = None,
 ) -> list[Job]:
     """Compose the full job list the production worker drives.
 
     Real job builders replace the placeholder-lambdas emitted by
     :func:`build_default_jobs` for every name they cover. Any job
     name the builders haven't claimed keeps the placeholder (which
-    log-skips). Only ``vault_reconcile`` still uses a placeholder.
+    log-skips). Post-musubi#345 every job has a real builder; the
+    placeholder fallback only fires for tests that intentionally
+    omit a group.
 
     Injection points keep unit tests deterministic — a test can
     pass a stub Job without wiring a QdrantClient / Ollama / etc.
@@ -248,6 +251,7 @@ def build_lifecycle_jobs(
         synthesis_jobs,
         promotion_jobs,
         reflection_jobs,
+        vault_reconcile_jobs,
     ):
         if group is not None:
             real_jobs.extend(group)
@@ -316,6 +320,7 @@ async def _main_async() -> None:
     from musubi.planes.episodic.plane import EpisodicPlane
     from musubi.planes.thoughts.plane import ThoughtsPlane
     from musubi.storage import build_qdrant_client
+    from musubi.vault.reconciler import build_vault_reconcile_jobs
     from musubi.vault.writelog import WriteLog
     from musubi.vault.writer import VaultWriter as _VaultWriter
 
@@ -465,12 +470,23 @@ async def _main_async() -> None:
         namespace=reflection_namespace,
         lock_dir=lock_dir,
     )
+    # vault_reconcile — periodic drift catch-up between the Obsidian
+    # vault filesystem and the curated plane. Real-time changes go
+    # through the (still-unbuilt) musubi-vault-watcher process; this
+    # 6h sweep catches anything the watcher missed (or runs in lieu of
+    # the watcher entirely until it's deployed). See musubi#345.
+    vault_reconcile_jobs = build_vault_reconcile_jobs(
+        vault_root=Path(settings.vault_path),
+        curated_plane=curated_plane,
+        lock_dir=lock_dir,
+    )
     jobs = build_lifecycle_jobs(
         maturation_jobs=mat_jobs,
         demotion_jobs=dem_jobs,
         synthesis_jobs=syn_jobs,
         promotion_jobs=prom_jobs,
         reflection_jobs=ref_jobs,
+        vault_reconcile_jobs=vault_reconcile_jobs,
     )
 
     runner = LifecycleRunner(jobs=jobs)

--- a/src/musubi/vault/reconciler.py
+++ b/src/musubi/vault/reconciler.py
@@ -1,10 +1,33 @@
-"""Periodic drift reconciler between vault and Qdrant."""
+"""Periodic drift reconciler between vault and Qdrant.
+
+The lifecycle-worker's ``vault_reconcile`` job calls :meth:`VaultReconciler.reconcile`
+every 6 hours. It walks the vault filesystem, parses frontmatter, and
+upserts any markdown file with a non-empty ``object_id`` into the
+curated plane.
+
+Scope of this slice (musubi#345, partial):
+
+- Clean up debug-print code, add structured logging at INFO/DEBUG.
+- Skip-on-unchanged: body-hash compare so unchanged files don't churn
+  embeddings on every 6h tick.
+- Wire into the lifecycle scheduler so the job runs.
+
+Out of scope (separate session per the issue):
+
+- ``musubi-vault-watcher`` real-time process — needs an architecture
+  decision on where the vault lives relative to the musubi host
+  (mounted, NAS-shared, git-synced).
+- Deletion handling — currently the reconciler is upsert-only; vault
+  files that disappear leave their qdrant rows behind. Requires a
+  "what's in qdrant but not on disk" pass + a deletion contract.
+"""
 
 from __future__ import annotations
 
 import hashlib
 import logging
 from pathlib import Path
+from typing import Any, Literal, cast
 
 from musubi.planes.curated.plane import CuratedPlane
 from musubi.types.curated import CuratedKnowledge
@@ -14,55 +37,103 @@ logger = logging.getLogger(__name__)
 
 
 class VaultReconciler:
-    """Detects and repairs drift between the filesystem and Qdrant index."""
+    """Detects and repairs drift between the filesystem and Qdrant index.
+
+    Idempotent and skip-on-unchanged: files whose body-hash matches the
+    last reconciled state are not re-upserted. Files without
+    ``object_id`` frontmatter are skipped (the watcher slice — when
+    implemented — generates IDs at first save; the reconciler only
+    deals with already-stamped files).
+    """
 
     def __init__(self, vault_root: Path, curated_plane: CuratedPlane) -> None:
         self.vault_root = vault_root
         self.curated_plane = curated_plane
+        # In-memory body-hash cache: ``object_id`` → last-upserted hash.
+        # Survives the process lifetime; on restart the first pass
+        # re-upserts everything (one-time cost; subsequent passes are
+        # quiet). Bigger persistence would need a SQLite table — out of
+        # scope for this slice; the in-memory cache is enough to avoid
+        # the steady-state churn complaint.
+        self._last_seen_hash: dict[str, str] = {}
 
-    async def reconcile(self) -> None:
-        """Perform one full reconciliation pass."""
-        logger.info("Starting vault reconciliation in %s", self.vault_root)
+    async def reconcile(self) -> int:
+        """Perform one full reconciliation pass.
 
-        # 1. Scan vault for new/changed files
-        # use glob but be careful with case on some OSs
-        vault_files = list(self.vault_root.rglob("*"))
-        logger.info("Found %d total items in vault", len(vault_files))
-        print(f"DEBUG: all vault items: {vault_files}")
+        Returns the number of files actually upserted (not the total
+        scanned). The lifecycle scheduler doesn't use the return value;
+        it's exposed for tests + future operator endpoints.
+        """
+        logger.info("vault-reconcile starting in %s", self.vault_root)
 
-        processed = 0
-        for file_path in vault_files:
+        if not self.vault_root.exists():
+            logger.warning("vault-reconcile root does not exist: %s", self.vault_root)
+            return 0
+
+        scanned = 0
+        upserted = 0
+        skipped_unchanged = 0
+        skipped_no_id = 0
+        errored = 0
+
+        for file_path in self.vault_root.rglob("*"):
             if not file_path.is_file() or file_path.suffix.lower() != ".md":
                 continue
             rel_parts = file_path.relative_to(self.vault_root).parts
-            print(f"DEBUG: rel_parts for {file_path}: {rel_parts}")
-            if any(part.startswith(".") or part.startswith("_") for part in rel_parts):
+            # Hidden dirs (`.obsidian`, `.git`), Markdown-Obsidian
+            # scratch dirs (`_sketch`, `_secrets`), and similar.
+            if any(p.startswith(".") or p.startswith("_") for p in rel_parts):
                 continue
-            print(f"DEBUG: calling _reconcile_file for {file_path}")
-            await self._reconcile_file(file_path)
-            processed += 1
 
-        logger.info("Vault reconciliation complete. Processed %d md files", processed)
+            scanned += 1
+            outcome = await self._reconcile_file(file_path)
+            if outcome == "upserted":
+                upserted += 1
+            elif outcome == "unchanged":
+                skipped_unchanged += 1
+            elif outcome == "no_object_id":
+                skipped_no_id += 1
+            elif outcome == "error":
+                errored += 1
 
-    async def _reconcile_file(self, path: Path) -> None:
+        logger.info(
+            "vault-reconcile complete scanned=%d upserted=%d "
+            "unchanged=%d no_object_id=%d errored=%d",
+            scanned,
+            upserted,
+            skipped_unchanged,
+            skipped_no_id,
+            errored,
+        )
+        return upserted
+
+    async def _reconcile_file(
+        self, path: Path
+    ) -> Literal["upserted", "unchanged", "no_object_id", "error"]:
         rel_path = str(path.relative_to(self.vault_root))
-        print(f"DEBUG: reconciling file {rel_path}")
         try:
             content = path.read_text(encoding="utf-8")
             data, body = parse_frontmatter(content)
-            print(f"DEBUG: {rel_path} has object_id: {data.get('object_id')}")
-            if not data.get("object_id"):
-                # Watcher will pick this up or next boot scan
-                return
+            object_id = data.get("object_id")
+            if not object_id:
+                # Watcher will pick this up at first save; the reconciler
+                # only deals with already-stamped files.
+                return "no_object_id"
 
             body_hash = hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+            # Skip-on-unchanged: if we've already upserted this file at
+            # the current body-hash, no work to do. Saves an embedding
+            # call + qdrant write on every 6h tick for the steady-state
+            # case (vault is mostly read-only between writes).
+            previous_hash = self._last_seen_hash.get(str(object_id))
+            if previous_hash == body_hash:
+                return "unchanged"
+
             fm = CuratedFrontmatter.model_validate(data)
-
-            from typing import Literal, cast
-
             memory = CuratedKnowledge(
-                object_id=fm.object_id,  # type: ignore
-                namespace=fm.namespace,  # type: ignore
+                object_id=fm.object_id,  # type: ignore[arg-type]
+                namespace=fm.namespace,  # type: ignore[arg-type]
                 vault_path=rel_path,
                 body_hash=body_hash,
                 title=fm.title,
@@ -77,6 +148,62 @@ class VaultReconciler:
                 updated_at=fm.updated,
             )
             await self.curated_plane.create(memory)
+            self._last_seen_hash[str(object_id)] = body_hash
+            logger.debug("vault-reconcile upserted %s (hash=%s)", rel_path, body_hash[:12])
+            return "upserted"
 
         except Exception as exc:
-            logger.error("Failed to reconcile %s: %s", rel_path, exc)
+            logger.error("vault-reconcile failed for %s: %s", rel_path, exc)
+            return "error"
+
+
+def build_vault_reconcile_jobs(
+    *,
+    vault_root: Path,
+    curated_plane: CuratedPlane,
+    lock_dir: Path,
+) -> list[Any]:
+    """Return the one-element ``Job`` list for the lifecycle scheduler.
+
+    Mirrors :func:`musubi.lifecycle.scheduler.build_default_jobs`'s
+    ``vault_reconcile`` entry (interval=6h). File lock at
+    ``lock_dir/vault_reconcile.lock`` serialises against any other
+    worker attempting the same pass.
+
+    Replaces the placeholder ``_placeholder("vault_reconcile")`` that
+    logged "not yet implemented; skipping" on every tick before this
+    slice landed.
+    """
+    import asyncio as _asyncio
+
+    from musubi.lifecycle.scheduler import Job, file_lock
+
+    lock_path = lock_dir / "vault_reconcile.lock"
+    reconciler = VaultReconciler(vault_root=vault_root, curated_plane=curated_plane)
+
+    async def _run_once() -> None:
+        try:
+            upserted = await reconciler.reconcile()
+            logger.info("vault-reconcile-job done upserted=%d", upserted)
+        except Exception:
+            logger.exception("vault-reconcile-job failed")
+
+    def _runner() -> None:
+        with file_lock(lock_path) as acquired:
+            if not acquired:
+                logger.info("lifecycle-job=vault_reconcile lock-held; skipping run")
+                return
+            _asyncio.run(_run_once())
+
+    return [
+        Job(
+            name="vault_reconcile",
+            trigger_kind="interval",
+            trigger_kwargs={"hours": 6},
+            func=_runner,
+            grace_time_s=1800,
+        ),
+    ]
+
+
+__all__ = ["VaultReconciler", "build_vault_reconcile_jobs"]

--- a/tests/vault/test_reconciler.py
+++ b/tests/vault/test_reconciler.py
@@ -1,0 +1,222 @@
+"""Tests for `musubi.vault.reconciler.VaultReconciler`.
+
+Covers the substantive contract of the partial musubi#345 fix:
+
+- Files with `object_id` frontmatter get upserted to the curated plane.
+- Files without `object_id` are skipped (watcher's job).
+- Files with unchanged body-hash are skipped on re-pass (no embed churn).
+- Files in hidden / underscore-prefixed dirs are excluded.
+- Failures on individual files don't abort the whole pass.
+- `build_vault_reconcile_jobs` produces the correct Job shape.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from ksuid import Ksuid
+
+from musubi.vault.reconciler import VaultReconciler, build_vault_reconcile_jobs
+
+
+def _ksuid() -> str:
+    """Fresh 27-char base62 KSUID matching CuratedFrontmatter's
+    validator. Tests use this rather than hardcoded strings so each
+    seed produces a unique object_id."""
+    return str(Ksuid())
+
+
+def _seed_md(
+    root: Path,
+    rel: str,
+    *,
+    object_id: str | None = None,
+    body: str = "body content",
+    title: str = "Title",
+    namespace: str = "aoi/shared/curated",
+) -> Path:
+    """Write a markdown file with valid CuratedFrontmatter shape."""
+    fm_lines = ["---"]
+    if object_id is not None:
+        fm_lines.append(f"object_id: {object_id}")
+    fm_lines.extend(
+        [
+            f"namespace: {namespace}",
+            f"title: {title}",
+            "state: matured",
+            "importance: 5",
+            "topics: []",
+            "tags: []",
+            "version: 1",
+            "created: 2026-05-01T00:00:00Z",
+            "updated: 2026-05-01T00:00:00Z",
+            "---",
+            "",
+            body,
+            "",
+        ]
+    )
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(fm_lines), encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def mock_curated_plane() -> MagicMock:
+    plane = MagicMock()
+    plane.create = AsyncMock(return_value=None)
+    return plane
+
+
+@pytest.mark.asyncio
+async def test_reconcile_upserts_stamped_file(
+    tmp_path: Path, mock_curated_plane: MagicMock
+) -> None:
+    _seed_md(tmp_path, "note.md", object_id=_ksuid())
+    rec = VaultReconciler(vault_root=tmp_path, curated_plane=mock_curated_plane)
+    upserted = await rec.reconcile()
+    assert upserted == 1
+    mock_curated_plane.create.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_skips_files_without_object_id(
+    tmp_path: Path, mock_curated_plane: MagicMock
+) -> None:
+    _seed_md(tmp_path, "no-id.md", object_id=None)
+    rec = VaultReconciler(vault_root=tmp_path, curated_plane=mock_curated_plane)
+    upserted = await rec.reconcile()
+    assert upserted == 0
+    mock_curated_plane.create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_skips_unchanged_on_second_pass(
+    tmp_path: Path, mock_curated_plane: MagicMock
+) -> None:
+    """Body-hash cache: same body → no second upsert. The core scope
+    of the musubi#345 cleanup — without this, every 6h tick re-embeds
+    the entire vault."""
+    _seed_md(tmp_path, "stable.md", object_id=_ksuid(), body="unchanged body")
+    rec = VaultReconciler(vault_root=tmp_path, curated_plane=mock_curated_plane)
+
+    first = await rec.reconcile()
+    second = await rec.reconcile()
+    assert first == 1
+    assert second == 0
+    assert mock_curated_plane.create.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_reconcile_reupserts_when_body_changes(
+    tmp_path: Path, mock_curated_plane: MagicMock
+) -> None:
+    obj_id = _ksuid()
+    _seed_md(tmp_path, "evolving.md", object_id=obj_id, body="first body")
+    rec = VaultReconciler(vault_root=tmp_path, curated_plane=mock_curated_plane)
+
+    await rec.reconcile()
+    # Re-seed with a different body but same object_id.
+    _seed_md(tmp_path, "evolving.md", object_id=obj_id, body="second body")
+    second = await rec.reconcile()
+    assert second == 1
+    assert mock_curated_plane.create.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_reconcile_excludes_hidden_and_underscore_dirs(
+    tmp_path: Path, mock_curated_plane: MagicMock
+) -> None:
+    _seed_md(tmp_path, "_secrets/keychain.md", object_id=_ksuid())
+    _seed_md(tmp_path, ".obsidian/workspace.md", object_id=_ksuid())
+    _seed_md(tmp_path, "normal.md", object_id=_ksuid())
+    rec = VaultReconciler(vault_root=tmp_path, curated_plane=mock_curated_plane)
+    upserted = await rec.reconcile()
+    assert upserted == 1
+
+
+@pytest.mark.asyncio
+async def test_reconcile_non_md_files_ignored(
+    tmp_path: Path, mock_curated_plane: MagicMock
+) -> None:
+    (tmp_path / "note.txt").write_text("not markdown")
+    (tmp_path / "image.png").write_bytes(b"binary")
+    rec = VaultReconciler(vault_root=tmp_path, curated_plane=mock_curated_plane)
+    upserted = await rec.reconcile()
+    assert upserted == 0
+
+
+@pytest.mark.asyncio
+async def test_reconcile_missing_root_returns_zero(
+    tmp_path: Path, mock_curated_plane: MagicMock
+) -> None:
+    nonexistent = tmp_path / "does-not-exist"
+    rec = VaultReconciler(vault_root=nonexistent, curated_plane=mock_curated_plane)
+    upserted = await rec.reconcile()
+    assert upserted == 0
+
+
+@pytest.mark.asyncio
+async def test_reconcile_individual_failure_doesnt_abort_pass(
+    tmp_path: Path, mock_curated_plane: MagicMock
+) -> None:
+    """One bad file shouldn't take down the whole pass."""
+    _seed_md(tmp_path, "ok-1.md", object_id=_ksuid())
+    _seed_md(tmp_path, "ok-2.md", object_id=_ksuid())
+    # Corrupted frontmatter on the third file.
+    (tmp_path / "broken.md").write_text(
+        "---\n[not valid yaml because: of: this\n---\n\nbody\n", encoding="utf-8"
+    )
+    rec = VaultReconciler(vault_root=tmp_path, curated_plane=mock_curated_plane)
+    upserted = await rec.reconcile()
+    # Two good files upserted; broken one logged + skipped.
+    assert upserted == 2
+
+
+def test_build_vault_reconcile_jobs_produces_correct_shape(
+    tmp_path: Path, mock_curated_plane: MagicMock
+) -> None:
+    lock_dir = tmp_path / "locks"
+    lock_dir.mkdir()
+    jobs = build_vault_reconcile_jobs(
+        vault_root=tmp_path,
+        curated_plane=mock_curated_plane,
+        lock_dir=lock_dir,
+    )
+    assert len(jobs) == 1
+    job = jobs[0]
+    assert job.name == "vault_reconcile"
+    assert job.trigger_kind == "interval"
+    assert job.trigger_kwargs == {"hours": 6}
+    # Callable wires correctly — invoking it should acquire the lock,
+    # run the (empty) reconciler, and release. No exception.
+    job.func()
+    assert (lock_dir / "vault_reconcile.lock").exists()
+
+
+def test_build_lifecycle_jobs_includes_real_vault_reconcile_job(
+    tmp_path: Path, mock_curated_plane: MagicMock
+) -> None:
+    """The lifecycle wiring should pick up the real vault_reconcile job
+    instead of the placeholder. Without this, the lifecycle worker
+    would keep logging 'not yet implemented; skipping' even after the
+    reconciler is shipped."""
+    from musubi.lifecycle.runner import build_lifecycle_jobs
+
+    lock_dir = tmp_path / "locks"
+    lock_dir.mkdir()
+    vault_reconcile_jobs = build_vault_reconcile_jobs(
+        vault_root=tmp_path,
+        curated_plane=mock_curated_plane,
+        lock_dir=lock_dir,
+    )
+    composed: list[Any] = build_lifecycle_jobs(vault_reconcile_jobs=vault_reconcile_jobs)
+    vr_jobs = [j for j in composed if j.name == "vault_reconcile"]
+    assert len(vr_jobs) == 1
+    # And it's our real one, not the placeholder lambda that logs "not yet implemented".
+    assert vr_jobs[0].trigger_kind == "interval"
+    assert vr_jobs[0].trigger_kwargs == {"hours": 6}

--- a/tests/vault/test_sync.py
+++ b/tests/vault/test_sync.py
@@ -480,8 +480,13 @@ async def test_reconciler_idempotent_on_second_run(
     await reconciler.reconcile()
 
     plane = reconciler.curated_plane
-    # create called twice, but CuratedPlane implementation handles the actual Qdrant idempotency
-    assert len(plane.created) == 2  # type: ignore
+    # Per musubi#345's skip-on-unchanged cache: the second reconcile
+    # pass sees the same body-hash and skips the upsert entirely (no
+    # embedding churn on every 6h tick). Before #345 this assertion was
+    # `== 2` — CuratedPlane handled the Qdrant idempotency downstream,
+    # but the reconciler still re-paid the embed cost. Now idempotency
+    # is enforced at the reconciler boundary too.
+    assert len(plane.created) == 1  # type: ignore
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Partial fix for #345. Replaces the `_placeholder("vault_reconcile")` lambda that's been logging "not yet implemented; skipping" every 6 hours since the lifecycle engine landed. With this PR merged + deployed, vault markdown files with `object_id` frontmatter will be reconciled into the curated plane on the scheduled cadence.

## What's in scope

- Clean up partially-built `reconciler.py` (debug prints, structured logging, skip-on-unchanged via body-hash cache).
- New `build_vault_reconcile_jobs` mirroring the other builders.
- Wire into `_main_async` so the scheduler picks up the real callable.
- 10 new tests + update to one pre-existing assertion.

## What's NOT in scope (separate sessions per #345)

- **`musubi-vault-watcher` compose deployment** — needs a where-does-the-vault-live decision (laptop-mounted? NAS? git-synced?).
- **Deletion handling** — reconciler is upsert-only. Requires a deletion contract.

These two close #345 fully; this PR moves the placeholder log line off the worker and the periodic sweep IS now wired and idempotent.

## Test plan

- [x] `uv run pytest tests/vault tests/api tests/lifecycle tests/observability tests/retrieve` — 624 passed, 100 skipped, 0 failures
- [x] mypy + ruff clean
- [ ] Post-merge + hw-ansible-deploy: lifecycle-worker stops logging "lifecycle-job=vault_reconcile not yet implemented; skipping" on each 6h tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)