### PR TITLE
chore(deploy): pin musubi-core to v1.11.3 signed digest

### DIFF
--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -38,12 +38,12 @@ musubi_core_port: 8100
 # For what's in a given version, see CHANGELOG.md (authoritative)
 # rather than a comment here — version-specific notes rot; the
 # changelog is the source of truth.
-musubi_core_image: "ghcr.io/ericmey/musubi-core@sha256:863e37e7be49ea61ea090bfde0bb265a90c0567ddc427f31e879c556434b0962"
+musubi_core_image: "ghcr.io/ericmey/musubi-core@sha256:f502174b34fea3910959bac6c54af70659ad2873e7208d02e07e952364df537a"
 # Human-readable version paired with `musubi_core_image`. Rendered into
 # `.env.production` as `MUSUBI_SERVICE_VERSION` so spans + dashboards carry
 # the tag, not just the digest. Bumped in lockstep with the image pin by
 # `.github/workflows/auto-digest-bump.yml`.
-musubi_core_version: "v1.11.2"
+musubi_core_version: "v1.11.3"
 musubi_qdrant_image: "qdrant/qdrant:v1.17.1"
 # TEI image tag = <compute-capability>-<version>. RTX 3080 is Ampere,
 # compute 8.6 → `86-*`. Other GPUs: `turing-*` (RTX 20xx), `89-*` (RTX 40xx),


### PR DESCRIPTION
chore(deploy): pin musubi-core to v1.11.3 signed digest

Automated by `.github/workflows/auto-digest-bump.yml` in response to the [v1.11.3](https://github.com/ericmey/musubi/releases/tag/v1.11.3) release.

## Supply-chain attestations
- cosign keyless signature via GitHub OIDC
- CycloneDX SBOM attached as a cosign attestation
- Trivy vulnerability scan — 0 CRITICAL (gate in `publish-core-image.yml`)

## Verify before deploy

```bash
cosign verify \
  --certificate-identity-regexp 'https://github.com/ericmey/musubi/.*' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  ghcr.io/ericmey/musubi-core@sha256:f502174b34fea3910959bac6c54af70659ad2873e7208d02e07e952364df537a
```

## After merge

```bash
# From the ansible control host:
cd ~/musubi
git pull origin main
ANSIBLE_VAULT_PASSWORD_FILE=~/ansible/.vault_pass \
  ansible-playbook \
    -i deploy/ansible/inventory.yml \
    -e @~/.musubi-secrets/inventory-vars.yml \
    -e @~/.musubi-secrets/vault.yml \
    -e 'changed_services=["core","lifecycle-worker"]' \
    deploy/ansible/update.yml
```

No tracking Issue: auto-generated release digest pin.