### PR TITLE
fix(ops): expose service version in status

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2704,6 +2704,11 @@ components:
         status:
           type: string
           title: Status
+        version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Version
         components:
           additionalProperties:
             $ref: '#/components/schemas/ComponentStatus'

--- a/src/musubi/api/responses.py
+++ b/src/musubi/api/responses.py
@@ -25,6 +25,7 @@ class ComponentStatus(BaseModel):
 
 class StatusResponse(BaseModel):
     status: str
+    version: str | None = None
     components: dict[str, ComponentStatus]
 
 

--- a/src/musubi/api/routers/ops.py
+++ b/src/musubi/api/routers/ops.py
@@ -71,6 +71,8 @@ async def status(
         overall = "degraded"
         return StatusResponse(status=overall, components=components)
 
+    version = settings.musubi_service_version or None
+
     # Per-service liveness paths. TEI exposes `/health`; Ollama doesn't —
     # it returns 404 on `/health` and 200 on `/api/tags` (empty model list
     # when no model is loaded, which still proves the daemon is up).
@@ -86,7 +88,7 @@ async def status(
         )
 
     overall = "ok" if all(c.healthy for c in components.values()) else "degraded"
-    return StatusResponse(status=overall, components=components)
+    return StatusResponse(status=overall, version=version, components=components)
 
 
 @router.get("/metrics")

--- a/tests/observability/test_observability.py
+++ b/tests/observability/test_observability.py
@@ -374,6 +374,87 @@ def test_ops_status_populates_real_components_per_aoi_review(obs_app: TestClient
         assert isinstance(c["healthy"], bool)
 
 
+def _ops_status_client_for_settings(
+    settings: Any,
+    qdrant: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> TestClient:
+    from musubi.api.app import create_app
+    from musubi.api.dependencies import get_qdrant_client, get_settings_dep
+    from musubi.api.routers import ops as ops_router_mod
+    from musubi.config import get_settings as _get_settings
+    from musubi.observability import health as health_mod
+
+    _get_settings.cache_clear()
+    monkeypatch.setattr("musubi.config.get_settings", lambda: settings)
+    monkeypatch.setattr("musubi.api.routers.ops.get_settings", lambda: settings)
+
+    real_check = health_mod.check_component_health
+
+    def _faked_check(
+        *,
+        name: str,
+        url: str,
+        transport: object | None = None,
+        timeout: float = 1.5,
+    ) -> object:
+        ok_transport = httpx.MockTransport(lambda r: httpx.Response(200, json={"status": "ok"}))
+        return real_check(name=name, url=url, transport=ok_transport, timeout=timeout)
+
+    monkeypatch.setattr(ops_router_mod, "check_component_health", _faked_check)
+
+    app = create_app(settings=settings)
+    app.dependency_overrides[get_qdrant_client] = lambda: qdrant
+    app.dependency_overrides[get_settings_dep] = lambda: settings
+    return TestClient(app)
+
+
+def test_ops_status_returns_configured_service_version(
+    obs_settings: Any,
+    obs_qdrant: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GitHub #382 — /ops/status reports the configured Core version."""
+    settings = obs_settings.model_copy(update={"musubi_service_version": "v1.11.0-test"})
+
+    with _ops_status_client_for_settings(settings, obs_qdrant, monkeypatch) as client:
+        resp = client.get("/v1/ops/status")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["version"] == "v1.11.0-test"
+    assert set(body["components"]) >= {
+        "qdrant",
+        "tei-dense",
+        "tei-sparse",
+        "tei-reranker",
+        "ollama",
+    }
+
+
+def test_ops_status_returns_null_when_service_version_empty(
+    obs_settings: Any,
+    obs_qdrant: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GitHub #382 — blank/default service version remains explicit null."""
+    settings = obs_settings.model_copy(update={"musubi_service_version": ""})
+
+    with _ops_status_client_for_settings(settings, obs_qdrant, monkeypatch) as client:
+        resp = client.get("/v1/ops/status")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["version"] is None
+    assert set(body["components"]) >= {
+        "qdrant",
+        "tei-dense",
+        "tei-sparse",
+        "tei-reranker",
+        "ollama",
+    }
+
+
 # ---------------------------------------------------------------------------
 # Coverage tests
 # ---------------------------------------------------------------------------

--- a/tests/observability/test_observability.py
+++ b/tests/observability/test_observability.py
@@ -455,6 +455,37 @@ def test_ops_status_returns_null_when_service_version_empty(
     }
 
 
+def test_ops_status_returns_null_when_settings_unavailable(
+    obs_settings: Any,
+    obs_qdrant: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GitHub #382 — settings-load failure keeps version explicit null."""
+    from musubi.api.app import create_app
+    from musubi.api.dependencies import get_qdrant_client, get_settings_dep
+    from musubi.config import get_settings as _get_settings
+
+    _get_settings.cache_clear()
+
+    def _broken_settings() -> object:
+        raise RuntimeError("settings unavailable")
+
+    monkeypatch.setattr("musubi.api.routers.ops.get_settings", _broken_settings)
+
+    app = create_app(settings=obs_settings)
+    app.dependency_overrides[get_qdrant_client] = lambda: obs_qdrant
+    app.dependency_overrides[get_settings_dep] = lambda: obs_settings
+
+    with TestClient(app) as client:
+        resp = client.get("/v1/ops/status")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "degraded"
+    assert body["version"] is None
+    assert body["components"]["tei-dense"]["detail"].startswith("settings unavailable:")
+
+
 # ---------------------------------------------------------------------------
 # Coverage tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #382.

## Summary
- Adds optional `version` to `StatusResponse`.
- Wires `/v1/ops/status` to `settings.musubi_service_version`, normalizing blank/default to `null`.
- Preserves existing component health fields and updates `openapi.yaml`.

## Validation
- `.venv/bin/pytest tests/observability/test_observability.py::test_ops_status_populates_real_components_per_aoi_review tests/observability/test_observability.py::test_ops_status_returns_configured_service_version tests/observability/test_observability.py::test_ops_status_returns_null_when_service_version_empty tests/api/test_api_v0_read.py::test_ready_includes_components -q`
- `make check` -> 1411 passed, 195 skipped, coverage 88.53%; one watcher RuntimeWarning observed
- `make agent-check` -> OK

## Authorship
Implemented by Codex/Yua from Eric's local GitHub credentials.
