### PR TITLE
fix(mcp): musubi_get 2-part namespace foot-gun + wire musubi_recent (#288)

### DIFF
--- a/src/musubi/adapters/mcp/tools.py
+++ b/src/musubi/adapters/mcp/tools.py
@@ -211,8 +211,10 @@ def attach_tools(mcp: FastMCP, client: AsyncMusubiClient) -> None:
         description=(
             "Recent activity in a namespace, newest first — no query needed. "
             "Use to orient ('what's happened lately') rather than to search. "
-            "Pass the 2-part presence root (e.g. `aoi/command-chair`) to span "
-            "every plane. Optional `tags` is an AND-filter (e.g. "
+            "A 2-part presence root (e.g. `aoi/command-chair`) returns recent "
+            "episodic memories (the default plane); pass a full 3-part "
+            "namespace (e.g. `aoi/command-chair/curated`) to see another "
+            "plane's recents. Optional `tags` is an AND-filter (e.g. "
             "`src:mcp-agent-remember` for captures from coding-agent sessions)."
         ),
     )

--- a/src/musubi/adapters/mcp/tools.py
+++ b/src/musubi/adapters/mcp/tools.py
@@ -10,9 +10,8 @@ Tools registered:
 - ``musubi_get`` — fetch one object's full content + metadata by id
 - ``musubi_remember`` — explicit episodic capture
 - ``musubi_think`` — presence-to-presence message
