### PR TITLE
fix(curated): same-id new-body is an UPDATE, not supersession (closes #362)

### DIFF
--- a/src/musubi/planes/curated/plane.py
+++ b/src/musubi/planes/curated/plane.py
@@ -159,15 +159,26 @@ class CuratedPlane:
         # supersession is for distinct objects sharing a vault slot;
         # same-id-different-body is just an in-place update.
         if memory.object_id == existing.object_id:
-            updated_data = existing.model_dump()
+            # Start from the FULL incoming memory so frontmatter-driven
+            # changes (valid_from/valid_until, musubi_managed, vault_path,
+            # state, etc.) all reach storage — earlier draft of this
+            # branch hand-copied a subset and silently dropped the rest
+            # (Copilot review on PR #363). Then preserve the invariants
+            # that must come from `existing`: the identity (object_id),
+            # the creation timestamps (immutable across an update), the
+            # lineage trail (supersedes/superseded_by carried forward
+            # untouched), and any state machine fields the update isn't
+            # supposed to mutate in-place. Bump version + refresh
+            # updated_at last.
+            updated_data = memory.model_dump()
             updated_data.update(
-                content=memory.content,
-                body_hash=memory.body_hash,
-                title=memory.title,
-                summary=memory.summary,
-                topics=memory.topics,
-                tags=memory.tags,
-                importance=memory.importance,
+                object_id=existing.object_id,
+                created_at=existing.created_at,
+                created_epoch=existing.created_epoch,
+                supersedes=existing.supersedes,
+                superseded_by=existing.superseded_by,
+                promoted_from=existing.promoted_from,
+                promoted_at=existing.promoted_at,
                 version=existing.version + 1,
                 updated_at=now,
                 updated_epoch=epoch_of(now),

--- a/src/musubi/planes/curated/plane.py
+++ b/src/musubi/planes/curated/plane.py
@@ -147,12 +147,43 @@ class CuratedPlane:
             self._upsert(fresh, dense=dense, sparse=sparse)
             return fresh
 
-        # Supersession path. Two writes: re-embed the new row, mark the
-        # old row superseded. Both writes hit the same collection; if the
-        # second one fails the first one is still on disk — acceptable
-        # because a stale "superseded" row simply won't appear in default
-        # queries until the supersession completes (eventual consistency
-        # handled at slice-lifecycle-engine).
+        # Same logical object (same `object_id` in vault frontmatter),
+        # new body: this is an UPDATE, not a supersession. Pre-musubi#362
+        # the code below went into the supersession path even for this
+        # case, which built a new_row with `object_id == existing.object_id`
+        # AND `supersedes=[existing.object_id]` — failing the
+        # `MemoryObject` invariant "object cannot appear in its own
+        # supersedes list." Surfaced loudly the first time vault_reconcile
+        # actually ran (musubi#357 deploy), errored 11 of 26 reflection
+        # files. Distinguishing the two cases here is the honest semantic:
+        # supersession is for distinct objects sharing a vault slot;
+        # same-id-different-body is just an in-place update.
+        if memory.object_id == existing.object_id:
+            updated_data = existing.model_dump()
+            updated_data.update(
+                content=memory.content,
+                body_hash=memory.body_hash,
+                title=memory.title,
+                summary=memory.summary,
+                topics=memory.topics,
+                tags=memory.tags,
+                importance=memory.importance,
+                version=existing.version + 1,
+                updated_at=now,
+                updated_epoch=epoch_of(now),
+            )
+            updated = CuratedKnowledge.model_validate(updated_data)
+            dense, sparse = await self._embed_both(_embed_target(updated))
+            self._upsert(updated, dense=dense, sparse=sparse)
+            return updated
+
+        # True supersession path (distinct objects sharing a vault slot).
+        # Two writes: insert the new row, mark the old row superseded.
+        # Both writes hit the same collection; if the second fails the
+        # first is still on disk — acceptable because a stale "superseded"
+        # row won't appear in default queries until the supersession
+        # completes (eventual consistency handled at
+        # slice-lifecycle-engine).
         data = memory.model_dump()
         data.update(
             state="matured",

--- a/tests/planes/test_curated.py
+++ b/tests/planes/test_curated.py
@@ -489,6 +489,54 @@ async def test_create_auto_embeds_dense_and_sparse_vectors(
     assert "sparse_splade_v1" in vectors
 
 
+async def test_create_same_object_id_new_body_updates_in_place(
+    plane: CuratedPlane, ns: str
+) -> None:
+    """Regression for musubi#362.
+
+    The supersession path was triggered any time `body_hash` differed
+    from the existing row's hash — even when `memory.object_id ==
+    existing.object_id` (the common case for vault reconcile: same file,
+    edited body). It built `new_row(object_id=X, supersedes=[X])` which
+    fails the MemoryObject invariant "object cannot appear in its own
+    supersedes list."
+
+    The fix: distinguish same-id-update from supersession. Same id +
+    new body should produce an updated row at the SAME object_id, with
+    `supersedes=[]` and an incremented version. Locks in the contract.
+    """
+    first = await plane.create(
+        _make(namespace=ns, content="original body", vault_path="curated/eric/note.md")
+    )
+
+    # Reconciler-style: same file (same object_id, same vault_path),
+    # edited body. Build a CuratedKnowledge with the existing object_id.
+    edited = _make(
+        namespace=ns,
+        content="edited body",
+        vault_path="curated/eric/note.md",
+        object_id=first.object_id,
+    )
+    updated = await plane.create(edited)
+
+    # Same logical row — id preserved.
+    assert updated.object_id == first.object_id
+    # Version bumped (update increments).
+    assert updated.version == first.version + 1
+    # New content reached storage.
+    assert updated.content == "edited body"
+    assert updated.body_hash != first.body_hash
+    # Supersession invariants: NOT a supersession (so the dangerous
+    # validator wouldn't have a chance to fail anyway).
+    assert updated.supersedes == []
+    assert updated.superseded_by is None
+
+    # And it's actually fetchable from storage (round-trip via get).
+    fetched = await plane.get(namespace=ns, object_id=first.object_id)
+    assert fetched is not None
+    assert fetched.content == "edited body"
+
+
 async def test_query_excludes_archived_by_default(plane: CuratedPlane, ns: str) -> None:
     saved = await plane.create(
         _make(namespace=ns, content="hidden-me", vault_path="curated/eric/hidden.md")

--- a/tests/planes/test_curated.py
+++ b/tests/planes/test_curated.py
@@ -537,6 +537,58 @@ async def test_create_same_object_id_new_body_updates_in_place(
     assert fetched.content == "edited body"
 
 
+async def test_create_same_object_id_update_propagates_frontmatter_fields(
+    plane: CuratedPlane, ns: str
+) -> None:
+    """Companion to musubi#362 — make sure the update path doesn't
+    silently drop fields that aren't body/title.
+
+    The earlier Copilot review on PR #363 pointed out that hand-copying
+    a subset of fields (content/title/summary/topics/tags/importance)
+    would leave bitemporal validity (`valid_from`, `valid_until`),
+    `musubi_managed`, and other frontmatter-driven fields stale across
+    a reconcile. Update path now starts from the FULL incoming memory
+    and preserves only identity/creation/lineage from existing.
+    """
+    now = datetime.now(UTC)
+    first = await plane.create(
+        _make(
+            namespace=ns,
+            content="original body",
+            vault_path="curated/eric/dated.md",
+            valid_from=now - timedelta(days=30),
+            valid_until=now + timedelta(days=30),
+            musubi_managed=True,
+        )
+    )
+
+    edited = _make(
+        namespace=ns,
+        content="edited body",
+        vault_path="curated/eric/dated.md",
+        object_id=first.object_id,
+        # Frontmatter edits the operator might make:
+        valid_from=now - timedelta(days=15),  # narrowed
+        valid_until=now + timedelta(days=60),  # extended
+        musubi_managed=False,  # operator un-flagged
+        tags=["edited", "newtag"],
+        importance=9,
+    )
+    updated = await plane.create(edited)
+
+    # All edited fields reached storage.
+    assert updated.valid_from is not None
+    assert updated.valid_until is not None
+    assert (now - timedelta(days=16)) <= updated.valid_from <= (now - timedelta(days=14))
+    assert (now + timedelta(days=59)) <= updated.valid_until <= (now + timedelta(days=61))
+    assert updated.musubi_managed is False
+    assert set(updated.tags) == {"edited", "newtag"}
+    assert updated.importance == 9
+    # And identity/creation invariants preserved.
+    assert updated.object_id == first.object_id
+    assert updated.created_at == first.created_at
+
+
 async def test_query_excludes_archived_by_default(plane: CuratedPlane, ns: str) -> None:
     saved = await plane.create(
         _make(namespace=ns, content="hidden-me", vault_path="curated/eric/hidden.md")


### PR DESCRIPTION
## Summary

Closes #362. `CuratedPlane.create` was firing the supersession path for the common reconcile case (same `object_id`, edited body), constructing `new_row(object_id=X, supersedes=[X])` which fails the MemoryObject "object cannot appear in its own supersedes list" validator. Pre-musubi#357 the reconciler was a placeholder, so the bug never surfaced; post-#357's deploy tonight, 11 of 26 reflection markdown files failed reconcile with this exact error.

## Fix

Distinguish same-id-update (in-place version bump, supersedes stays empty) from real supersession (different objects sharing a vault slot). One added branch in `CuratedPlane.create`.

## Test plan
- [x] New regression test `test_create_same_object_id_new_body_updates_in_place` locks in the contract
- [x] 547 tests pass across planes/vault/api/lifecycle; mypy + ruff clean
- [ ] Post-merge + deploy: next vault_reconcile sweep produces `errored=0` instead of `errored=11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)