### PR TITLE
fix(auth): make recursive scope read-only

### DIFF
--- a/docs/Musubi/07-interfaces/canonical-api.md
+++ b/docs/Musubi/07-interfaces/canonical-api.md
@@ -36,9 +36,11 @@ Tokens carry a scope list; each scope is a namespace glob:
 - `eric/claude-code/episodic:rw` — read+write to that specific namespace.
 - `eric/*/episodic:r` — read any of Eric's episodic (rare; operator scope).
 - `eric/_shared/curated:rw` — shared curated.
-- `**:r` — recursive read across all namespaces. Recursive write is not granted;
-  `**:rw` is treated as read-only by the matcher. Use explicit segment globs
-  for scoped writes or `operator` for admin/migration actions.
+- `**:r` — recursive read across all namespaces. Unlike `*`, which matches a
+  single segment and requires the same segment count, `**` is special-cased to
+  match any namespace at any depth. Recursive write is not granted; `**:rw` is
+  treated as read-only by the matcher. Use explicit segment globs for scoped
+  writes or `operator` for admin/migration actions.
 - `operator` — meta scope for admin endpoints.
 
 See [[10-security/auth]] for token issuance and validation.

--- a/docs/Musubi/07-interfaces/canonical-api.md
+++ b/docs/Musubi/07-interfaces/canonical-api.md
@@ -36,6 +36,9 @@ Tokens carry a scope list; each scope is a namespace glob:
 - `eric/claude-code/episodic:rw` — read+write to that specific namespace.
 - `eric/*/episodic:r` — read any of Eric's episodic (rare; operator scope).
 - `eric/_shared/curated:rw` — shared curated.
+- `**:r` — recursive read across all namespaces. Recursive write is not granted;
+  `**:rw` is treated as read-only by the matcher. Use explicit segment globs
+  for scoped writes or `operator` for admin/migration actions.
 - `operator` — meta scope for admin endpoints.
 
 See [[10-security/auth]] for token issuance and validation.

--- a/docs/Musubi/10-security/auth.md
+++ b/docs/Musubi/10-security/auth.md
@@ -82,7 +82,10 @@ Namespace glob:
 - `eric/claude-code/episodic` — exact.
 - `eric/_shared/curated` — shared scope.
 - `eric/*/episodic` — all of Eric's episodic (rare; operator scope).
-- `**` — full access (operator only).
+- `**` — recursive read across all namespaces. Recursive namespace scope is
+  read-only by policy; `**:rw` does not grant write access. Use explicit
+  segment wildcards for scoped writes, or `operator` for admin/migration
+  actions.
 
 Access level:
 

--- a/src/musubi/auth/scopes.py
+++ b/src/musubi/auth/scopes.py
@@ -122,6 +122,9 @@ def _namespace_scope_allows(scope: str, namespace: str, access: AccessLevel) -> 
         return False
 
     pattern, granted_access = parsed
+    if pattern == "**" and access == "w":
+        return False
+
     return _namespace_matches(pattern, namespace) and _access_allows(granted_access, access)
 
 

--- a/tests/auth/test_auth.py
+++ b/tests/auth/test_auth.py
@@ -165,6 +165,61 @@ def test_scope_match_grants_access(
     assert scope_result.value.scope_used == "eric/claude-code/episodic:rw"
 
 
+def test_recursive_scope_grants_read_without_write() -> None:
+    context = AuthContext(
+        subject="aoi-phone",
+        issuer="https://auth.example.test",
+        audience="musubi",
+        scopes=("**:r",),
+        presence="aoi/voice",
+        token_id="token-123",
+    )
+
+    read = resolve_namespace_scope(context, namespace="yua/command-chair/episodic", access="r")
+    write = resolve_namespace_scope(context, namespace="yua/command-chair/episodic", access="w")
+
+    assert read.is_ok()
+    assert write.is_err()
+    assert isinstance(write, Err)
+    assert "yua/command-chair/episodic" in write.error.detail
+
+
+def test_recursive_rw_scope_does_not_grant_cross_namespace_write() -> None:
+    context = AuthContext(
+        subject="legacy-shared-token",
+        issuer="https://auth.example.test",
+        audience="musubi",
+        scopes=("**:rw",),
+        presence="openclaw-nyla",
+        token_id="token-123",
+    )
+
+    read = resolve_namespace_scope(context, namespace="aoi/voice/episodic", access="r")
+    write = resolve_namespace_scope(context, namespace="aoi/voice/episodic", access="w")
+
+    assert read.is_ok()
+    assert write.is_err()
+    assert isinstance(write, Err)
+    assert "aoi/voice/episodic" in write.error.detail
+
+
+def test_segment_wildcard_rw_scope_still_grants_matching_write() -> None:
+    context = AuthContext(
+        subject="aoi-voice",
+        issuer="https://auth.example.test",
+        audience="musubi",
+        scopes=("aoi/voice/*:rw",),
+        presence="aoi/voice",
+        token_id="token-123",
+    )
+
+    own_write = resolve_namespace_scope(context, namespace="aoi/voice/episodic", access="w")
+    cross_write = resolve_namespace_scope(context, namespace="yua/voice/episodic", access="w")
+
+    assert own_write.is_ok()
+    assert cross_write.is_err()
+
+
 def test_scope_mismatch_returns_403_with_detail(auth_settings: Settings) -> None:
     token = _hs_token(auth_settings)
     request = SimpleNamespace(


### PR DESCRIPTION
No tracking Issue: tracked as harem-ops team-task `musubi-v111-phone-token-scope`.

## Summary
- keep recursive `**` namespace scope usable for broad reads
- deny write authorization from recursive `**`, including legacy `**:rw` tokens
- document recursive scope as read-only and point write-broad callers to explicit segment globs or `operator`

## Tests
- `uv run pytest tests/auth/test_auth.py -q`
- `make check`
- `make agent-check`

## Notes
- `make check` passed with the pre-existing watcher RuntimeWarning in `tests/vault/test_watcher_boot_scan.py::test_boot_scan_archives_removed_files`; no new failure introduced.
- First commit is test-only and demonstrates the previous unsafe `**:rw` write behavior.