### PR TITLE
fix(api): default episodic typed tags

### DIFF
--- a/docs/Musubi/05-retrieval/context-pack.md
+++ b/docs/Musubi/05-retrieval/context-pack.md
@@ -69,6 +69,18 @@ Only these typed kinds are accepted:
 
 Legacy rows without a typed `kind:` tag adapt as `episode`.
 
+New episodic captures default missing typed tags at the API boundary:
+
+- missing `kind:*` -> `kind:episode`
+- missing `staleness:*` -> `staleness:episodic`
+- caller-supplied typed tags are preserved exactly
+
+`kind:episode` is therefore the default classification for rows written through
+`POST /v1/episodic`, not proof that the caller explicitly marked the row as an
+episode. Future read filters should treat it as a broad episodic-plane default;
+if a caller-intent distinction becomes necessary, add a separate provenance tag
+or metadata field instead of overloading `kind:episode`.
+
 Typed writes use tags:
 
 ```text
@@ -76,8 +88,8 @@ kind:project-stance
 staleness:durable
 ```
 
-Unknown `kind:` or `staleness:` tags are rejected at capture/patch time. Plain
-legacy tags remain legal.
+Unknown `kind:` or `staleness:` tags are rejected at capture/patch time with a
+422 request-validation error. Plain legacy tags remain legal.
 
 ## Ranking
 

--- a/docs/Musubi/07-interfaces/canonical-api.md
+++ b/docs/Musubi/07-interfaces/canonical-api.md
@@ -281,6 +281,12 @@ Typed metadata uses tags such as `kind:project-stance` and
 patch. Legacy rows with no `kind:` tag adapt as `episode`. Superseded/history
 records are suppressed unless `include_history=true`.
 
+`POST /v1/episodic` and `POST /v1/episodic/batch` fill missing typed metadata at
+the API boundary: missing `kind:*` becomes `kind:episode`; missing
+`staleness:*` becomes `staleness:episodic`; caller-supplied typed tags are
+preserved. The default `kind:episode` is a broad episodic-plane classification,
+not evidence that the caller explicitly chose that kind.
+
 See [[05-retrieval/context-pack]] for the ranking contract and acceptance
 tests.
 

--- a/src/musubi/api/routers/writes_episodic.py
+++ b/src/musubi/api/routers/writes_episodic.py
@@ -121,6 +121,15 @@ def _validate_context_tags(tags: list[str]) -> list[str]:
     return tags
 
 
+def _with_default_episode_tags(tags: list[str]) -> list[str]:
+    out = list(tags)
+    if not any(tag.startswith("kind:") for tag in out):
+        out.append("kind:episode")
+    if not any(tag.startswith("staleness:") for tag in out):
+        out.append("staleness:episodic")
+    return out
+
+
 class CaptureRequest(BaseModel):
     namespace: str
     content: str = Field(min_length=1)
@@ -222,7 +231,7 @@ async def capture(
         "namespace": body.namespace,
         "content": body.content,
         "summary": body.summary,
-        "tags": body.tags,
+        "tags": _with_default_episode_tags(body.tags),
         "importance": body.importance,
     }
     preserve_created_at = False
@@ -266,7 +275,7 @@ async def batch_capture(
             "namespace": body.namespace,
             "content": item.content,
             "summary": item.summary,
-            "tags": item.tags,
+            "tags": _with_default_episode_tags(item.tags),
             "importance": item.importance,
         }
         preserve = False

--- a/tests/api/test_api_v0_write.py
+++ b/tests/api/test_api_v0_write.py
@@ -36,6 +36,20 @@ from musubi.types.episodic import EpisodicMemory
 # ---------------------------------------------------------------------------
 
 
