### PR TITLE
fix(deploy): refresh env during image updates

### DIFF
--- a/deploy/ansible/update.yml
+++ b/deploy/ansible/update.yml
@@ -37,6 +37,15 @@
         group: "{{ musubi_service_group }}"
         mode: "0640"
 
+    - name: Refresh production environment (version / config vars)
+      ansible.builtin.template:
+        src: templates/env.production.j2
+        dest: "{{ musubi_config_dir }}/.env.production"
+        owner: root
+        group: "{{ musubi_service_group }}"
+        mode: "0640"
+      no_log: true
+
     - name: Refresh Prometheus scrape config (may have new targets)
       ansible.builtin.template:
         src: templates/prometheus.yml.j2
@@ -79,6 +88,9 @@
         wait: true
         wait_timeout: 300
         services: "{{ changed_services }}"
+      notify:
+        - Ensure upgrade-history log directory exists
+        - Append an upgrade-history entry
 
     - name: Probe Core health post-update
       ansible.builtin.uri:

--- a/tests/ops/test_update_playbook.py
+++ b/tests/ops/test_update_playbook.py
@@ -101,6 +101,29 @@ def test_update_recreates_only_named_services_with_core_default() -> None:
     )
 
 
+def test_update_renders_production_env_before_recreate() -> None:
+    tasks = _tasks(_play())
+    env_indices = [
+        idx
+        for idx, task in enumerate(tasks)
+        if task.get("ansible.builtin.template", {}).get("dest")
+        == "{{ musubi_config_dir }}/.env.production"
+    ]
+    assert env_indices, "update.yml must refresh .env.production"
+    env_task = tasks[env_indices[0]]
+    assert env_task.get("no_log") is True, ".env.production rendering must not log secrets"
+
+    recreate_indices = [
+        idx
+        for idx, task in enumerate(tasks)
+        if "services" in (task.get("community.docker.docker_compose_v2") or {})
+    ]
+    assert recreate_indices, "update.yml has no per-service compose recreate task"
+    assert env_indices[0] < recreate_indices[0], (
+        ".env.production must render before containers are recreated"
+    )
+
+
 def test_update_does_not_invoke_bootstrap_tasks() -> None:
     """update.yml must NOT re-run apt installs or user-creation tasks —
     that's bootstrap.yml's job and re-running it on every upgrade is slow
@@ -144,6 +167,15 @@ def test_update_writes_upgrade_history() -> None:
     # Line contents must carry the core_image + service list for later forensics.
     assert "core_image" in text
     assert "services" in text
+    for task in _tasks(_play()):
+        module = task.get("community.docker.docker_compose_v2")
+        if not module or "services" not in module:
+            continue
+        notify = task.get("notify") or []
+        assert "Ensure upgrade-history log directory exists" in notify
+        assert "Append an upgrade-history entry" in notify
+        return
+    raise AssertionError("update.yml has no per-service compose recreate task")
 
 
 def test_update_playbook_does_not_lower_deploys_digest_pin_behaviour() -> None:


### PR DESCRIPTION
No tracking Issue: deploy exposed an update-playbook gap during the v1.11.4 rollout.

## Summary
- render `.env.production` during `deploy/ansible/update.yml` before service recreation, so `MUSUBI_SERVICE_VERSION` advances with the pinned image
- notify upgrade-history handlers from the recreate task, so update runs append `/var/log/musubi/upgrade-history.jsonl` as the runbook promises
- add structural tests for both behaviors

## Validation
- `uv run pytest tests/ops/test_update_playbook.py tests/ops/test_ansible.py`
- `uv run ruff format --check tests/ops/test_update_playbook.py`
- `uv run ruff check tests/ops/test_update_playbook.py`
- `ansible-playbook -i deploy/ansible/inventory.yml --syntax-check deploy/ansible/update.yml`