### PR TITLE
fix(lifecycle): wrap embedder in ChunkedEmbedder (closes #367)

### DIFF
--- a/src/musubi/lifecycle/runner.py
+++ b/src/musubi/lifecycle/runner.py
@@ -292,6 +292,7 @@ async def _main_async() -> None:
     from pathlib import Path
 
     from musubi.config import get_settings
+    from musubi.embedding.chunked import ChunkedEmbedder
     from musubi.embedding.tei import TEIDenseClient, TEIRerankerClient, TEISparseClient
     from musubi.lifecycle.demotion import DemotionDeps, build_demotion_jobs
     from musubi.lifecycle.emitters import (
@@ -368,10 +369,18 @@ async def _main_async() -> None:
     # Protocols — see src/musubi/llm/ollama.py.
     ollama = default_ollama_client()
 
-    embedder = _TEICompositeEmbedder(
-        dense=TEIDenseClient(base_url=str(settings.tei_dense_url)),
-        sparse=TEISparseClient(base_url=str(settings.tei_sparse_url)),
-        reranker=TEIRerankerClient(base_url=str(settings.tei_reranker_url)),
+    # Wrap the composite in ChunkedEmbedder so sparse inputs > 510 tokens
+    # are sliding-window-chunked + max-pooled before they hit tei-sparse
+    # (SPLADE-v3 has a hard 512-token model cap). The API server's
+    # bootstrap (src/musubi/api/bootstrap.py) wraps the same way; without
+    # this, vault_reconcile / synthesis / any lifecycle-side embed of a
+    # long input HTTP 413s. See musubi#367.
+    embedder = ChunkedEmbedder(
+        _TEICompositeEmbedder(
+            dense=TEIDenseClient(base_url=str(settings.tei_dense_url)),
+            sparse=TEISparseClient(base_url=str(settings.tei_sparse_url)),
+            reranker=TEIRerankerClient(base_url=str(settings.tei_reranker_url)),
+        )
     )
 
     episodic_plane = EpisodicPlane(client=qdrant, embedder=embedder)


### PR DESCRIPTION
## Summary

Fixes #367. Lifecycle worker was building \`_TEICompositeEmbedder\` directly without the \`ChunkedEmbedder\` wrap that \`api/bootstrap.py:216\` uses. Any vault file > 510 tokens bounced with HTTP 413 from tei-sparse on every reconcile tick.

ChunkedEmbedder (already in the codebase, \`src/musubi/embedding/chunked.py\`) handles this canonically: SPLADE-v3 tokenizer windowing + sliding-window chunks + max-pool aggregation — the standard SPLADE long-doc pattern.

One wrap at \`runner.py:371-381\` propagates to every plane (episodic / concept / curated / thoughts / artifact) and to \`vault_reconcile_jobs\` via the shared embedder reference. No API-surface change, no new dependency, no env var.

## How surfaced

Observed live on \`musubi.mey.house\` after the v1.10.1 deploy:

\`\`\`
{"ts": "2026-05-18T03:42:45.702Z", "level": "error",
 "service": "musubi.vault.reconciler",
 "msg": "vault-reconcile failed for vault/reflections/2026-04/2026-04-23.md:
         TEI returned 413: inputs must have less than 512 tokens. Given: 691"}
\`\`\`

The reconciler logged this on every 6h tick because the file is structurally over the cap.

## Why this and not option (4) from #367

I investigated retiring tei-sparse entirely by routing sparse through bge-m3 (which is already deployed on tei-dense with an 8192-token window). The probe failed cleanly:

\`\`\`
$ curl tei-dense/info  →  "pooling":"cls"
$ curl tei-dense/embed_sparse  →  "Model is not an embedding model with SPLADE pooling"
\`\`\`

TEI 1.2.0's \`/embed_sparse\` only works with a SPLADE-pooled model; bge-m3 was deployed with CLS pooling. Switching it would require either a second bge-m3 container with \`--pooling splade\` (and verifying that mode actually exposes the lexical-weights output — uncertain) or bypassing TEI and running bge-m3 in-process with the FlagEmbedding SDK. Both are bigger redesigns; (4) stays open in #367 as a future cleanup.

The chunking wrap is option (1) from #367 — the principled SPLADE-standard fix — and the infrastructure was already built. Wiring it in costs one wrap.

## Test plan

- [x] \`uv run pytest tests/lifecycle/\` — 202 passed, 40 skipped (pre-existing skips)
- [x] \`uv run mypy src/musubi/lifecycle/runner.py\` — clean
- [x] \`uv run ruff check src/musubi/lifecycle/runner.py\` — clean
- [x] \`uv run ruff format --check\` — clean
- [ ] Post-deploy: \`vault/reflections/2026-04/2026-04-23.md\` reconciles successfully on the next tick (errored=0)
- [ ] Post-deploy: \`musubi_lifecycle_*\` show no new 413 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)