+def _get_tags(
+    client: TestClient, headers: dict[str, str], namespace: str, object_id: str
+) -> list[str]:
+    got = client.get(
+        f"/v1/episodic/{object_id}",
+        headers=headers,
+        params={"namespace": namespace},
+    )
+    assert got.status_code == 200, got.text
+    tags = got.json()["tags"]
+    assert isinstance(tags, list)
+    return tags
+
+
 def test_capture_happy_returns_object_id(
     client: TestClient,
     valid_token: str,
@@ -105,13 +119,7 @@ def test_capture_adds_default_typed_episode_tags(
     )
     assert r.status_code == 202, r.text
     object_id = r.json()["object_id"]
-    got = client.get(
-        f"/v1/episodic/{object_id}",
-        headers=headers,
-        params={"namespace": namespace},
-    )
-    assert got.status_code == 200, got.text
-    assert got.json()["tags"] == [
+    assert _get_tags(client, headers, namespace, object_id) == [
         "src:direct-test",
         "kind:episode",
         "staleness:episodic",
@@ -136,15 +144,97 @@ def test_capture_preserves_explicit_typed_tags(
     )
     assert r.status_code == 202, r.text
     object_id = r.json()["object_id"]
-    got = client.get(
-        f"/v1/episodic/{object_id}",
+    saved_tags = _get_tags(client, headers, namespace, object_id)
+    assert saved_tags == tags
+    assert "kind:episode" not in saved_tags
+    assert "staleness:episodic" not in saved_tags
+
+
+def test_capture_adds_missing_staleness_when_kind_supplied(
+    client: TestClient,
+    valid_token: str,
+) -> None:
+    headers = {"Authorization": f"Bearer {valid_token}"}
+    namespace = "eric/claude-code/episodic"
+    r = client.post(
+        "/v1/episodic",
         headers=headers,
-        params={"namespace": namespace},
+        json={
+            "namespace": namespace,
+            "content": "typed-kind-only-capture-write",
+            "tags": ["src:direct-test", "kind:project-stance"],
+        },
     )
-    assert got.status_code == 200, got.text
-    assert got.json()["tags"] == tags
-    assert "kind:episode" not in got.json()["tags"]
-    assert "staleness:episodic" not in got.json()["tags"]
+    assert r.status_code == 202, r.text
+    assert _get_tags(client, headers, namespace, r.json()["object_id"]) == [
+        "src:direct-test",
+        "kind:project-stance",
+        "staleness:episodic",
+    ]
+
+
+def test_capture_adds_missing_kind_when_staleness_supplied(
+    client: TestClient,
+    valid_token: str,
+) -> None:
+    headers = {"Authorization": f"Bearer {valid_token}"}
+    namespace = "eric/claude-code/episodic"
+    r = client.post(
+        "/v1/episodic",
+        headers=headers,
+        json={
+            "namespace": namespace,
+            "content": "typed-staleness-only-capture-write",
+            "tags": ["src:direct-test", "staleness:current"],
+        },
+    )
+    assert r.status_code == 202, r.text
+    assert _get_tags(client, headers, namespace, r.json()["object_id"]) == [
+        "src:direct-test",
+        "staleness:current",
+        "kind:episode",
+    ]
+
+
+def test_capture_does_not_double_add_default_typed_tags(
+    client: TestClient,
+    valid_token: str,
+) -> None:
+    headers = {"Authorization": f"Bearer {valid_token}"}
+    namespace = "eric/claude-code/episodic"
+    r = client.post(
+        "/v1/episodic",
+        headers=headers,
+        json={
+            "namespace": namespace,
+            "content": "typed-defaults-already-present-write",
+            "tags": ["src:direct-test", "kind:episode", "staleness:episodic"],
+        },
+    )
+    assert r.status_code == 202, r.text
+    tags = _get_tags(client, headers, namespace, r.json()["object_id"])
+    assert tags == ["src:direct-test", "kind:episode", "staleness:episodic"]
+    assert tags.count("kind:episode") == 1
+    assert tags.count("staleness:episodic") == 1
+
+
+def test_capture_rejects_unknown_typed_tags(
+    client: TestClient,
+    valid_token: str,
+) -> None:
+    headers = {"Authorization": f"Bearer {valid_token}"}
+    namespace = "eric/claude-code/episodic"
+    r = client.post(
+        "/v1/episodic",
+        headers=headers,
+        json={
+            "namespace": namespace,
+            "content": "typed-invalid-capture-write",
+            "tags": ["src:direct-test", "kind:whatever"],
+        },
+    )
+    assert r.status_code == 422
+    assert "unknown essence kind tag 'kind:whatever'" in r.text
 
 
 def test_capture_rejects_out_of_scope_namespace(
@@ -208,25 +298,13 @@ def test_batch_capture_adds_default_typed_episode_tags_per_item(
     assert r.status_code == 202, r.text
     object_ids = r.json()["object_ids"]
 
-    defaulted = client.get(
-        f"/v1/episodic/{object_ids[0]}",
-        headers=headers,
-        params={"namespace": namespace},
-    )
-    assert defaulted.status_code == 200, defaulted.text
-    assert defaulted.json()["tags"] == [
+    assert _get_tags(client, headers, namespace, object_ids[0]) == [
         "src:direct-test",
         "kind:episode",
         "staleness:episodic",
     ]
 
-    explicit = client.get(
-        f"/v1/episodic/{object_ids[1]}",
-        headers=headers,
-        params={"namespace": namespace},
-    )
-    assert explicit.status_code == 200, explicit.text
-    assert explicit.json()["tags"] == [
+    assert _get_tags(client, headers, namespace, object_ids[1]) == [
         "src:direct-test",
         "kind:project-stance",
         "staleness:durable",

--- a/tests/api/test_api_v0_write.py
+++ b/tests/api/test_api_v0_write.py
@@ -88,6 +88,65 @@ def test_capture_dedup_returns_same_id(
     assert r2.json()["object_id"] == r1.json()["object_id"]
 
 
+def test_capture_adds_default_typed_episode_tags(
+    client: TestClient,
+    valid_token: str,
+) -> None:
+    headers = {"Authorization": f"Bearer {valid_token}"}
+    namespace = "eric/claude-code/episodic"
+    r = client.post(
+        "/v1/episodic",
+        headers=headers,
+        json={
+            "namespace": namespace,
+            "content": "typed-default-capture-write",
+            "tags": ["src:direct-test"],
+        },
+    )
+    assert r.status_code == 202, r.text
+    object_id = r.json()["object_id"]
+    got = client.get(
+        f"/v1/episodic/{object_id}",
+        headers=headers,
+        params={"namespace": namespace},
+    )
+    assert got.status_code == 200, got.text
+    assert got.json()["tags"] == [
+        "src:direct-test",
+        "kind:episode",
+        "staleness:episodic",
+    ]
+
+
+def test_capture_preserves_explicit_typed_tags(
+    client: TestClient,
+    valid_token: str,
+) -> None:
+    headers = {"Authorization": f"Bearer {valid_token}"}
+    namespace = "eric/claude-code/episodic"
+    tags = ["src:direct-test", "kind:project-stance", "staleness:durable"]
+    r = client.post(
+        "/v1/episodic",
+        headers=headers,
+        json={
+            "namespace": namespace,
+            "content": "typed-explicit-capture-write",
+            "tags": tags,
+        },
+    )
+    assert r.status_code == 202, r.text
+    object_id = r.json()["object_id"]
+    got = client.get(
+        f"/v1/episodic/{object_id}",
+        headers=headers,
+        params={"namespace": namespace},
+    )
+    assert got.status_code == 200, got.text
+    assert got.json()["tags"] == tags
+    assert "kind:episode" not in got.json()["tags"]
+    assert "staleness:episodic" not in got.json()["tags"]
+
+
 def test_capture_rejects_out_of_scope_namespace(
     client: TestClient,
     out_of_scope_token: str,
@@ -124,6 +183,54 @@ def test_batch_capture_writes_each_row(client: TestClient, valid_token: str) -> 
     assert len(out["object_ids"]) == 3
     for oid in out["object_ids"]:
         assert len(oid) == 27
+
+
+def test_batch_capture_adds_default_typed_episode_tags_per_item(
+    client: TestClient,
+    valid_token: str,
+) -> None:
+    headers = {"Authorization": f"Bearer {valid_token}"}
+    namespace = "eric/claude-code/episodic"
+    body = {
+        "namespace": namespace,
+        "items": [
+            {
+                "content": "batch-typed-default-write",
+                "tags": ["src:direct-test"],
+            },
+            {
+                "content": "batch-typed-explicit-write",
+                "tags": ["src:direct-test", "kind:project-stance", "staleness:durable"],
+            },
+        ],
+    }
+    r = client.post("/v1/episodic/batch", headers=headers, json=body)
+    assert r.status_code == 202, r.text
+    object_ids = r.json()["object_ids"]
+
+    defaulted = client.get(
+        f"/v1/episodic/{object_ids[0]}",
+        headers=headers,
+        params={"namespace": namespace},
+    )
+    assert defaulted.status_code == 200, defaulted.text
+    assert defaulted.json()["tags"] == [
+        "src:direct-test",
+        "kind:episode",
+        "staleness:episodic",
+    ]
+
+    explicit = client.get(
+        f"/v1/episodic/{object_ids[1]}",
+        headers=headers,
+        params={"namespace": namespace},
+    )
+    assert explicit.status_code == 200, explicit.text
+    assert explicit.json()["tags"] == [
+        "src:direct-test",
+        "kind:project-stance",
+        "staleness:durable",
+    ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
No tracking Issue: follow-on slice from team-task `musubi-v111-typed-write-migration` after PR #386 identified direct `/episodic` writers as the remaining typed-write axis.

## Summary

- default missing typed metadata at the canonical `/v1/episodic` write boundary
- preserve caller-supplied `kind:*` and `staleness:*` tags exactly
- document that `kind:episode` is the broad default classification, not caller-intent proof
- add API tests for single capture, batch capture, partial typed tags, no double-add, and unknown typed-tag rejection

## Behavior

`POST /v1/episodic` and `POST /v1/episodic/batch` now apply:

- no `kind:*` -> append `kind:episode`
- no `staleness:*` -> append `staleness:episodic`
- explicit typed tags are preserved and not overridden
- unknown typed tags still fail request validation

This covers the direct local wrappers (`yua-memory-data`, `aoi-memory-data`, `tama-memory-data`, `shiori-memory-data`) and future raw clients without requiring every client to learn the defaults independently.

## Alignment

- Shiori: ACCEPT, no blockers.
- Aoi: ACCEPT, no blockers. Non-blocking notes recorded: shared helper, optional future audit marker, no pre-existing row backfill in this slice.
- Tama: ACCEPT with non-blocking concerns. C1/C2/C3 addressed in docs/tests by clarifying default-vs-explicit semantics, 422 validation behavior, and valid default values. C4/C6 left as follow-up scope.

## Validation

- `uv run pytest tests/api/test_api_v0_write.py tests/adapters/test_mcp_canonical_tools.py tests/adapters/test_livekit.py tests/retrieve/test_context_pack.py -q` -> 94 passed, 4 skipped
- `make agent-check` -> OK
- `make check` -> 1424 passed, 195 skipped, 17 deselected, coverage 88.59%; same pre-existing watcher RuntimeWarning in `tests/vault/test_watcher_boot_scan.py::test_boot_scan_archives_removed_files`
