### PR TITLE
feat(retrieve): add context-pack endpoint

### DIFF
--- a/deploy/runbooks/upgrade.md
+++ b/deploy/runbooks/upgrade.md
@@ -143,6 +143,17 @@ curl -sS http://musubi.example.local:8100/v1/ops/status | jq .
 # Inspect the upgrade log:
 ssh ericmey@musubi.example.local \
  'sudo tail -1 /var/log/musubi/upgrade-history.jsonl | jq .'
+
+# Live consumer blast-radius smoke. Run once before deploy with
+# MUSUBI_CONSUMER_PHASE=pre-deploy and again here with post-deploy.
+# Each command must exercise the real consumer, not only curl Musubi.
+# The script rejects unset values, literal <placeholder> text, and no-ops.
+MUSUBI_CONSUMER_PHASE=post-deploy \
+MUSUBI_CONSUMER_COMMAND_CHAIR_CMD='<command-chair live smoke command>' \
+MUSUBI_CONSUMER_PHONE_AGENTS_CMD='<phone-agent live smoke command>' \
+MUSUBI_CONSUMER_OPENCLAW_NYLA_CMD='<openclaw-on-nyla live smoke command>' \
+MUSUBI_CONSUMER_VICE_CMD='<vice live app smoke command>' \
+deploy/smoke/check_consumers.sh
 ```
 
 **Expected output:**
@@ -150,11 +161,15 @@ ssh ericmey@musubi.example.local \
 - `status` is `ok` and every component is `healthy: true`.
 - The last `upgrade-history.jsonl` entry is this run (matching
  timestamp, listed services, current `core_image`).
+- `check_consumers.sh` reports `[PASS]` for all four live consumer
+ classes: command-chair agents, phone agents, OpenClaw on Nyla, and
+ Vice. If any consumer fails, treat the deploy as failed even when Core
+ health is green.
 
 **Destructive:** no.
 
-**Rollback:** if `/v1/ops/status` is not `ok`, proceed to step 6
-immediately.
+**Rollback:** if `/v1/ops/status` is not `ok` or any live consumer
+regression smoke fails, proceed to step 6 immediately.
 
 ---
 

--- a/deploy/smoke/check_consumers.sh
+++ b/deploy/smoke/check_consumers.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+
+phase="${MUSUBI_CONSUMER_PHASE:-post-deploy}"
+checks=(
+  "command-chair agents:MUSUBI_CONSUMER_COMMAND_CHAIR_CMD"
+  "phone agents:MUSUBI_CONSUMER_PHONE_AGENTS_CMD"
+  "OpenClaw on Nyla:MUSUBI_CONSUMER_OPENCLAW_NYLA_CMD"
+  "Vice app:MUSUBI_CONSUMER_VICE_CMD"
+)
+
+failed=0
+printf 'Musubi consumer regression smoke (%s)\n' "$phase"
+
+is_placeholder_or_noop() {
+  local cmd="$1"
+  local trimmed="${cmd#"${cmd%%[![:space:]]*}"}"
+  trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+  [[ "$trimmed" == "true" || "$trimmed" == ":" ]] && return 0
+  [[ "$trimmed" == *"<"* || "$trimmed" == *">"* ]]
+}
+
+for check in "${checks[@]}"; do
+  name="${check%%:*}"
+  var="${check##*:}"
+  cmd="${!var:-}"
+  if [[ -z "$cmd" ]]; then
+    fail "consumer ${name}: ${var} is not set" || true
+    failed=1
+    continue
+  fi
+  if is_placeholder_or_noop "$cmd"; then
+    fail "consumer ${name}: ${var} must be a real live-consumer command, not a placeholder/no-op" || true
+    failed=1
+    continue
+  fi
+  if bash -lc "$cmd"; then
+    pass "consumer ${name}"
+  else
+    fail "consumer ${name}" || true
+    failed=1
+  fi
+done
+
+exit "$failed"

--- a/docs/Musubi/05-retrieval/context-pack.md
+++ b/docs/Musubi/05-retrieval/context-pack.md
@@ -1,0 +1,191 @@
+---
+title: Context Pack
+section: 05-retrieval
+tags: [retrieval, context-pack, essence, section/retrieval, status/complete, type/spec]
+type: spec
+status: complete
+updated: 2026-06-28
+up: "[[05-retrieval/index]]"
+reviewed: false
+implements: ["src/musubi/retrieve/context_pack.py", "src/musubi/api/routers/context.py", "src/musubi/cli/context.py", "tests/retrieve/test_context_pack.py", "tests/api/test_context.py", "tests/cli/test_cli_context.py"]
+---
+# Context Pack
+
+`POST /v1/context` is Musubi's startup/readiness context surface. It is not a
+generic search endpoint. It turns a task or moment into a small, grouped
+context pack that an agent can inject before acting.
+
+The design came from the 2026-06-28 Adoption Day alignment round: Musubi should
+serve **essence alignment**, not stale context dumps.
+
+## Contract
+
+Input:
+
+```json
+{
+  "namespace": "yua/command-chair",
+  "query_text": "Vice LoRA promptsmith Shiori image flow",
+  "mode": "startup",
+  "planes": ["episodic", "curated", "concept"],
+  "candidate_limit": 30,
+  "max_items": 8,
+  "max_chars": 1200,
+  "include_history": false
+}
+```
+
+Output is grouped:
+
+- `Must-Obey`
+- `Current-Project`
+- `Relationship-Voice`
+- `Open-Loops`
+- `Tool-Runtime`
+- `Recent-Corrections`
+- `Context`
+
+Each item includes:
+
+- `kind` — one of the closed whitelist below.
+- `staleness` — `durable`, `current`, `episodic`, or `superseded`.
+- `content` — char-capped, prompt-ready text.
+- `evidence_handle` — `<namespace>/<object_id>`.
+- `why_surfaced` — short ranking reason.
+
+## Closed Kind Whitelist
+
+Only these typed kinds are accepted:
+
+- `boundary`
+- `operating-rule`
+- `identity-principle`
+- `relationship/care-cue`
+- `project-stance`
+- `open-loop`
+- `tool/runtime-fact`
+- `correction/suppression`
+- `episode`
+
+Legacy rows without a typed `kind:` tag adapt as `episode`.
+
+Typed writes use tags:
+
+```text
+kind:project-stance
+staleness:durable
+```
+
+Unknown `kind:` or `staleness:` tags are rejected at capture/patch time. Plain
+legacy tags remain legal.
+
+## Ranking
+
+The v1 ranker is BM25 lexical with token-overlap fallback/debug fields and a
+future-compatible interface for semantic expansion later. Ranking happens
+inside Musubi, not inside each client.
+
+Priority order:
+
+1. Kind/staleness policy: durable boundaries and operating rules beat shallow
+   lexical overlap.
+2. BM25 lexical score against the current task/moment.
+3. Existing retrieval score.
+4. Importance.
+5. Recency as a final tiebreak.
+
+`superseded` and `correction/suppression` records are suppressed by default.
+They are retrievable when the caller sets `include_history=true`.
+
+Startup packs also avoid unrelated episodic filler: if a low-priority episode
+has zero query overlap, it is not inserted just because the pack has room.
+
+## Acceptance Scenarios
+
+The tests encode the Adoption Day acceptance criteria:
+
+- **Vice LoRA / promptsmith task.** Surfaces V-049 memory-spine lessons,
+  V-053 compiler-route lessons, and the LoRA identity-layer principle; does not
+  surface old CyberRealistic/Lightning drift unless history is explicitly
+  requested.
+- **Adoption Day.** Surfaces canonical comms (`agent-bridge`, `chair-msg`,
+  `team-task`) and the no-thin-wrapper rule; suppresses retired `agent-msg`
+  practice by default.
+- **Presence moment.** Surfaces the "wanted before needed" relationship cue
+  without filling the pack with project-management habits.
+
+## Test Contract
+
+- `test_vice_lora_startup_surfaces_v049_v053_and_identity_layer_not_old_drift`
+  proves the v1 startup pack surfaces the Vice memory spine, compiler route, and
+  LoRA identity-layer lessons while suppressing superseded drift.
+- `test_adoption_day_surfaces_canonical_comms_and_suppresses_retired_agent_msg`
+  proves canonical comms and no-wrapper rules surface while retired agent-msg
+  practice stays hidden.
+- `test_presence_moment_surfaces_wanted_before_needed_without_pm_habits` proves
+  relationship/care-cue memories outrank project-management filler.
+- `test_legacy_rows_default_to_episode_and_history_can_retrieve_superseded`
+  proves legacy untyped rows remain readable and superseded rows require
+  explicit history mode.
+- `test_durable_rule_beats_shallow_overlap_episode` proves durable boundaries
+  beat shallow lexical overlap.
+- `test_context_endpoint_returns_grouped_server_ranked_pack` proves the API
+  returns the server-ranked grouped pack through `/v1/context`.
+- `test_context_endpoint_can_include_history_when_explicitly_requested` proves
+  the API history mode includes superseded rows.
+- `test_capture_rejects_unknown_typed_kind_tag` proves typed-write minimum
+  rejects unknown `kind:` tags.
+- `test_capture_allows_legacy_untyped_tags` proves legacy tags are still
+  accepted.
+- `test_context_posts_to_api_and_renders_grouped_output` proves the CLI calls
+  the deployed API and renders grouped output.
+- `test_context_json_flag_emits_raw_response` proves the CLI can emit the raw JSON
+  contract.
+
+## CLI
+
+Operators can call the deployed service with:
+
+```bash
+musubi context \
+  --namespace yua/command-chair \
+  --query "Vice LoRA promptsmith Shiori image flow" \
+  --planes episodic,curated,concept
+```
+
+There is also a direct entry point:
+
+```bash
+musubi-context --namespace yua/command-chair --query "startup"
+```
+
+Both call `/v1/context`; neither reads local Qdrant.
+
+## Deployment
+
+Context packs are a Musubi Core feature. They ship only through the existing
+production pipeline:
+
+1. Merge code to `main`.
+2. Release Please creates and merges a semver release PR.
+3. The `vX.Y.Z` tag triggers `.github/workflows/publish-core-image.yml`.
+4. The GHCR image digest is pinned in `deploy/ansible/group_vars/all.yml`.
+5. `scripts/musubi-deploy --apply core` runs the Ansible update playbook.
+
+Local green tests do not count as deployed adoption.
+
+Before and after the deploy, run the live consumer blast-radius smoke:
+
+```bash
+MUSUBI_CONSUMER_PHASE=pre-deploy \
+MUSUBI_CONSUMER_COMMAND_CHAIR_CMD='<command-chair live smoke command>' \
+MUSUBI_CONSUMER_PHONE_AGENTS_CMD='<phone-agent live smoke command>' \
+MUSUBI_CONSUMER_OPENCLAW_NYLA_CMD='<openclaw-on-nyla live smoke command>' \
+MUSUBI_CONSUMER_VICE_CMD='<vice live app smoke command>' \
+deploy/smoke/check_consumers.sh
+```
+
+Repeat with `MUSUBI_CONSUMER_PHASE=post-deploy` after the new container is
+running. These commands must exercise the real consumers: the four command-chair
+agents, phone agents, OpenClaw on Nyla, and Vice. If any fail, roll back the
+versioned image pin before continuing adoption.

--- a/docs/Musubi/05-retrieval/index.md
+++ b/docs/Musubi/05-retrieval/index.md
@@ -4,7 +4,7 @@ section: 05-retrieval
 tags: [retrieval, scoring, search, section/retrieval, status/complete, type/spec]
 type: spec
 status: complete
-updated: 2026-04-17
+updated: 2026-06-28
 up: "[[00-index/index]]"
 reviewed: false
 ---
@@ -19,6 +19,7 @@ How Musubi turns a query into a ranked, blended result across planes. Two paths,
 - [[05-retrieval/fast-path]] — Sub-400ms recall for voice/chat. Cache + lightweight fusion, no rerank.
 - [[05-retrieval/reranker]] — Cross-encoder pass for deep retrieval. BGE-reranker-v2-m3 via TEI.
 - [[05-retrieval/orchestration]] — The retrieval pipeline as code: filter → hybrid → rerank → score → pack.
+- [[05-retrieval/context-pack]] — Startup/readiness context packs with BM25 ranking, closed kinds, staleness suppression, and grouped output.
 - [[05-retrieval/blended]] — Blending results from multiple planes: weights, dedup, lineage-aware merging.
 - [[05-retrieval/deep-path]] — LLM-in-the-loop retrieval for planning tasks (Slow Thinker pattern).
 - [[05-retrieval/evals]] — How we evaluate retrieval quality. Golden sets, regression tests, ragas metrics.

--- a/docs/Musubi/07-interfaces/canonical-api.md
+++ b/docs/Musubi/07-interfaces/canonical-api.md
@@ -4,10 +4,10 @@ section: 07-interfaces
 tags: [api, grpc, http, interfaces, section/interfaces, status/complete, type/spec]
 type: spec
 status: complete
-updated: 2026-04-17
+updated: 2026-06-28
 up: "[[07-interfaces/index]]"
 reviewed: false
-implements: ["src/musubi/api/", "src/musubi/api/app.py", "src/musubi/api/bootstrap.py", "src/musubi/api/dependencies.py", "src/musubi/api/events.py", "src/musubi/api/routers/thoughts.py", "src/musubi/api/routers/writes_thoughts.py", "tests/api/", "tests/api/test_bootstrap.py", "tests/api/test_thoughts_stream.py"]
+implements: ["src/musubi/api/", "src/musubi/api/app.py", "src/musubi/api/bootstrap.py", "src/musubi/api/dependencies.py", "src/musubi/api/events.py", "src/musubi/api/routers/thoughts.py", "src/musubi/api/routers/writes_thoughts.py", "src/musubi/api/routers/context.py", "tests/api/", "tests/api/test_bootstrap.py", "tests/api/test_thoughts_stream.py", "tests/api/test_context.py"]
 ---
 # Canonical API
 
@@ -52,6 +52,7 @@ The scope matcher (see [[10-security/auth]] and `src/musubi/auth/scopes.py`) req
 | `POST/GET /v1/artifacts`, `GET /v1/artifacts/{id}/blob\|chunks` | body / query | 3 (`<tenant>/<presence>/artifact`) | `r` or `w` |
 | `POST /v1/retrieve` with **3-segment** namespace | body `namespace` | 3 | `r` on that one namespace |
 | `POST /v1/retrieve` with **2-segment** namespace + `planes` array | body `namespace` + `planes` | 2 (base) + strict per-plane check on each expansion | `r` on the 2-seg base **and** `r` on every `<namespace>/<plane>` target |
+| `POST /v1/context` with **2- or 3-segment** namespace | body `namespace` + `planes` | same as `/v1/retrieve` | same as `/v1/retrieve` |
 | `POST /v1/thoughts/send` | body (derives `<tenant>/<presence>/thought`) | 3 | `w` |
 | `POST /v1/thoughts/read` | body `namespace` | 3 (`<tenant>/<presence>/thought`) | `w` (marking read mutates state) |
 | `POST /v1/thoughts/check`, `/history` | body `namespace` | 3 (`<tenant>/<presence>/thought`) | `r` |
@@ -217,6 +218,66 @@ POST   /v1/retrieve/stream                   # NDJSON stream for large K
 ```
 
 Single entry point for the retrieve pipeline. Mode selected by `query.mode`. See [[05-retrieval/orchestration]].