-- ``musubi_recent`` — recency-ordered scroll
-  (currently a deferred stub — depends on [[_slices/slice-retrieve-
-  recent]] / Musubi #288 for ``mode=recent``)
+- ``musubi_recent`` — recency-ordered scroll (``retrieve`` ``mode=recent``,
+  no query needed), backed by [[_slices/slice-retrieve-recent]] / Musubi #288
 
 Plus two deprecation aliases for one minor release:
 
@@ -23,6 +22,7 @@ Plus two deprecation aliases for one minor release:
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -203,39 +203,25 @@ def attach_tools(mcp: FastMCP, client: AsyncMusubiClient) -> None:
         return f"Sent to {to_presence}. (id={res['object_id']})"
 
     # ------------------------------------------------------------------
-    # musubi_recent — deferred stub (#288 / slice-retrieve-recent)
+    # musubi_recent — recency-ordered scroll (retrieve mode=recent)
     # ------------------------------------------------------------------
 
     @mcp.tool(
         name="musubi_recent",
         description=(
-            "Recent activity, recency-ordered, no query needed. NOT YET "
-            "WIRED — depends on slice-retrieve-recent (Musubi #288). The "
-            "tool registers so its name is reserved at the canonical "
-            "surface; calls return a clear deferred message until the "
-            "backend ships."
+            "Recent activity in a namespace, newest first — no query needed. "
+            "Use to orient ('what's happened lately') rather than to search. "
+            "Pass the 2-part presence root (e.g. `aoi/command-chair`) to span "
+            "every plane. Optional `tags` is an AND-filter (e.g. "
+            "`src:mcp-agent-remember` for captures from coding-agent sessions)."
         ),
     )
     async def musubi_recent(
         namespace: str,
         limit: int = 10,
+        tags: list[str] | None = None,
     ) -> str:
-        # Per [[CLAUDE#prohibited-patterns]]: ADR-punted dependencies fail
-        # loud. This tool's contract is canonical, but the backend it needs
-        # (`mode=recent`) is on the way. We return a clearly user-readable
-        # message rather than silently no-op, and we log at WARNING so the
-        # operator notices repeated calls in degraded mode.
-        logger.warning(
-            "musubi_recent invoked but is not yet available "
-            "(deferred to slice-retrieve-recent / Musubi #288)"
-        )
-        return (
-            "musubi_recent is not yet available — its backend dependency "
-            "(slice-retrieve-recent, Musubi #288) hasn't shipped. Until it does, "
-            "use `musubi_search` with a date- or recency-flavored query as a "
-            "workaround. Tracking issue: "
-            "https://github.com/ericmey/musubi/issues/288"
-        )
+        return await _do_recent(client, namespace=namespace, limit=limit, tags=tags)
 
     # ------------------------------------------------------------------
     # Deprecation aliases — one minor release, then drop
@@ -327,6 +313,62 @@ async def _do_search(
         ns = hit.get("namespace") or namespace
         title_or_oid = hit.get("title") or f"{ns}/{oid}"
         lines.append(f"[{plane}]{score_str} {title_or_oid}")
+        content = (hit.get("content") or hit.get("snippet") or "").strip()
+        if content:
+            lines.append(content)
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def _fmt_recent_when(score: Any) -> str:
+    """Render a recent row's ``score`` (which is ``created_epoch`` in recent
+    mode) as a compact UTC timestamp. Returns ``""`` if it isn't a usable
+    epoch so the line degrades to just the id rather than erroring."""
+    if not isinstance(score, (int, float)):
+        return ""
+    try:
+        return datetime.fromtimestamp(score, tz=UTC).strftime("%Y-%m-%d %H:%M") + "  "
+    except (ValueError, OverflowError, OSError):
+        return ""
+
+
+async def _do_recent(
+    client: AsyncMusubiClient,
+    *,
+    namespace: str,
+    limit: int,
+    tags: list[str] | None,
+) -> str:
+    """Backing implementation for ``musubi_recent`` — ``retrieve(mode="recent")``.
+
+    No query, no rerank: rows come back newest-first (``score`` is
+    ``created_epoch``), so order is the signal. Renders a timestamp instead of
+    the raw epoch ``score`` that ``_do_search`` would show.
+    """
+    try:
+        res = await client.retrieve(
+            namespace=namespace,
+            mode="recent",
+            limit=limit,
+            tags=tags,
+        )
+    except Exception as e:
+        return f"Error: {e}"
+    rows: list[dict[str, Any]] = res.get("results") or []
+    if not rows:
+        scope = f" tagged {', '.join(tags)}" if tags else ""
+        return f"No recent activity in {namespace!r}{scope}."
+    suffix = f" tagged {', '.join(tags)}" if tags else ""
+    lines: list[str] = [f"{len(rows)} recent in {namespace!r}{suffix} (newest first):", ""]
+    for hit in rows:
+        plane = hit.get("plane") or "memory"
+        oid = hit.get("object_id") or "<no-id>"
+        ns = hit.get("namespace") or namespace
+        head = f"[{plane}] {_fmt_recent_when(hit.get('score'))}{ns}/{oid}"
+        title = hit.get("title")
+        if title:
+            head += f" — {title}"
+        lines.append(head)
         content = (hit.get("content") or hit.get("snippet") or "").strip()
         if content:
             lines.append(content)

--- a/src/musubi/adapters/mcp/tools.py
+++ b/src/musubi/adapters/mcp/tools.py
@@ -52,6 +52,28 @@ _PLANE_ATTR: dict[str, str] = {
 }
 
 
+def _normalize_get_namespace(namespace: str, plane: str) -> str:
+    """Resolve the namespace ``musubi_get`` needs from what an agent realistically passes.
+
+    Objects are stored under the canonical 3-part namespace
+    ``tenant/presence/plane`` (e.g. ``aoi/command-chair/episodic``), and
+    ``get`` filters on it exactly. But ``musubi_search`` accepts — and is
+    usually called with — the **2-part presence root** (``aoi/command-chair``),
+    because a 2-part namespace is a *blended* cross-plane query. Search result
+    rows then render the full 3-part namespace, so an agent passing "namespace +
+    plane straight from a search row" naturally splits off the 2-part root and a
+    separate plane. Composing them here makes that Just Work instead of returning
+    a false ``NOT_FOUND`` that an exact-namespace filter could never match.
+
+    A 2-part namespace + ``plane`` composes to ``{namespace}/{plane}``; an
+    already-3-part namespace is trusted as-is.
+    """
+    ns = namespace.rstrip("/")
+    if ns.count("/") == 1:  # exactly 2 parts → presence root, append the plane
+        return f"{ns}/{plane}"
+    return ns
+
+
 def attach_tools(mcp: FastMCP, client: AsyncMusubiClient) -> None:
     """Register every canonical agent tool on the given FastMCP server.
 
@@ -92,7 +114,10 @@ def attach_tools(mcp: FastMCP, client: AsyncMusubiClient) -> None:
             "Fetch one Musubi object's full content + metadata by id. "
             "Use after `musubi_search` when a snippet looks load-bearing "
             "and you need the underlying source. Pass `plane`, `namespace`, "
-            "and `object_id` straight from a search result row."
+            "and `object_id` straight from a search result row — `namespace` "
+            "may be the 2-part presence root (e.g. `aoi/command-chair`) or the "
+            "full 3-part namespace (`aoi/command-chair/episodic`); the 2-part "
+            "form is composed with `plane` automatically."
         ),
     )
     async def musubi_get(
@@ -102,6 +127,7 @@ def attach_tools(mcp: FastMCP, client: AsyncMusubiClient) -> None:
     ) -> str:
         if plane not in _PLANE_ATTR:
             return f"Error: unknown plane {plane!r} — must be one of {sorted(_PLANE_ATTR)}."
+        namespace = _normalize_get_namespace(namespace, plane)
         plane_client = getattr(client, _PLANE_ATTR[plane])
         try:
             row = await plane_client.get(namespace=namespace, object_id=object_id)

--- a/tests/adapters/test_mcp_canonical_tools.py
+++ b/tests/adapters/test_mcp_canonical_tools.py
@@ -33,6 +33,7 @@ class _PlaneStub:
         self.name = name
         self.store = store if store is not None else {}
         self.captured: list[dict[str, Any]] = []
+        self.get_calls: list[dict[str, str]] = []
 
     async def capture(
         self,
@@ -57,6 +58,7 @@ class _PlaneStub:
         return {"object_id": oid, "state": "provisional"}
 
     async def get(self, *, namespace: str, object_id: str) -> dict[str, Any]:
+        self.get_calls.append({"namespace": namespace, "object_id": object_id})
         if object_id not in self.store:
             from musubi.sdk.exceptions import NotFound
 
@@ -292,6 +294,51 @@ async def test_get_unknown_id_returns_tool_error_with_id_and_namespace() -> None
     )
     assert "missing-xyz" in result
     assert "eric/claude-code/episodic" in result
+
+
+def test_normalize_get_namespace_composes_two_part_root_with_plane() -> None:
+    from musubi.adapters.mcp.tools import _normalize_get_namespace
+
+    # 2-part presence root (what musubi_search takes) + plane → canonical 3-part
+    assert _normalize_get_namespace("aoi/command-chair", "episodic") == "aoi/command-chair/episodic"
+    # trailing slash on the root is tolerated, not double-slashed
+    assert _normalize_get_namespace("aoi/command-chair/", "curated") == "aoi/command-chair/curated"
+    # an already-3-part namespace is trusted as-is — never double-suffixed
+    assert (
+        _normalize_get_namespace("aoi/command-chair/episodic", "episodic")
+        == "aoi/command-chair/episodic"
+    )
+    # an explicit 3-part namespace is left alone even if its tail differs from `plane`
+    assert (
+        _normalize_get_namespace("aoi/command-chair/episodic", "curated")
+        == "aoi/command-chair/episodic"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_accepts_two_part_root_and_composes_plane() -> None:
+    # Regression: an agent that splits a search result row into the 2-part presence
+    # root + a plane (the natural reading) must still resolve to the stored 3-part
+    # namespace — not a false NOT_FOUND. (2026-06-07 namespace foot-gun.)
+    mcp, client = _make_server()
+    client.episodic.store["ep-2"] = {
+        "object_id": "ep-2",
+        "namespace": "eric/claude-code/episodic",
+        "content": "Body fetched via the 2-part presence root.",
+        "title": None,
+    }
+    result = await _invoke(
+        mcp,
+        "musubi_get",
+        plane="episodic",
+        namespace="eric/claude-code",  # 2-part root, NOT the full 3-part namespace
+        object_id="ep-2",
+    )
+    assert "Body fetched via the 2-part presence root." in result
+    # the SDK get() was actually called with the composed canonical namespace
+    assert client.episodic.get_calls[-1]["namespace"] == "eric/claude-code/episodic"
+    # and the rendered header reflects it
+    assert "eric/claude-code/episodic/ep-2" in result
 
 
 # --------------------------------------------------------------------------

--- a/tests/adapters/test_mcp_canonical_tools.py
+++ b/tests/adapters/test_mcp_canonical_tools.py
@@ -121,10 +121,12 @@ class _ClientStub:
         self,
         *,
         namespace: str,
-        query_text: str,
+        query_text: str = "",
         mode: str = "fast",
         limit: int = 10,
         planes: list[str] | None = None,
+        since: float | None = None,
+        tags: list[str] | None = None,
     ) -> dict[str, Any]:
         self._retrieve_calls.append(
             {
@@ -133,6 +135,8 @@ class _ClientStub:
                 "mode": mode,
                 "limit": limit,
                 "planes": planes,
+                "since": since,
+                "tags": tags,
             }
         )
         if self._retrieve_raise is not None:
@@ -408,24 +412,69 @@ async def test_think_sends_thought_to_recipient_presence() -> None:
 
 
 # --------------------------------------------------------------------------
-# musubi_recent — deferred stub
+# musubi_recent
 # --------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_recent_returns_deferred_message_until_backend_lands() -> None:
-    """`musubi_recent` is the canonical-contract tool; its full implementation
-    waits on slice-retrieve-recent (Musubi #288). The stub must return a
-    clearly user-readable deferred message, not silently no-op or 500."""
-    mcp, _ = _make_server()
+async def test_recent_invokes_retrieve_recent_mode_without_query() -> None:
+    """`musubi_recent` runs retrieve in recent mode with no query_text, and
+    renders each row newest-first with a timestamp from the created_epoch
+    (carried as `score`), not the raw float."""
+    mcp, client = _make_server()
+    client._retrieve_response = {
+        "results": [
+            {
+                "plane": "episodic",
+                "object_id": "ep-9",
+                "namespace": "aoi/command-chair/episodic",
+                "title": None,
+                "snippet": "the freshest thing that happened",
+                "score": 1780794147.0,  # created_epoch → 2026-06-07 01:02 UTC
+            }
+        ]
+    }
     result = await _invoke(
         mcp,
         "musubi_recent",
-        namespace="eric/claude-code",
-        limit=10,
+        namespace="aoi/command-chair",
+        limit=5,
     )
-    assert "not yet available" in result.lower() or "deferred" in result.lower()
-    assert "slice-retrieve-recent" in result or "#288" in result
+    call = client._retrieve_calls[-1]
+    assert call["mode"] == "recent"
+    assert call["query_text"] == ""  # recent omits the query
+    assert call["limit"] == 5
+    assert "the freshest thing that happened" in result
+    assert "aoi/command-chair/episodic/ep-9" in result
+    assert "2026-06-07 01:02" in result  # epoch rendered as a timestamp, not 1780794147.0
+
+
+@pytest.mark.asyncio
+async def test_recent_passes_tags_filter() -> None:
+    mcp, client = _make_server()
+    await _invoke(
+        mcp,
+        "musubi_recent",
+        namespace="aoi/command-chair",
+        tags=["src:mcp-agent-remember"],
+    )
+    assert client._retrieve_calls[-1]["tags"] == ["src:mcp-agent-remember"]
+
+
+@pytest.mark.asyncio
+async def test_recent_no_results_returns_clear_message() -> None:
+    mcp, client = _make_server()
+    client._retrieve_response = {"results": []}
+    result = await _invoke(mcp, "musubi_recent", namespace="aoi/command-chair")
+    assert "no recent activity" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_recent_backend_error_returns_tool_error_string() -> None:
+    mcp, client = _make_server()
+    client._retrieve_raise = RuntimeError("boom")
+    result = await _invoke(mcp, "musubi_recent", namespace="aoi/command-chair")
+    assert result.startswith("Error:")
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Two MCP-adapter fixes that surfaced together while debugging why `musubi_get` "couldn't find" objects that `musubi_search` returns.

## 1. `musubi_get` composes the 2-part presence root with `plane` (the real bug)

Objects are stored under the canonical **3-part** namespace `tenant/presence/plane` (e.g. `aoi/command-chair/episodic`), and `get` filters on it exactly. But `musubi_search` accepts — and is usually called with — the **2-part presence root** (`aoi/command-chair`), because a 2-part namespace is a *blended cross-plane query*. Search result rows then render the full 3-part namespace, so an agent following the tool's own "pass namespace + plane straight from a search row" guidance naturally splits off the 2-part root + a separate `plane` — and gets a **false `NOT_FOUND`** that an exact-namespace filter can never match.

This was load-bearing in practice: it masqueraded as a "get-by-id read-path bug" and even a "token write-scope bug" across two days of notes, when every object had actually landed fine.

Fix: `musubi_get` composes `{namespace}/{plane}` when given the 2-part form; an already-3-part namespace is trusted as-is. Tool description updated to say both forms are accepted.

## 2. Wire `musubi_recent` to `retrieve(mode="recent")` (closes #288)

The slice-retrieve-recent backend (`retrieve/recent.py`, orchestration `mode=recent`, the `/retrieve` recent branch) has shipped and is live in v1.10.1 — only the MCP tool was still a deferred stub. Replaced it with a real call (no `query_text`), mirroring `_do_search`:
- newest-first rows; renders `created_epoch` (carried as `score`) as a compact UTC timestamp instead of a raw float
- optional `tags` AND-filter (e.g. `src:mcp-agent-remember`)
- clear empty + error messages

Verified live against the deployed backend: recent mode returns the namespace's captures newest-first as expected.

## Tests
- `_normalize_get_namespace` unit coverage + an integration test proving the SDK `get` receives the composed 3-part namespace
- recent: mode/no-query, timestamp rendering, tags pass-through, empty, error
- `_ClientStub.retrieve` aligned to the real SDK signature (`query_text` default, `since`/`tags`) so the double can't drift

`ruff` / `ruff format` / `mypy` clean; `tests/adapters` + `tests/retrieve` = 191 passed, 45 pre-existing skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)