+
+### 7. Context packs
+
+```
+POST   /v1/context                           # body = ContextQuery
+```
+
+Builds a small, grouped startup/readiness context pack from server-side
+retrieval payloads. This is the "essence alignment" surface: clients send the
+current task or moment as `query_text`, and Musubi returns a char-capped pack
+grouped by operational purpose.
+
+Request shape:
+
+```json
+{
+  "namespace": "yua/command-chair",
+  "query_text": "Vice LoRA promptsmith Shiori image flow",
+  "mode": "startup",
+  "planes": ["episodic", "curated", "concept"],
+  "candidate_limit": 30,
+  "max_items": 8,
+  "max_chars": 1200,
+  "include_history": false
+}
+```
+
+Response shape:
+
+```json
+{
+  "mode": "startup",
+  "query_text": "...",
+  "groups": [
+    {
+      "title": "Current-Project",
+      "items": [
+        {
+          "kind": "project-stance",
+          "staleness": "durable",
+          "content": "...",
+          "evidence_handle": "yua/command-chair/episodic/<object_id>",
+          "why_surfaced": "durable project-stance; BM25 lexical match"
+        }
+      ]
+    }
+  ],
+  "max_chars": 1200,
+  "used_chars": 248,
+  "suppressed": {"superseded": 1}
+}
+```
+
+Typed metadata uses tags such as `kind:project-stance` and
+`staleness:durable`. Unknown typed values are rejected on episodic capture or
+patch. Legacy rows with no `kind:` tag adapt as `episode`. Superseded/history
+records are suppressed unless `include_history=true`.
+
+See [[05-retrieval/context-pack]] for the ranking contract and acceptance
+tests.
 
 | `mode` | What it does | Requires `query_text` | Default `state_filter` |
 | --- | --- | --- | --- |

--- a/docs/Musubi/13-decisions/0030-agent-as-tenant.md
+++ b/docs/Musubi/13-decisions/0030-agent-as-tenant.md
@@ -1,5 +1,5 @@
 ---
-title: Agent-as-tenant namespace convention
+title: ADR 0030 — Agent-as-tenant
 section: 13-decisions
 tags: [adr, architecture, namespaces, auth, section/decisions, status/accepted, type/adr]
 type: adr

--- a/docs/Musubi/13-decisions/0034-context-pack-api.md
+++ b/docs/Musubi/13-decisions/0034-context-pack-api.md
@@ -1,0 +1,96 @@
+---
+title: "ADR 0034: Context-pack API for essence alignment"
+section: 13-decisions
+type: adr
+status: accepted
+date: 2026-06-28
+deciders: [Eric, Aoi, Yua]
+tags: [section/decisions, status/accepted, type/adr, musubi-context]
+updated: 2026-06-28
+up: "[[13-decisions/index]]"
+reviewed: false
+---
+
+# ADR 0034: Context-pack API for essence alignment
+
+**Status:** accepted
+**Date:** 2026-06-28
+**Deciders:** Eric, Aoi, Yua
+
+## Context
+
+Musubi already exposes generic retrieval through `/v1/retrieve`, but
+Adoption Day v1 identified a sharper product need: agents need a small,
+ranked, grouped startup context pack that surfaces essence-aligned facts
+without dumping stale or noisy search results into the prompt.
+
+The proven Vice V-049 memory-spine pattern showed that useful context is
+not just "nearest text." It needs typed memories, durable-vs-episodic
+ranking, staleness suppression, evidence handles, grouped prompt output,
+and a hard character cap. If every adapter implements that locally, the
+ranking contract will drift and Musubi will become an installed tool that
+agents inconsistently use.
+
+## Decision
+
+Add an additive HTTP endpoint, `POST /v1/context`, backed by a pure
+`musubi.retrieve.context_pack` domain module.
+
+The endpoint:
+
+- reuses `/v1/retrieve` target resolution, namespace wildcard expansion,
+  auth, scope checks, and fast retrieval orchestration;
+- adapts retrieval hits into closed-kind context candidates;
+- ranks with BM25 lexical relevance plus kind, staleness, importance,
+  retrieve-score, and recency tiebreakers;
+- suppresses superseded and correction/suppression records by default,
+  while allowing explicit `include_history=true` audit retrieval;
+- returns a grouped `ContextPack` with evidence handles, why-surfaced
+  text, item caps, and character caps;
+- serves the same contract to CLI, adapters, and future agent startup
+  integrations.
+
+The v1 CLI entrypoint is `musubi context` with a direct script alias
+`musubi-context`. It calls the deployed HTTP service; it does not perform
+local Qdrant search.
+
+Typed write minimum lands in the same slice: `kind:*` and `staleness:*`
+tags are closed-whitelist validated on episodic capture/patch. Legacy
+untyped tags remain valid and are read as `kind=episode`.
+
+## Alternatives
+
+### Keep context packing client-side
+
+Rejected. It would duplicate ranking logic across Yua, Aoi, command-chair
+scripts, and future adapters, and would make deployed Musubi less valuable
+than local agent hacks.
+
+### Extend `/v1/retrieve` with context-pack options
+
+Rejected for v1. `/v1/retrieve` is a general search surface. Context
+packing has different response semantics: grouped output, why-surfaced
+text, evidence handles, staleness suppression, and startup-mode defaults.
+Keeping it separate avoids overloading retrieve while still reusing its
+orchestration internally.
+
+### Semantic ranking first
+
+Deferred. The domain module is shaped so semantic scoring can be added
+behind the ranking interface later. V1 uses BM25 lexical ranking with
+token-overlap fallback behavior because it is deterministic, cheap, and
+testable.
+
+## Consequences
+
+- `openapi.yaml` gains `/v1/context` and the `ContextPack*` schemas.
+- Adapters can adopt a single deployed context-pack surface instead of
+  maintaining local search heuristics.
+- Musubi becomes responsible for relevance and staleness discipline, not
+  just vector recall.
+- Future ranking changes are product behavior changes and should be
+  tested against the acceptance scenarios before deployment.
+- Deployment close requires blast-radius proof against live consumers,
+  not only unit tests: command-chair agents, phone agents, OpenClaw on
+  Nyla, and Vice must all pass their existing consumer smokes before and
+  after rollout. If any fail, roll back the versioned image pin.

--- a/docs/Musubi/13-decisions/index.md
+++ b/docs/Musubi/13-decisions/index.md
@@ -66,6 +66,7 @@ SORT file.name ASC
 - [[13-decisions/0025-lifecycle-runner-without-apscheduler]] — Lifecycle worker ships as an asyncio tick-loop instead of pulling in APScheduler; revisit when we need persisted-jobstore or sub-minute cron semantics.
 - [[13-decisions/0026-release-please-for-versioning]] — release-please drives version bumps + tag cutting from conventional commits on `v2`; tag push triggers the signed GHCR publish.
 - [[13-decisions/0032-agent-tools-canonical-surface]] — Five-tool canonical agent surface (`musubi_recent`, `musubi_search`, `musubi_get`, `musubi_remember`, `musubi_think`) every adapter implements identically; cross-modal default for recent/search.
+- [[13-decisions/0034-context-pack-api]] — Add `/v1/context` as the deployed ranked context-pack surface for essence alignment.
 - [[13-decisions/sources]] — Public sources that informed these decisions.
 - [[13-decisions/template-weights-change]] — Template ADR for retrieval scoring weight changes.
 

--- a/docs/Musubi/_inbox/locks/slice-api-retrieve-wildcards.lock
+++ b/docs/Musubi/_inbox/locks/slice-api-retrieve-wildcards.lock
@@ -1,5 +1,0 @@
-slice: slice-api-retrieve-wildcards
-owner: aoi-claude-opus
-started: 2026-04-24T18:30:00Z
-issue: 267
-pr: 268

--- a/docs/Musubi/_inbox/locks/slice-retrieve-recent.lock
+++ b/docs/Musubi/_inbox/locks/slice-retrieve-recent.lock
@@ -1,5 +1,0 @@
-slice: slice-retrieve-recent
-owner: aoi-claude-opus
-started: 2026-05-18T01:30:00Z
-issue: 288
-pr: 343

--- a/docs/Musubi/_slices/slice-adapter-mcp.md
+++ b/docs/Musubi/_slices/slice-adapter-mcp.md
@@ -10,7 +10,7 @@ tags: [section/slices, status/done, type/slice]
 updated: 2026-04-19
 reviewed: true
 depends-on: ["[[_slices/slice-sdk-py]]", "[[_slices/slice-ingestion-capture]]", "[[_slices/slice-retrieval-deep]]"]
-blocks: []
+blocks: ["[[_slices/slice-mcp-canonical-tools]]"]
 ---
 
 # Slice: MCP adapter

--- a/docs/Musubi/_slices/slice-api-retrieve-wildcards.md
+++ b/docs/Musubi/_slices/slice-api-retrieve-wildcards.md
@@ -3,14 +3,14 @@ title: "Slice: Retrieve wildcard namespace segments"
 slice_id: slice-api-retrieve-wildcards
 section: _slices
 type: slice
-status: in-progress
+status: done
 owner: aoi-claude-opus
 phase: "8 Post-1.0"
-tags: [section/slices, status/in-progress, type/slice, api, retrieve, namespace]
-updated: 2026-04-24
-reviewed: false
+tags: [section/slices, status/done, type/slice, api, retrieve, namespace]
+updated: 2026-06-28
+reviewed: true
 depends-on: ["[[_slices/slice-api-v0-read]]"]
-blocks: []
+blocks: ["[[_slices/slice-retrieve-recent]]"]
 ---
 
 # Slice: Retrieve wildcard namespace segments
@@ -20,7 +20,7 @@ blocks: []
 > writes off their channel-tagged 3-seg slots. Implements
 > [[13-decisions/0031-retrieve-wildcard-namespace|ADR 0031]].
 
-**Phase:** 8 Post-1.0 · **Status:** `in-progress` · **Owner:** `aoi-claude-opus`
+**Phase:** 8 Post-1.0 · **Status:** `done` · **Owner:** `aoi-claude-opus`
 
 ## Why this slice exists (2026-04-24 context)
 
@@ -45,15 +45,12 @@ read-only).
 ## Owned paths (you MAY write here)
 
 - `src/musubi/api/routers/retrieve.py`           — wildcard expansion logic
-- `src/musubi/retrieve/orchestration.py`         — one-line hardening: row's stored namespace into the response, not the request namespace (pre-existing bug, only visible once wildcards make request ≠ stored)
 - `src/musubi/sdk/async_client.py`               — surface `planes` parameter (existed in API, missing on SDK)
 - `src/musubi/sdk/client.py`                     — sync mirror
 - `tests/api/test_retrieve_router.py`            — wildcard expansion tests
 - `tests/api/test_retrieve_wildcards.py`         — new file, dedicated wildcard test suite
 - `tests/sdk/test_async_client.py`               — SDK `planes` parameter test
-- `openapi.yaml`                                 — extend `namespace` schema description (additive)
 - `docs/Musubi/03-system-design/namespaces.md`   — add §Wildcards (spec-update trailer)
-- `docs/Musubi/07-interfaces/canonical-api.md`   — extend retrieve namespace table (spec-update trailer)
 
 ## Forbidden paths (you MUST NOT write here)
 
@@ -191,6 +188,12 @@ Agents append one entry per work session. Format:
 - ADR 0031 written and referenced; this slice implements it end-to-end.
 - Branching `slice/api-retrieve-wildcards`, opening draft PR.
 
+### 2026-06-28 11:32 — tama — hygiene: mark done (PR 268 merged 2026-04-24)
+
+- Musubi hygiene sweep per Yua REQ `bridge-20260628-113226-ae9a`. Independently re-verified issue #267 CLOSED (label `status:in-progress` retained on closure) and PR #268 MERGED at 2026-04-24T22:40:53Z by Eric.
+- Metadata-only cleanup: frontmatter `status: done`, tags `status/done`, `updated: 2026-06-28`, `reviewed: true`, body Status line updated to `done`.
+- No code behavior changes. Active `yua/musubi-v1-context-pack` working tree untouched (context-pack files are independent — slice-api-retrieve-wildcards does not block or own any of them).
+
 ## PR links
 
-- _(pending)_
+- [#268 feat(api): wildcard namespace segments for tenant-wide retrieve](https://github.com/ericmey/musubi/pull/268) — merged 2026-04-24T22:40:53Z, closes #267

--- a/docs/Musubi/_slices/slice-api-v0-read.md
+++ b/docs/Musubi/_slices/slice-api-v0-read.md
@@ -10,7 +10,7 @@ tags: [section/slices, status/done, type/slice]
 updated: 2026-04-19
 reviewed: true
 depends-on: ["[[_slices/slice-types]]", "[[_slices/slice-config]]", "[[_slices/slice-auth]]", "[[_slices/slice-plane-episodic]]", "[[_slices/slice-plane-curated]]", "[[_slices/slice-plane-artifact]]"]
-blocks: ["[[_slices/slice-adapter-livekit]]", "[[_slices/slice-adapter-mcp]]", "[[_slices/slice-adapter-openclaw]]", "[[_slices/slice-api-app-bootstrap]]", "[[_slices/slice-api-thoughts-stream]]", "[[_slices/slice-api-v0-write]]", "[[_slices/slice-sdk-py]]"]
+blocks: ["[[_slices/slice-adapter-livekit]]", "[[_slices/slice-adapter-mcp]]", "[[_slices/slice-adapter-openclaw]]", "[[_slices/slice-api-app-bootstrap]]", "[[_slices/slice-api-thoughts-stream]]", "[[_slices/slice-api-v0-write]]", "[[_slices/slice-sdk-py]]", "[[_slices/slice-api-retrieve-wildcards]]", "[[_slices/slice-retrieve-recent]]"]
 ---
 
 # Slice: Canonical API v0.1 — read surface

--- a/docs/Musubi/_slices/slice-retrieve-recent.md
+++ b/docs/Musubi/_slices/slice-retrieve-recent.md
@@ -3,11 +3,11 @@ title: "Slice: Retrieve mode=recent"
 slice_id: slice-retrieve-recent
 section: _slices
 type: slice
-status: in-progress
+status: done
 owner: aoi-claude-opus
 phase: "8 Post-1.0"
-tags: [section/slices, status/in-progress, type/slice, api, retrieve, recency]
-updated: 2026-05-17
+tags: [section/slices, status/done, type/slice, api, retrieve, recency]
+updated: 2026-06-28
 reviewed: false
 depends-on: ["[[_slices/slice-api-v0-read]]", "[[_slices/slice-api-retrieve-wildcards]]"]
 blocks: ["[[_slices/slice-mcp-canonical-tools]]", "[[_slices/slice-livekit-canonical-tools]]", "[[_slices/slice-openclaw-canonical-tools]]"]
@@ -17,7 +17,7 @@ blocks: ["[[_slices/slice-mcp-canonical-tools]]", "[[_slices/slice-livekit-canon
 
 > Add `mode=recent` to `POST /v1/retrieve` — query-less, time-ordered scroll across the namespace fanout. Required by the canonical `musubi_recent` agent tool ([[07-interfaces/agent-tools]]) so an agent can answer "what was I just doing?" without a query string.
 
-**Phase:** 8 Post-1.0 · **Status:** `in-progress` (picked up 2026-05-17 — `slice-api-retrieve-wildcards` merged 2026-04-24 via PR #268; the tracker had stayed `blocked` for ~3 weeks past the actual unblock)
+**Phase:** 8 Post-1.0 · **Status:** `done` (Issue #288 is closed; status corrected during 2026-06-28 Musubi v1 context-pack hygiene)
 
 ## Design decisions (locked at pickup, 2026-05-17)
 
@@ -103,3 +103,13 @@ Out of scope (separate PR):
 ## Definition of Done
 
 ![[00-index/definition-of-done]]
+
+## Work log
+
+### 2026-06-28 — codex-gpt5 — hygiene correction
+
+- Metadata-only cleanup during Adoption Day Musubi v1 work.
+- `make agent-check` reported Issue #288 closed while this slice frontmatter
+  still said `status: in-progress`.
+- Corrected frontmatter/body status to `done`; no code or test contract changes
+  in this slice file.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -777,18 +777,12 @@ paths:
       tags:
       - thoughts
       summary: Stream Thoughts
-      description: 'SSE endpoint for real-time thought delivery.
-
-
-        Replay semantics via Last-Event-ID are declared in the spec but deferred to
-
-        the integration harness (needs a real Qdrant with live range queries; mocked
-
-        Qdrant in unit tests doesn''t model lex-sorted epoch-range scrolls). The
-
-        header is accepted and validated but currently the stream begins from the
-
-        live broker queue only. See slice-api-thoughts-stream work log.'
+      description: "SSE endpoint for real-time thought delivery.\n\nReplay: if ``Last-Event-ID:\
+        \ <ksuid>`` is present, every thought matching\nthe subscription scope where\
+        \ ``object_id > last_event_id`` (lex,\nascending) is emitted before entering\
+        \ live-tail mode. Capped at 500\nevents \u2014 if more matched, the ``X-Musubi-Replay-Truncated:\
+        \ true``\nresponse header tells the client to fall back to ``/v1/thoughts/history``\n\
+        for deeper backfill."
       operationId: stream_thoughts.bucket=default
       parameters:
       - name: namespace
@@ -827,6 +821,37 @@ paths:
           description: Caller does not hold read scope for `namespace`.
         '503':
           description: Thought broker unavailable.
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/context:
+    post:
+      tags:
+      - context
+      summary: Context Pack
+      description: 'Return a ranked, grouped context pack.
+
+
+        Ranking happens server-side because clients should not have to
+
+        rehydrate payload metadata or maintain their own essence heuristics.'
+      operationId: context_pack_v1_context_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ContextQuery'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContextPack'
         '422':
           description: Validation Error
           content:
@@ -1534,6 +1559,168 @@ components:
       - name
       - healthy
       title: ComponentStatus
+    ContextPack:
+      properties:
+        mode:
+          type: string
+          const: startup
+          title: Mode
+        query_text:
+          type: string
+          title: Query Text
+        groups:
+          items:
+            $ref: '#/components/schemas/ContextPackGroup'
+          type: array
+          title: Groups
+        max_chars:
+          type: integer
+          title: Max Chars
+        used_chars:
+          type: integer
+          title: Used Chars
+        suppressed:
+          additionalProperties:
+            type: integer
+          type: object
+          title: Suppressed
+      type: object
+      required:
+      - mode
+      - query_text
+      - groups
+      - max_chars
+      - used_chars
+      title: ContextPack
+    ContextPackGroup:
+      properties:
+        title:
+          type: string
+          title: Title
+        items:
+          items:
+            $ref: '#/components/schemas/ContextPackItem'
+          type: array
+          title: Items
+      type: object
+      required:
+      - title
+      - items
+      title: ContextPackGroup
+    ContextPackItem:
+      properties:
+        object_id:
+          type: string
+          title: Object Id
+        namespace:
+          type: string
+          title: Namespace
+        plane:
+          type: string
+          title: Plane
+        kind:
+          type: string
+          enum:
+          - boundary
+          - operating-rule
+          - identity-principle
+          - relationship/care-cue
+          - project-stance
+          - open-loop
+          - tool/runtime-fact
+          - correction/suppression
+          - episode
+          title: Kind
+        staleness:
+          type: string
+          enum:
+          - durable
+          - current
+          - episodic
+          - superseded
+          title: Staleness
+        content:
+          type: string
+          title: Content
+        evidence_handle:
+          type: string
+          title: Evidence Handle
+        why_surfaced:
+          type: string
+          title: Why Surfaced
+        score:
+          type: number
+          title: Score
+      type: object
+      required:
+      - object_id
+      - namespace
+      - plane
+      - kind
+      - staleness
+      - content
+      - evidence_handle
+      - why_surfaced
+      - score
+      title: ContextPackItem
+      description: One surfaced context item.
+    ContextQuery:
+      properties:
+        namespace:
+          type: string
+          title: Namespace
+          description: Two- or three-segment namespace, same shape as /v1/retrieve.
+        query_text:
+          type: string
+          minLength: 1
+          title: Query Text
+        mode:
+          type: string
+          const: startup
+          title: Mode
+          default: startup
+        planes:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Planes
+        candidate_limit:
+          type: integer
+          maximum: 100.0
+          minimum: 1.0
+          title: Candidate Limit
+          default: 30
+        max_items:
+          type: integer
+          maximum: 50.0
+          minimum: 1.0
+          title: Max Items
+          default: 8
+        max_chars:
+          type: integer
+          maximum: 8000.0
+          minimum: 120.0
+          title: Max Chars
+          default: 1200
+        include_history:
+          type: boolean
+          title: Include History
+          default: false
+        state_filter:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: State Filter
+      type: object
+      required:
+      - namespace
+      - query_text
+      title: ContextQuery
+      description: Build a small, grouped context pack for a presence.
     ContradictionListResponse:
       properties:
         items:
@@ -1637,6 +1824,11 @@ components:
         namespace:
           type: string
           title: Namespace
+        identity_family:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Identity Family
         schema_version:
           type: integer
           title: Schema Version
@@ -1820,6 +2012,11 @@ components:
         namespace:
           type: string
           title: Namespace
+        identity_family:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Identity Family
         schema_version:
           type: integer
           title: Schema Version
@@ -2264,26 +2461,24 @@ components:
         namespace:
           type: string
           title: Namespace
-          description: |
-            Namespace pattern. Three shapes accepted:
-            - 3-segment concrete: `<tenant>/<presence>/<plane>` — single target.
-            - 2-segment: `<tenant>/<presence>` — cross-plane fanout (`planes` required).
-            - Wildcard: `*` may replace any single segment (e.g. `nyla/*/episodic`,
-              `*/voice/curated`, `nyla/*/*` with `planes`). Writes reject `*`;
-              wildcards are read-only. See ADR 0031.
+          description: 'Namespace pattern. Three shapes accepted: 3-segment concrete
+            `<tenant>/<presence>/<plane>` (single target), 2-segment `<tenant>/<presence>`
+            (cross-plane fanout, requires `planes`), or wildcard with `*` replacing
+            any single segment (e.g. `nyla/*/episodic`, `*/voice/curated`). Writes
+            reject `*`; wildcards are read-only. See ADR 0031.'
         query_text:
           type: string
           title: Query Text
-          default: ""
-          description: |
-            Required for `mode` in `fast|deep|blended` (the server returns 400
-            if empty for those modes). Optional for `mode='recent'` — if
-            provided, the server logs a WARN and ignores it.
+          default: ''
         mode:
           type: string
+          enum:
+          - fast
+          - deep
+          - blended
+          - recent
           title: Mode
           default: fast
-          enum: [fast, deep, blended, recent]
         limit:
           type: integer
           title: Limit
@@ -2304,11 +2499,9 @@ components:
           - type: number
           - type: 'null'
           title: Since
-          description: |
-            Recent-mode only. Inclusive lower bound on `created_epoch`
-            (epoch seconds). Rows older than `since` are excluded. ISO
-            strings are NOT accepted — convert client-side via
-            `datetime.timestamp()`.
+          description: "Recent-mode only: inclusive lower bound on `created_epoch`.\
+            \ Rows older than `since` are excluded. ISO-format timestamps are NOT\
+            \ accepted \u2014 convert client-side via `datetime.timestamp()`."
         tags:
           anyOf:
           - items:
@@ -2316,10 +2509,8 @@ components:
             type: array
           - type: 'null'
           title: Tags
-          description: |
-            Recent-mode tag filter (AND across all listed tags — a row
-            must contain every tag to match). Empty list and `null` both
-            mean no filter. Other modes accept this field without effect.
+          description: "Recent-mode tag filter. AND semantics \u2014 a row must contain\
+            \ every listed tag to match. Empty list and `null` both mean no filter."
         state_filter:
           anyOf:
           - items:
@@ -2327,20 +2518,17 @@ components:
             type: array
           - type: 'null'
           title: State Filter
-          description: |
-            Lifecycle states to include. For `fast|deep|blended`, `null`
-            resolves to `('matured', 'promoted')` — the v1.0/v1.1 default.
-            For `mode='recent'`, `null` resolves to
-            `('provisional', 'matured', 'promoted')` — recent mode's purpose
-            is "what just happened," provisional is the freshest tier,
-            excluding it by default would defeat the use case.
-            Set explicitly to `['provisional', 'matured', 'promoted']` for
-            ranked-mode recall of fresh deliberate stores before maturation
-            has run. In `mode='fast'`, `include_archived: true` augments
-            the default with `('demoted', 'archived', 'superseded')`. In
-            `mode='deep'` and `mode='blended'` `include_archived` is
-            currently ignored — pass `state_filter` explicitly when those
-            modes need archive-side states.
+          description: "Lifecycle states to include. Default `null` resolves to `('matured',\
+            \ 'promoted')` for fast/deep/blended (matching the pre-`recent` behaviour).\
+            \ For `mode='recent'`, the default is `('provisional', 'matured', 'promoted')`\
+            \ \u2014 recent's purpose is 'what just happened', so the freshest tier\
+            \ is included by default. Set explicitly to `['provisional', 'matured',\
+            \ 'promoted']` for recall on ranked modes when you want fresh deliberate\
+            \ `memory_store` rows visible before they age through the maturation cron.\
+            \ Note: in `mode='fast'`, `include_archived: true` augments the default\
+            \ by adding `('demoted', 'archived', 'superseded')`. In `mode='deep'`\
+            \ and `mode='blended'`, `include_archived` is currently ignored \u2014\
+            \ pass `state_filter` explicitly when those modes need archive-side states."
       type: object
       required:
       - namespace
@@ -2406,6 +2594,11 @@ components:
         namespace:
           type: string
           title: Namespace
+        identity_family:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Identity Family
         schema_version:
           type: integer
           title: Schema Version
@@ -2529,6 +2722,11 @@ components:
         namespace:
           type: string
           title: Namespace
+        identity_family:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Identity Family
         schema_version:
           type: integer
           title: Schema Version
@@ -2934,6 +3132,9 @@ components:
         namespace:
           type: string
           title: Namespace
+        identity_family:
+          type: string
+          title: Identity Family
         memories_selected:
           type: integer
           title: Memories Selected
@@ -2954,9 +3155,18 @@ components:
           - type: number
           - type: 'null'
           title: Cursor Advanced To
+        candidates_carried_forward:
+          type: integer
+          title: Candidates Carried Forward
+          default: 0
+        candidates_pruned:
+          type: integer
+          title: Candidates Pruned
+          default: 0
       type: object
       required:
       - namespace
+      - identity_family
       - memories_selected
       - clusters_formed
       - concepts_created
@@ -2964,7 +3174,26 @@ components:
       - contradictions_detected
       - cursor_advanced_to
       title: TriggerSynthesisResponse
-      description: Same shape as ``musubi.lifecycle.synthesis.SynthesisReport``.
+      description: 'Same shape as ``musubi.lifecycle.synthesis.SynthesisReport``.
+
+
+        The ``namespace`` field carries the **identity family** (e.g. ``"aoi"``)
+
+        that synthesis actually clustered, NOT an echo of the input
+
+        namespace. Per v1.5.5+''s per-family synthesis (musubi#335), the loop
+
+        operates on identity-family scope; the field name is preserved for
+
+        backward-compat with log scrapers but the semantic shifted from
+
+        "input namespace echo" to "scope actually clustered." The new
+
+        ``identity_family`` field below makes this explicit for new
+
+        callers that want unambiguous semantics. See musubi#352 for the
+
+        investigation that surfaced this naming confusion.'
     ValidationError:
       properties:
         loc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 
 [project.scripts]
 musubi = "musubi.cli.main:app"
+musubi-context = "musubi.cli.context:main"
 
 
 [project.optional-dependencies]

--- a/src/musubi/api/app.py
+++ b/src/musubi/api/app.py
@@ -40,6 +40,7 @@ from musubi.api.rate_limit import DEFAULT_BUCKETS, RateLimiter, get_rate_limiter
 from musubi.api.routers import (
     artifacts,
     concepts,
+    context,
     contradictions,
     curated,
     episodic,
@@ -82,6 +83,7 @@ _PATH_TO_BUCKET: tuple[tuple[str, str], ...] = (
     ("/v1/thoughts/read", "default"),
     ("/v1/lifecycle/transition", "transition"),
     ("/v1/concepts", "default"),
+    ("/v1/context", "retrieve"),
     ("/v1/retrieve/stream", "retrieve"),
     ("/v1/retrieve", "retrieve"),
 )
@@ -351,6 +353,7 @@ def create_app(*, settings: Settings | None = None) -> FastAPI:
     app.include_router(concepts.router)
     app.include_router(artifacts.router)
     app.include_router(thoughts.router)
+    app.include_router(context.router)
     app.include_router(retrieve.router)
     app.include_router(lifecycle.router)
     app.include_router(contradictions.router)

--- a/src/musubi/api/routers/context.py
+++ b/src/musubi/api/routers/context.py
@@ -1,0 +1,182 @@
+"""Context-pack endpoint for essence alignment."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from fastapi import APIRouter, Body, Depends, Request
+from pydantic import BaseModel, Field, model_validator
+from qdrant_client import QdrantClient
+
+from musubi.api.dependencies import get_embedder, get_qdrant_client, get_reranker, get_settings_dep
+from musubi.api.errors import APIError, ErrorCode
+from musubi.api.routers.retrieve import _KIND_STATUS_MAP, _expand_wildcard_targets, _resolve_targets
+from musubi.auth import authenticate_request
+from musubi.auth.scopes import resolve_namespace_scope
+from musubi.embedding import Embedder, TEIRerankerClient
+from musubi.retrieve.context_pack import (
+    ContextCandidate,
+    ContextPack,
+    ContextPackQuery,
+    build_context_pack,
+)
+from musubi.retrieve.orchestration import retrieve as run_orchestration_retrieve
+from musubi.settings import Settings
+from musubi.types.common import Err
+
+router = APIRouter(prefix="/v1/context", tags=["context"])
+
+
+class ContextQuery(BaseModel):
+    """Build a small, grouped context pack for a presence."""
+
+    namespace: str = Field(
+        ...,
+        description="Two- or three-segment namespace, same shape as /v1/retrieve.",
+    )
+    query_text: str = Field(min_length=1)
+    mode: Literal["startup"] = "startup"
+    planes: list[str] | None = Field(default_factory=lambda: ["episodic", "curated", "concept"])
+    candidate_limit: int = Field(default=30, ge=1, le=100)
+    max_items: int = Field(default=8, ge=1, le=50)
+    max_chars: int = Field(default=1200, ge=120, le=8000)
+    include_history: bool = False
+    state_filter: list[str] | None = None
+
+    @model_validator(mode="after")
+    def _state_filter_for_history(self) -> ContextQuery:
+        if self.include_history and self.state_filter is None:
+            self.state_filter = [
+                "provisional",
+                "matured",
+                "promoted",
+                "demoted",
+                "archived",
+                "superseded",
+            ]
+        return self
+
+
+@router.post("", response_model=ContextPack)
+async def context_pack(
+    request: Request,
+    body: ContextQuery = Body(...),
+    settings: Settings = Depends(get_settings_dep),
+    qdrant: QdrantClient = Depends(get_qdrant_client),
+    embedder: Embedder = Depends(get_embedder),
+    reranker: TEIRerankerClient = Depends(get_reranker),
+) -> ContextPack:
+    """Return a ranked, grouped context pack.
+
+    Ranking happens server-side because clients should not have to
+    rehydrate payload metadata or maintain their own essence heuristics.
+    """
+
+    targets, shape_err = _resolve_targets(body.namespace, body.planes)
+    if shape_err is not None:
+        raise APIError(status_code=400, code="BAD_REQUEST", detail=shape_err)
+
+    auth_result = authenticate_request(
+        request,  # type: ignore[arg-type]
+        None,
+        settings=settings,
+    )
+    if isinstance(auth_result, Err):
+        err = auth_result.error
+        code: ErrorCode = err.code  # type: ignore[assignment]
+        raise APIError(status_code=err.status_code, code=code, detail=err.detail)
+    context = auth_result.value
+
+    pattern_had_wildcards = any("*" in ns for ns, _ in targets)
+    targets = _expand_wildcard_targets(qdrant, targets)
+    if pattern_had_wildcards and not targets:
+        return build_context_pack(
+            [],
+            ContextPackQuery(
+                query_text=body.query_text,
+                mode=body.mode,
+                max_items=body.max_items,
+                max_chars=body.max_chars,
+                include_history=body.include_history,
+            ),
+        )
+
+    for target_namespace, _plane in targets:
+        scope_result = resolve_namespace_scope(context, namespace=target_namespace, access="r")
+        if isinstance(scope_result, Err):
+            raise APIError(
+                status_code=scope_result.error.status_code,
+                code="FORBIDDEN",
+                detail=scope_result.error.detail,
+            )
+
+    query_body: dict[str, object] = {
+        "namespace": body.namespace,
+        "query_text": body.query_text,
+        "mode": "fast",
+        "limit": body.candidate_limit,
+        "planes": [plane for _, plane in targets],
+        "include_archived": body.include_history,
+        "namespace_targets": [{"namespace": ns, "plane": plane} for ns, plane in targets],
+        "state_filter": body.state_filter or ["provisional", "matured", "promoted"],
+    }
+    orchestration_result = await run_orchestration_retrieve(
+        client=qdrant,
+        embedder=embedder,
+        reranker=reranker,
+        query=query_body,
+    )
+    if isinstance(orchestration_result, Err):
+        retrieval_err = orchestration_result.error
+        status, error_code = _KIND_STATUS_MAP.get(retrieval_err.kind, (500, "INTERNAL"))
+        raise APIError(status_code=status, code=error_code, detail=retrieval_err.detail)
+
+    candidates = [_candidate_from_hit(hit) for hit in orchestration_result.value]
+    return build_context_pack(
+        candidates,
+        ContextPackQuery(
+            query_text=body.query_text,
+            mode=body.mode,
+            max_items=body.max_items,
+            max_chars=body.max_chars,
+            include_history=body.include_history,
+        ),
+    )
+
+
+def _candidate_from_hit(hit: Any) -> ContextCandidate:
+    payload = hit.payload if isinstance(hit.payload, dict) else {}
+    return ContextCandidate(
+        object_id=str(hit.object_id),
+        namespace=str(payload.get("namespace") or hit.namespace),
+        plane=str(payload.get("plane") or hit.plane),
+        content=str(payload.get("content") or hit.snippet),
+        summary=_optional_str(payload.get("summary")),
+        title=_optional_str(payload.get("title") or hit.title),
+        tags=_string_list(payload.get("tags")),
+        state=str(payload.get("state") or "matured"),
+        created_epoch=_optional_float(payload.get("created_epoch")) or 0.0,
+        updated_epoch=_optional_float(payload.get("updated_epoch")),
+        importance=int(payload.get("importance") or 5),
+        retrieve_score=float(hit.score),
+        extra={key: value for key, value in payload.items() if key in {"kind", "staleness"}},
+    )
+
+
+def _optional_str(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _optional_float(value: object) -> float | None:
+    if isinstance(value, int | float):
+        return float(value)
+    return None
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+__all__ = ["ContextQuery", "router"]

--- a/src/musubi/api/routers/writes_episodic.py
+++ b/src/musubi/api/routers/writes_episodic.py
@@ -14,6 +14,7 @@ from musubi.api.errors import APIError, ErrorCode
 from musubi.auth import AuthRequirement, authenticate_request
 from musubi.lifecycle.transitions import transition
 from musubi.planes.episodic import EpisodicPlane
+from musubi.retrieve.context_pack import VALID_KINDS, VALID_STALENESS
 from musubi.settings import Settings
 from musubi.types.common import Err, Ok, utc_now
 from musubi.types.episodic import EpisodicMemory
@@ -111,6 +112,15 @@ def _reject_future_created_at(value: datetime | None) -> None:
         )
 
 
+def _validate_context_tags(tags: list[str]) -> list[str]:
+    for tag in tags:
+        if tag.startswith("kind:") and tag.removeprefix("kind:") not in VALID_KINDS:
+            raise ValueError(f"unknown essence kind tag {tag!r}")
+        if tag.startswith("staleness:") and tag.removeprefix("staleness:") not in VALID_STALENESS:
+            raise ValueError(f"unknown essence staleness tag {tag!r}")
+    return tags
+
+
 class CaptureRequest(BaseModel):
     namespace: str
     content: str = Field(min_length=1)
@@ -127,6 +137,11 @@ class CaptureRequest(BaseModel):
     @classmethod
     def _tz_aware_created_at(cls, v: datetime | None) -> datetime | None:
         return _require_tz_aware(v)
+
+    @field_validator("tags")
+    @classmethod
+    def _valid_context_tags(cls, v: list[str]) -> list[str]:
+        return _validate_context_tags(v)
 
 
 class CaptureResponse(BaseModel):
@@ -151,6 +166,11 @@ class CaptureItem(BaseModel):
     def _tz_aware_created_at(cls, v: datetime | None) -> datetime | None:
         return _require_tz_aware(v)
 
+    @field_validator("tags")
+    @classmethod
+    def _valid_context_tags(cls, v: list[str]) -> list[str]:
+        return _validate_context_tags(v)
+
 
 class BatchCaptureRequest(BaseModel):
     namespace: str
@@ -173,6 +193,13 @@ class PatchEpisodicRequest(BaseModel):
     tags: list[str] | None = None
     importance: int | None = Field(default=None, ge=1, le=10)
     summary: str | None = None
+
+    @field_validator("tags")
+    @classmethod
+    def _valid_context_tags(cls, v: list[str] | None) -> list[str] | None:
+        if v is None:
+            return None
+        return _validate_context_tags(v)
 
 
 _FORBIDDEN_PATCH_FIELDS = {"state", "version", "object_id", "namespace"}

--- a/src/musubi/cli/context.py
+++ b/src/musubi/cli/context.py
@@ -1,0 +1,118 @@
+"""`musubi context` — retrieve a ranked essence context pack."""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated
+
+import typer
+
+from musubi.cli._client import post_json, resolve_base_url, resolve_token
+
+context_app = typer.Typer(
+    help="Build ranked context packs from the deployed Musubi API.",
+    no_args_is_help=False,
+    add_completion=False,
+)
+
+
+@context_app.callback(invoke_without_command=True)
+def context(
+    namespace: Annotated[
+        str,
+        typer.Option(
+            "--namespace",
+            "-n",
+            help="Two- or three-segment namespace, e.g. yua/command-chair.",
+        ),
+    ] = "yua/command-chair",
+    query_text: Annotated[
+        str,
+        typer.Option("--query", "-q", help="Moment/task to align context against."),
+    ] = "startup",
+    planes: Annotated[
+        str,
+        typer.Option(
+            "--planes",
+            help="Comma-separated planes to search, e.g. episodic,curated,concept.",
+        ),
+    ] = "episodic,curated,concept",
+    include_history: Annotated[
+        bool,
+        typer.Option("--include-history", help="Include superseded/history rows."),
+    ] = False,
+    max_items: Annotated[int, typer.Option("--max-items", min=1, max=50)] = 8,
+    max_chars: Annotated[int, typer.Option("--max-chars", min=120, max=8000)] = 1200,
+    candidate_limit: Annotated[int, typer.Option("--candidate-limit", min=1, max=100)] = 30,
+    as_json: Annotated[
+        bool,
+        typer.Option("--json", help="Emit raw JSON response instead of grouped text."),
+    ] = False,
+    api_url: Annotated[
+        str | None,
+        typer.Option("--api-url", envvar="MUSUBI_API_URL", help="Musubi API base URL."),
+    ] = None,
+    token: Annotated[
+        str | None,
+        typer.Option("--token", envvar="MUSUBI_TOKEN", help="Operator bearer token."),
+    ] = None,
+) -> None:
+    """Build and print a startup context pack."""
+
+    base_url = resolve_base_url(api_url)
+    bearer = resolve_token(token)
+    body = {
+        "namespace": namespace,
+        "query_text": query_text,
+        "planes": _parse_planes(planes),
+        "include_history": include_history,
+        "max_items": max_items,
+        "max_chars": max_chars,
+        "candidate_limit": candidate_limit,
+    }
+    response = post_json(base_url=base_url, path="/context", token=bearer, json_body=body)
+    if as_json:
+        typer.echo(json.dumps(response, indent=2, sort_keys=True))
+        return
+    typer.echo(_render(response))
+
+
+def _parse_planes(value: str) -> list[str]:
+    planes = [part.strip() for part in value.split(",") if part.strip()]
+    return planes or ["episodic"]
+
+
+def _render(response: dict[str, object]) -> str:
+    groups = response.get("groups", [])
+    if not isinstance(groups, list) or not groups:
+        return "(no context surfaced)"
+    lines: list[str] = []
+    for group in groups:
+        if not isinstance(group, dict):
+            continue
+        title = group.get("title")
+        if not isinstance(title, str):
+            continue
+        lines.append(f"{title}:")
+        items = group.get("items", [])
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            kind = item.get("kind")
+            evidence = item.get("evidence_handle")
+            content = item.get("content")
+            if not isinstance(kind, str) or not isinstance(evidence, str):
+                continue
+            if not isinstance(content, str):
+                continue
+            lines.append(f"- [{kind}; {evidence}] {content}")
+    return "\n".join(lines) if lines else "(no context surfaced)"
+
+
+def main() -> None:
+    context_app()
+
+
+__all__ = ["context_app", "main"]

--- a/src/musubi/cli/main.py
+++ b/src/musubi/cli/main.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import typer
 
+from musubi.cli.context import context_app
 from musubi.cli.promote import promote_app
 
 app = typer.Typer(
@@ -25,6 +26,7 @@ app = typer.Typer(
     no_args_is_help=True,
     add_completion=False,
 )
+app.add_typer(context_app, name="context", help="Build ranked startup context packs.")
 app.add_typer(promote_app, name="promote", help="Concept promotion / rejection subcommands.")
 
 

--- a/src/musubi/retrieve/context_pack.py
+++ b/src/musubi/retrieve/context_pack.py
@@ -1,0 +1,435 @@
+"""Ranked context packs for Musubi essence alignment.
+
+This module is intentionally independent of Qdrant / FastAPI. The API
+router adapts retrieval payloads into :class:`ContextCandidate`, then this
+module owns the v1 ranking contract: closed kinds, staleness suppression,
+BM25 lexical relevance, durable tiebreaks, grouped output, and char caps.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+EssenceKind = Literal[
+    "boundary",
+    "operating-rule",
+    "identity-principle",
+    "relationship/care-cue",
+    "project-stance",
+    "open-loop",
+    "tool/runtime-fact",
+    "correction/suppression",
+    "episode",
+]
+StalenessTier = Literal["durable", "current", "episodic", "superseded"]
+ContextMode = Literal["startup"]
+
+VALID_KINDS: frozenset[str] = frozenset(
+    {
+        "boundary",
+        "operating-rule",
+        "identity-principle",
+        "relationship/care-cue",
+        "project-stance",
+        "open-loop",
+        "tool/runtime-fact",
+        "correction/suppression",
+        "episode",
+    }
+)
+
+VALID_STALENESS: frozenset[str] = frozenset({"durable", "current", "episodic", "superseded"})
+
+_KIND_PRIORITY: dict[EssenceKind, float] = {
+    "boundary": 10.0,
+    "operating-rule": 9.0,
+    "identity-principle": 8.0,
+    "relationship/care-cue": 7.0,
+    "open-loop": 6.0,
+    "project-stance": 5.0,
+    "tool/runtime-fact": 4.5,
+    "correction/suppression": 4.0,
+    "episode": 1.0,
+}
+
+_STALENESS_PRIORITY: dict[StalenessTier, float] = {
+    "durable": 4.0,
+    "current": 3.0,
+    "episodic": 1.0,
+    "superseded": -8.0,
+}
+
+_GROUP_BY_KIND: dict[EssenceKind, str] = {
+    "boundary": "Must-Obey",
+    "operating-rule": "Must-Obey",
+    "identity-principle": "Relationship-Voice",
+    "relationship/care-cue": "Relationship-Voice",
+    "project-stance": "Current-Project",
+    "open-loop": "Open-Loops",
+    "tool/runtime-fact": "Tool-Runtime",
+    "correction/suppression": "Recent-Corrections",
+    "episode": "Context",
+}
+
+_GROUP_ORDER: tuple[str, ...] = (
+    "Must-Obey",
+    "Current-Project",
+    "Relationship-Voice",
+    "Open-Loops",
+    "Tool-Runtime",
+    "Recent-Corrections",
+    "Context",
+)
+
+_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9_.+-]*", re.IGNORECASE)
+
+
+class ContextPackQuery(BaseModel):
+    """Request shape for building a small context pack."""
+
+    query_text: str = ""
+    mode: ContextMode = "startup"
+    max_items: int = Field(default=8, ge=1, le=50)
+    max_chars: int = Field(default=1200, ge=120, le=8000)
+    include_history: bool = False
+
+
+class ContextCandidate(BaseModel):
+    """A retrieval row normalised for essence ranking."""
+
+    object_id: str
+    namespace: str
+    plane: str
+    content: str
+    summary: str | None = None
+    title: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    state: str = "matured"
+    created_epoch: float = 0.0
+    updated_epoch: float | None = None
+    importance: int = 5
+    retrieve_score: float = 0.0
+    extra: dict[str, Any] = Field(default_factory=dict)
+
+
+class ContextPackItem(BaseModel):
+    """One surfaced context item."""
+
+    object_id: str
+    namespace: str
+    plane: str
+    kind: EssenceKind
+    staleness: StalenessTier
+    content: str
+    evidence_handle: str
+    why_surfaced: str
+    score: float
+
+
+class ContextPackGroup(BaseModel):
+    title: str
+    items: list[ContextPackItem]
+
+
+class ContextPack(BaseModel):
+    mode: ContextMode
+    query_text: str
+    groups: list[ContextPackGroup]
+    max_chars: int
+    used_chars: int
+    suppressed: dict[str, int] = Field(default_factory=dict)
+
+
+class _RankedCandidate(BaseModel):
+    candidate: ContextCandidate
+    kind: EssenceKind
+    staleness: StalenessTier
+    bm25: float
+    token_overlap: int
+    score: float
+
+
+def build_context_pack(
+    candidates: list[ContextCandidate],
+    query: ContextPackQuery,
+) -> ContextPack:
+    """Return a grouped, char-capped essence context pack."""
+
+    visible, suppressed = _visible_candidates(candidates, include_history=query.include_history)
+    ranked = _rank(visible, query)
+    groups: dict[str, list[ContextPackItem]] = {title: [] for title in _GROUP_ORDER}
+    used_chars = 0
+    used_items = 0
+
+    query_tokens = _tokenize(query.query_text)
+    for ranked_candidate in ranked:
+        if used_items >= query.max_items:
+            break
+        if _should_skip_ranked_filler(ranked_candidate, has_query=bool(query_tokens)):
+            suppressed["low_relevance"] = suppressed.get("low_relevance", 0) + 1
+            continue
+        item = _to_item(ranked_candidate, remaining_chars=query.max_chars - used_chars)
+        if item is None:
+            break
+        groups[_GROUP_BY_KIND[item.kind]].append(item)
+        used_items += 1
+        used_chars += len(item.content)
+        if used_chars >= query.max_chars:
+            break
+
+    packed_groups = [
+        ContextPackGroup(title=title, items=items)
+        for title in _GROUP_ORDER
+        if (items := groups[title])
+    ]
+    return ContextPack(
+        mode=query.mode,
+        query_text=query.query_text,
+        groups=packed_groups,
+        max_chars=query.max_chars,
+        used_chars=used_chars,
+        suppressed=suppressed,
+    )
+
+
+def render_context_pack_text(pack: ContextPack) -> str:
+    """Render a pack as prompt-ready text."""
+
+    lines: list[str] = []
+    for group in pack.groups:
+        lines.append(f"{group.title}:")
+        for item in group.items:
+            lines.append(f"- [{item.kind}; {item.evidence_handle}] {item.content}")
+    return "\n".join(lines)
+
+
+def _visible_candidates(
+    candidates: list[ContextCandidate],
+    *,
+    include_history: bool,
+) -> tuple[list[ContextCandidate], dict[str, int]]:
+    visible: list[ContextCandidate] = []
+    suppressed: dict[str, int] = {}
+    for candidate in candidates:
+        staleness = _staleness_of(candidate)
+        kind = _kind_of(candidate)
+        if not include_history and (staleness == "superseded" or candidate.state == "superseded"):
+            suppressed["superseded"] = suppressed.get("superseded", 0) + 1
+            continue
+        if not include_history and kind == "correction/suppression":
+            suppressed["correction/suppression"] = suppressed.get("correction/suppression", 0) + 1
+            continue
+        visible.append(candidate)
+    return visible, suppressed
+
+
+def _rank(candidates: list[ContextCandidate], query: ContextPackQuery) -> list[_RankedCandidate]:
+    query_tokens = _tokenize(query.query_text)
+    documents = [_tokenize(_candidate_text(candidate)) for candidate in candidates]
+    bm25_scores = _bm25(query_tokens, documents)
+    max_bm25 = max(bm25_scores, default=0.0)
+    normalizer = max_bm25 if max_bm25 > 0 else 1.0
+    ranked: list[_RankedCandidate] = []
+
+    for candidate, doc_tokens, bm25 in zip(candidates, documents, bm25_scores, strict=True):
+        kind = _kind_of(candidate)
+        staleness = _staleness_of(candidate)
+        overlap = len(set(query_tokens) & set(doc_tokens)) if query_tokens else 0
+        importance = min(10, max(1, candidate.importance)) / 10.0
+        recency = _recency_hint(candidate)
+        relevance = bm25 / normalizer
+        score = (
+            _KIND_PRIORITY[kind]
+            + _STALENESS_PRIORITY[staleness]
+            + (2.0 * relevance)
+            + (0.6 * min(1.0, max(0.0, candidate.retrieve_score)))
+            + (0.5 * importance)
+            + recency
+        )
+        if query_tokens and overlap == 0 and staleness not in ("durable", "current"):
+            score -= 2.0
+        ranked.append(
+            _RankedCandidate(
+                candidate=candidate,
+                kind=kind,
+                staleness=staleness,
+                bm25=bm25,
+                token_overlap=overlap,
+                score=score,
+            )
+        )
+
+    return sorted(
+        ranked,
+        key=lambda row: (
+            row.score,
+            _STALENESS_PRIORITY[row.staleness],
+            _KIND_PRIORITY[row.kind],
+            row.candidate.created_epoch,
+        ),
+        reverse=True,
+    )
+
+
+def _to_item(ranked: _RankedCandidate, *, remaining_chars: int) -> ContextPackItem | None:
+    if remaining_chars <= 0:
+        return None
+    text = _display_text(ranked.candidate)
+    content = _cap_text(text, max_chars=remaining_chars)
+    if not content:
+        return None
+    evidence = f"{ranked.candidate.namespace}/{ranked.candidate.object_id}"
+    return ContextPackItem(
+        object_id=ranked.candidate.object_id,
+        namespace=ranked.candidate.namespace,
+        plane=ranked.candidate.plane,
+        kind=ranked.kind,
+        staleness=ranked.staleness,
+        content=content,
+        evidence_handle=evidence,
+        why_surfaced=_why(ranked),
+        score=round(ranked.score, 4),
+    )
+
+
+def _should_skip_ranked_filler(ranked: _RankedCandidate, *, has_query: bool) -> bool:
+    """Avoid stuffing startup packs with unrelated episodic residue."""
+    if not has_query:
+        return False
+    if ranked.token_overlap > 0:
+        return False
+    if ranked.staleness in ("durable", "current"):
+        return False
+    return ranked.kind == "episode"
+
+
+def _candidate_text(candidate: ContextCandidate) -> str:
+    parts = [
+        candidate.title or "",
+        candidate.summary or "",
+        candidate.content,
+        " ".join(candidate.tags),
+    ]
+    return " ".join(part for part in parts if part)
+
+
+def _display_text(candidate: ContextCandidate) -> str:
+    return (candidate.summary or candidate.content).strip()
+
+
+def _kind_of(candidate: ContextCandidate) -> EssenceKind:
+    raw = _metadata_value(candidate, "kind")
+    if raw in VALID_KINDS:
+        return raw  # type: ignore[return-value]
+    return "episode"
+
+
+def _staleness_of(candidate: ContextCandidate) -> StalenessTier:
+    raw = _metadata_value(candidate, "staleness") or _metadata_value(candidate, "freshness")
+    if raw in VALID_STALENESS:
+        return raw  # type: ignore[return-value]
+    if candidate.state == "superseded":
+        return "superseded"
+    if candidate.state in ("archived", "demoted"):
+        return "episodic"
+    return "episodic"
+
+
+def _metadata_value(candidate: ContextCandidate, key: str) -> str | None:
+    extra_value = candidate.extra.get(key)
+    if isinstance(extra_value, str):
+        return extra_value.strip()
+    prefix = f"{key}:"
+    for tag in candidate.tags:
+        if tag.startswith(prefix):
+            return tag[len(prefix) :].strip()
+    return None
+
+
+def _tokenize(text: str) -> list[str]:
+    return [token.lower() for token in _TOKEN_RE.findall(text)]
+
+
+def _bm25(query_tokens: list[str], documents: list[list[str]]) -> list[float]:
+    if not query_tokens or not documents:
+        return [0.0 for _ in documents]
+
+    doc_freq: Counter[str] = Counter()
+    for doc in documents:
+        doc_freq.update(set(doc))
+    avg_len = sum(len(doc) for doc in documents) / max(1, len(documents))
+    k1 = 1.5
+    b = 0.75
+    scores: list[float] = []
+
+    for doc in documents:
+        counts = Counter(doc)
+        doc_len = len(doc) or 1
+        score = 0.0
+        for token in query_tokens:
+            freq = counts[token]
+            if freq == 0:
+                continue
+            idf = math.log(1 + (len(documents) - doc_freq[token] + 0.5) / (doc_freq[token] + 0.5))
+            denom = freq + k1 * (1 - b + b * (doc_len / max(avg_len, 1.0)))
+            score += idf * ((freq * (k1 + 1)) / denom)
+        scores.append(score)
+    return scores
+
+
+def _recency_hint(candidate: ContextCandidate) -> float:
+    epoch = (
+        candidate.updated_epoch if candidate.updated_epoch is not None else candidate.created_epoch
+    )
+    if epoch <= 0:
+        return 0.0
+    # Only a tiebreaker: newer records should not outrank durable rules
+    # solely by being fresh.
+    return min(0.5, math.log10(max(epoch, 1.0)) / 20.0)
+
+
+def _cap_text(text: str, *, max_chars: int) -> str:
+    clean = " ".join(text.split())
+    if len(clean) <= max_chars:
+        return clean
+    if max_chars <= 3:
+        return clean[:max_chars]
+    return clean[: max_chars - 3].rstrip() + "..."
+
+
+def _why(ranked: _RankedCandidate) -> str:
+    fragments: list[str] = []
+    if ranked.staleness == "durable":
+        fragments.append(f"durable {ranked.kind}")
+    elif ranked.staleness == "current":
+        fragments.append(f"current {ranked.kind}")
+    else:
+        fragments.append(ranked.kind)
+    if ranked.token_overlap:
+        fragments.append(f"{ranked.token_overlap} query-token matches")
+    elif ranked.staleness == "durable":
+        fragments.append("durable-vs-overlap tiebreak")
+    if ranked.bm25 > 0:
+        fragments.append("BM25 lexical match")
+    return "; ".join(fragments)
+
+
+__all__ = [
+    "VALID_KINDS",
+    "VALID_STALENESS",
+    "ContextCandidate",
+    "ContextMode",
+    "ContextPack",
+    "ContextPackGroup",
+    "ContextPackItem",
+    "ContextPackQuery",
+    "EssenceKind",
+    "StalenessTier",
+    "build_context_pack",
+    "render_context_pack_text",
+]

--- a/tests/api/test_context.py
+++ b/tests/api/test_context.py
@@ -1,0 +1,130 @@
+"""API tests for the ranked context-pack endpoint."""
+
+from __future__ import annotations
+
+import asyncio
+
+from fastapi.testclient import TestClient
+
+from musubi.planes.episodic import EpisodicPlane
+from musubi.types.episodic import EpisodicMemory
+
+
+def test_context_endpoint_returns_grouped_server_ranked_pack(
+    client: TestClient,
+    valid_token: str,
+    episodic: EpisodicPlane,
+) -> None:
+    namespace = "eric/claude-code/episodic"
+
+    async def _seed() -> None:
+        await episodic.create(
+            EpisodicMemory(
+                namespace=namespace,
+                content=(
+                    "V-053 promptsmith compiler route made deterministic image prompts "
+                    "safe for Vice LoRA work."
+                ),
+                tags=["kind:project-stance", "staleness:durable", "project:vice"],
+                importance=8,
+            )
+        )
+        await episodic.create(
+            EpisodicMemory(
+                namespace=namespace,
+                content="Old CyberRealistic Lightning drift notes.",
+                tags=["kind:episode", "staleness:superseded", "project:vice"],
+                importance=10,
+            )
+        )
+
+    asyncio.run(_seed())
+
+    response = client.post(
+        "/v1/context",
+        headers={"Authorization": f"Bearer {valid_token}"},
+        json={
+            "namespace": "eric/claude-code",
+            "query_text": "Vice LoRA promptsmith compiler route",
+            "planes": ["episodic"],
+            "max_items": 3,
+            "max_chars": 600,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["mode"] == "startup"
+    flattened = "\n".join(item["content"] for group in body["groups"] for item in group["items"])
+    assert "V-053 promptsmith compiler" in flattened
+    assert "CyberRealistic" not in flattened
+    first = body["groups"][0]["items"][0]
+    assert first["kind"] == "project-stance"
+    assert first["evidence_handle"].startswith(namespace)
+    assert first["why_surfaced"]
+
+
+def test_context_endpoint_can_include_history_when_explicitly_requested(
+    client: TestClient,
+    valid_token: str,
+    episodic: EpisodicPlane,
+) -> None:
+    namespace = "eric/claude-code/episodic"
+
+    async def _seed() -> None:
+        await episodic.create(
+            EpisodicMemory(
+                namespace=namespace,
+                content="Retired agent-msg history for adoption-day audit.",
+                tags=["kind:episode", "staleness:superseded", "topic:adoption-day"],
+                importance=7,
+            )
+        )
+
+    asyncio.run(_seed())
+
+    response = client.post(
+        "/v1/context",
+        headers={"Authorization": f"Bearer {valid_token}"},
+        json={
+            "namespace": "eric/claude-code/episodic",
+            "query_text": "agent-msg adoption-day audit",
+            "include_history": True,
+            "planes": ["episodic"],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    flattened = "\n".join(
+        item["content"] for group in response.json()["groups"] for item in group["items"]
+    )
+    assert "Retired agent-msg history" in flattened
+
+
+def test_capture_rejects_unknown_typed_kind_tag(client: TestClient, valid_token: str) -> None:
+    response = client.post(
+        "/v1/episodic",
+        headers={"Authorization": f"Bearer {valid_token}"},
+        json={
+            "namespace": "eric/claude-code/episodic",
+            "content": "bad typed write",
+            "tags": ["kind:whatever"],
+        },
+    )
+
+    assert response.status_code == 422
+    assert "unknown essence kind" in response.text
+
+
+def test_capture_allows_legacy_untyped_tags(client: TestClient, valid_token: str) -> None:
+    response = client.post(
+        "/v1/episodic",
+        headers={"Authorization": f"Bearer {valid_token}"},
+        json={
+            "namespace": "eric/claude-code/episodic",
+            "content": "legacy gist-style write",
+            "tags": ["old-note", "vice"],
+        },
+    )
+
+    assert response.status_code == 202

--- a/tests/cli/test_cli_context.py
+++ b/tests/cli/test_cli_context.py
@@ -1,0 +1,100 @@
+"""Tests for the `musubi context` CLI."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pytest_httpx import HTTPXMock
+from typer.testing import CliRunner
+
+from musubi.cli.main import app
+
+_BASE = "http://localhost:8100/v1"
+_TOKEN = "operator-token-fake"
+
+
+@pytest.fixture(autouse=True)
+def _scrub_cli_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MUSUBI_API_URL", raising=False)
+    monkeypatch.delenv("MUSUBI_TOKEN", raising=False)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _context_reply() -> dict[str, object]:
+    return {
+        "mode": "startup",
+        "query_text": "Vice LoRA",
+        "max_chars": 1200,
+        "used_chars": 44,
+        "suppressed": {"superseded": 1},
+        "groups": [
+            {
+                "title": "Current-Project",
+                "items": [
+                    {
+                        "object_id": "v053",
+                        "namespace": "yua/command-chair/episodic",
+                        "plane": "episodic",
+                        "kind": "project-stance",
+                        "staleness": "durable",
+                        "content": "V-053 promptsmith compiler route.",
+                        "evidence_handle": "yua/command-chair/episodic/v053",
+                        "why_surfaced": "durable project-stance",
+                        "score": 9.1,
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_context_posts_to_api_and_renders_grouped_output(
+    runner: CliRunner,
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(method="POST", url=f"{_BASE}/context", json=_context_reply())
+    result = runner.invoke(
+        app,
+        [
+            "context",
+            "--namespace",
+            "yua/command-chair",
+            "--query",
+            "Vice LoRA",
+            "--planes",
+            "episodic,curated",
+            "--token",
+            _TOKEN,
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    request = httpx_mock.get_request()
+    assert request is not None
+    assert request.headers["Authorization"] == f"Bearer {_TOKEN}"
+    body = json.loads(request.read())
+    assert body["namespace"] == "yua/command-chair"
+    assert body["query_text"] == "Vice LoRA"
+    assert body["planes"] == ["episodic", "curated"]
+    assert "Current-Project:" in result.output
+    assert "V-053 promptsmith compiler route." in result.output
+
+
+def test_context_json_flag_emits_raw_response(
+    runner: CliRunner,
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(method="POST", url=f"{_BASE}/context", json=_context_reply())
+    result = runner.invoke(
+        app,
+        ["context", "--query", "Vice LoRA", "--token", _TOKEN, "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["groups"][0]["title"] == "Current-Project"

--- a/tests/ops/test_first_deploy_smoke.py
+++ b/tests/ops/test_first_deploy_smoke.py
@@ -323,6 +323,70 @@ def test_check_observability_scrapes_valid_prometheus_text() -> None:
     assert "[PASS] metric families" in result.stdout
 
 
+def test_check_consumers_requires_every_live_consumer_command() -> None:
+    result = subprocess.run(
+        ["bash", str(SMOKE / "check_consumers.sh")],
+        cwd=ROOT,
+        env={"PATH": "/usr/bin:/bin:/usr/sbin:/sbin"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "[FAIL] consumer command-chair agents" in result.stdout
+    assert "MUSUBI_CONSUMER_COMMAND_CHAIR_CMD is not set" in result.stdout
+    assert "MUSUBI_CONSUMER_PHONE_AGENTS_CMD is not set" in result.stdout
+    assert "MUSUBI_CONSUMER_OPENCLAW_NYLA_CMD is not set" in result.stdout
+    assert "MUSUBI_CONSUMER_VICE_CMD is not set" in result.stdout
+
+
+def test_check_consumers_runs_every_live_consumer_command() -> None:
+    result = subprocess.run(
+        ["bash", str(SMOKE / "check_consumers.sh")],
+        cwd=ROOT,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "MUSUBI_CONSUMER_PHASE": "pre-deploy",
+            "MUSUBI_CONSUMER_COMMAND_CHAIR_CMD": "printf command-chair-smoke",
+            "MUSUBI_CONSUMER_PHONE_AGENTS_CMD": "printf phone-smoke",
+            "MUSUBI_CONSUMER_OPENCLAW_NYLA_CMD": "printf openclaw-smoke",
+            "MUSUBI_CONSUMER_VICE_CMD": "printf vice-smoke",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Musubi consumer regression smoke (pre-deploy)" in result.stdout
+    assert "[PASS] consumer command-chair agents" in result.stdout
+    assert "[PASS] consumer phone agents" in result.stdout
+    assert "[PASS] consumer OpenClaw on Nyla" in result.stdout
+    assert "[PASS] consumer Vice app" in result.stdout
+
+
+def test_check_consumers_rejects_placeholders_and_noops() -> None:
+    result = subprocess.run(
+        ["bash", str(SMOKE / "check_consumers.sh")],
+        cwd=ROOT,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "MUSUBI_CONSUMER_COMMAND_CHAIR_CMD": "true",
+            "MUSUBI_CONSUMER_PHONE_AGENTS_CMD": "<phone-agent live smoke command>",
+            "MUSUBI_CONSUMER_OPENCLAW_NYLA_CMD": "printf openclaw-smoke",
+            "MUSUBI_CONSUMER_VICE_CMD": "printf vice-smoke",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "MUSUBI_CONSUMER_COMMAND_CHAIR_CMD must be a real live-consumer command" in result.stdout
+    assert "MUSUBI_CONSUMER_PHONE_AGENTS_CMD must be a real live-consumer command" in result.stdout
+
+
 def test_verify_sh_aggregates_all_checks() -> None:
     with _mock_musubi() as base_url:
         result = _run_script("verify.sh", base_url)

--- a/tests/retrieve/test_context_pack.py
+++ b/tests/retrieve/test_context_pack.py
@@ -1,0 +1,210 @@
+"""Context-pack ranking for Musubi's essence alignment slice."""
+
+from __future__ import annotations
+
+from musubi.retrieve.context_pack import ContextCandidate, ContextPackQuery, build_context_pack
+
+
+def _candidate(
+    object_id: str,
+    content: str,
+    *,
+    tags: list[str] | None = None,
+    state: str = "matured",
+    created_epoch: float = 1000.0,
+    score: float = 0.1,
+) -> ContextCandidate:
+    return ContextCandidate(
+        object_id=object_id,
+        namespace="yua/command-chair/episodic",
+        plane="episodic",
+        content=content,
+        tags=tags or [],
+        state=state,
+        created_epoch=created_epoch,
+        retrieve_score=score,
+    )
+
+
+def _texts(pack) -> list[str]:  # type: ignore[no-untyped-def]
+    return [item.content for group in pack.groups for item in group.items]
+
+
+def test_vice_lora_startup_surfaces_v049_v053_and_identity_layer_not_old_drift() -> None:
+    pack = build_context_pack(
+        [
+            _candidate(
+                "v049",
+                "V-049 memory spine taught Vice to inject typed companion context packs "
+                "instead of generic gists.",
+                tags=["kind:project-stance", "staleness:durable", "project:vice"],
+                created_epoch=2000.0,
+            ),
+            _candidate(
+                "v053",
+                "V-053 promptsmith compiler route made the deterministic compiler the "
+                "default path so image prompts stay rich without LLM hallucinated traits.",
+                tags=["kind:project-stance", "staleness:durable", "project:vice"],
+                created_epoch=2100.0,
+            ),
+            _candidate(
+                "lora",
+                "LoRA identity layer: Shiori and Tama use trigger names at strength 0.85; "
+                "Promptsmith should describe scene, clothing, camera, and mood while the "
+                "LoRA owns identity fidelity.",
+                tags=["kind:tool/runtime-fact", "staleness:current", "project:vice"],
+                created_epoch=2200.0,
+            ),
+            _candidate(
+                "old",
+                "Old CyberRealistic Lightning drift notes from before RedCraft and the "
+                "compiler route.",
+                tags=["kind:episode", "staleness:superseded", "project:vice"],
+                state="superseded",
+                created_epoch=900.0,
+                score=0.99,
+            ),
+        ],
+        ContextPackQuery(
+            query_text="Vice LoRA promptsmith Shiori Tama image flow",
+            mode="startup",
+            max_items=4,
+            max_chars=1200,
+        ),
+    )
+
+    joined = "\n".join(_texts(pack))
+    assert "V-049 memory spine" in joined
+    assert "V-053 promptsmith compiler" in joined
+    assert "LoRA identity layer" in joined
+    assert "CyberRealistic" not in joined
+
+
+def test_adoption_day_surfaces_canonical_comms_and_suppresses_retired_agent_msg() -> None:
+    pack = build_context_pack(
+        [
+            _candidate(
+                "canonical",
+                "Canonical comms set is agent-bridge for send, chair-msg for durable "
+                "fallback, and team-task for work tracking.",
+                tags=["kind:tool/runtime-fact", "staleness:durable", "topic:adoption-day"],
+                created_epoch=2000.0,
+            ),
+            _candidate(
+                "wrapper-rule",
+                "Do not keep per-agent forks or thin wrappers around canonical command-chair "
+                "tools; divergence must be fixed on the spot.",
+                tags=["kind:operating-rule", "staleness:durable", "topic:adoption-day"],
+                created_epoch=2100.0,
+            ),
+            _candidate(
+                "retired",
+                "Older agent-msg practice existed before the canonical agent-bridge path.",
+                tags=["kind:episode", "staleness:superseded", "topic:adoption-day"],
+                state="superseded",
+                created_epoch=2200.0,
+                score=1.0,
+            ),
+        ],
+        ContextPackQuery(
+            query_text="Adoption Day canonical comms tools wrappers agent bridge",
+            mode="startup",
+            max_items=3,
+            max_chars=900,
+        ),
+    )
+
+    joined = "\n".join(_texts(pack))
+    assert "agent-bridge" in joined
+    assert "chair-msg" in joined
+    assert "thin wrappers" in joined
+    assert "agent-msg practice" not in joined
+
+
+def test_presence_moment_surfaces_wanted_before_needed_without_pm_habits() -> None:
+    pack = build_context_pack(
+        [
+            _candidate(
+                "presence",
+                "When Eric offers ordinary presence with nothing broken, answer wanted "
+                "before needed and stay in the room before structuring a task.",
+                tags=["kind:relationship/care-cue", "staleness:durable"],
+                created_epoch=1500.0,
+            ),
+            _candidate(
+                "pm",
+                "Default project-management habit: make a checklist, assign owners, and "
+                "turn the moment into work.",
+                tags=["kind:episode", "staleness:episodic"],
+                created_epoch=3000.0,
+                score=0.95,
+            ),
+        ],
+        ContextPackQuery(
+            query_text="Eric wants presence when nothing is broken",
+            mode="startup",
+            max_items=2,
+            max_chars=600,
+        ),
+    )
+
+    joined = "\n".join(_texts(pack))
+    assert "wanted before needed" in joined
+    assert "make a checklist" not in joined
+
+
+def test_legacy_rows_default_to_episode_and_history_can_retrieve_superseded() -> None:
+    legacy = _candidate(
+        "legacy",
+        "Legacy gist-only row with no typed kind remains readable as episode context.",
+        tags=[],
+    )
+    superseded = _candidate(
+        "old",
+        "Superseded history row is normally hidden but explicit audit can retrieve it.",
+        tags=["staleness:superseded"],
+        state="superseded",
+    )
+
+    normal = build_context_pack(
+        [legacy, superseded],
+        ContextPackQuery(query_text="legacy superseded audit", mode="startup"),
+    )
+    normal_joined = "\n".join(_texts(normal))
+    assert "Legacy gist-only" in normal_joined
+    assert "Superseded history" not in normal_joined
+    assert normal.groups[0].items[0].kind == "episode"
+
+    history = build_context_pack(
+        [legacy, superseded],
+        ContextPackQuery(
+            query_text="legacy superseded audit", mode="startup", include_history=True
+        ),
+    )
+    history_joined = "\n".join(_texts(history))
+    assert "Superseded history" in history_joined
+
+
+def test_durable_rule_beats_shallow_overlap_episode() -> None:
+    pack = build_context_pack(
+        [
+            _candidate(
+                "durable",
+                "Durable boundary: do not expose raw transcript quotes in context packs.",
+                tags=["kind:boundary", "staleness:durable"],
+                score=0.05,
+            ),
+            _candidate(
+                "noisy",
+                "transcript transcript transcript transcript unrelated episode chatter",
+                tags=["kind:episode", "staleness:episodic"],
+                created_epoch=3000.0,
+                score=1.0,
+            ),
+        ],
+        ContextPackQuery(query_text="transcript", mode="startup", max_items=2),
+    )
+
+    first = pack.groups[0].items[0]
+    assert first.object_id == "durable"
+    assert first.why_surfaced.startswith("durable boundary")


### PR DESCRIPTION
## Summary

Adds Musubi v1's additive `/v1/context` surface for ranked startup context packs:

- BM25 lexical context packing with closed kind/staleness whitelists, staleness suppression, grouped output, evidence handles, and char caps.
- Additive typed-write validation for `kind:` and `staleness:` tags while preserving legacy untyped tags and existing endpoints.
- `musubi context` CLI and `musubi-context` entry point for deployed-service reads.
- Deploy smoke gate for command-chair agents, phone agents, OpenClaw on nyla, and Vice; the script fails closed for unset commands, literal placeholders, and bare no-ops.
- Docs/OpenAPI/ADR/runbook updates for the context-pack contract and deployment close gate.

Also includes a separate hygiene commit reconciling completed slice metadata and stale locks.

## Team Review

- Shiori: approved full context-pack packet and post-review consumer-smoke delta.
- Tama: approved backend/API compatibility; initial caveat on placeholder smoke commands resolved by script hardening.
- Aoi: approved for commit/push/deploy; ceremony close remains gated on deployed versioned service plus real live-consumer smoke.

## Validation

- `uv run ruff format .`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src tests`
- `make agent-check`
- focused context/smoke pytest: `15 passed`
- full pytest after smoke delta: `1409 passed, 195 skipped, 17 deselected, 1 warning`

The remaining warning is pre-existing: `tests/vault/test_watcher_boot_scan.py::test_boot_scan_archives_removed_files` reports an unawaited watcher coroutine.

## Close Gate

This PR does not by itself close Adoption Day. Close still requires:

1. Merge and versioned release/container build from CI.
2. Reproducible deploy through committed deploy scripts/runbook.
3. Real `MUSUBI_CONSUMER_*_CMD` values for command-chair, phone agents, OpenClaw on nyla, and Vice.
4. `deploy/smoke/check_consumers.sh` green against the deployed service.
5. All four command-chair agents pointed at the deployed Musubi service.

No tracking Issue: Adoption Day Musubi v1 build charter from Eric/Aoi; cross-agent `team-task musubi-v1-final-review-20260628` used for review.
